### PR TITLE
Feature/storm 55

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,13 +45,13 @@ Maven (Java)::
 <dependency>
     <groupId>st.orm</groupId>
     <artifactId>storm-java21</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <scope>compile</scope>
 </dependency>
 <dependency>
     <groupId>st.orm</groupId>
     <artifactId>storm-core</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <scope>runtime</scope>
 </dependency>
 ----
@@ -59,15 +59,15 @@ Gradle (Java)::
 +
 [source,groovy]
 ----
-implementation 'st.orm:storm-java21:1.8.0'
-runtimeOnly 'st.orm:storm-core:1.8.0'
+implementation 'st.orm:storm-java21:1.8.1'
+runtimeOnly 'st.orm:storm-core:1.8.1'
 ----
 Gradle (Kotlin)::
 +
 [source,groovy]
 ----
-implementation 'st.orm:storm-kotlin:1.8.0'
-runtimeOnly 'st.orm:storm-core:1.8.0'
+implementation 'st.orm:storm-kotlin:1.8.1'
+runtimeOnly 'st.orm:storm-core:1.8.1'
 ----
 ====
 
@@ -1192,7 +1192,7 @@ Maven::
 <dependency>
     <groupId>st.orm</groupId>
     <artifactId>storm-oracle</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <scope>runtime</scope>
 </dependency>
 ----
@@ -1200,7 +1200,7 @@ Gradle::
 +
 [source,groovy]
 ----
-runtimeOnly 'st.orm:storm-oracle:1.8.0'
+runtimeOnly 'st.orm:storm-oracle:1.8.1'
 ----
 ====
 
@@ -1222,7 +1222,7 @@ Maven::
 <dependency>
     <groupId>st.orm</groupId>
     <artifactId>storm-metamodel-processor</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <scope>provided</scope>
 </dependency>
 ----
@@ -1230,7 +1230,7 @@ Gradle::
 +
 [source,groovy]
 ----
-annotationProcessor 'st.orm:storm-metamodel-processor:1.8.0'
+annotationProcessor 'st.orm:storm-metamodel-processor:1.8.1'
 ----
 ====
 
@@ -1294,7 +1294,7 @@ Maven (Jackson)::
 <dependency>
     <groupId>st.orm</groupId>
     <artifactId>storm-jackson</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <scope>compile</scope>
 </dependency>
 ----
@@ -1302,13 +1302,13 @@ Gradle (Jackson)::
 +
 [source,groovy]
 ----
-implementation 'st.orm:storm-jackson:1.8.0'
+implementation 'st.orm:storm-jackson:1.8.1'
 ----
 Gradle (Kotlinx Serialization)::
 +
 [source,groovy]
 ----
-implementation 'st.orm:storm-kotlinx-serialization:1.8.0'
+implementation 'st.orm:storm-kotlinx-serialization:1.8.1'
 ----
 ====
 
@@ -1598,7 +1598,7 @@ Maven (Java)::
 <dependency>
     <groupId>st.orm</groupId>
     <artifactId>storm-spring</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <scope>compile</scope>
 </dependency>
 ----
@@ -1606,7 +1606,7 @@ Gradle (Java)::
 +
 [source,groovy]
 ----
-implementation 'st.orm:storm-spring:1.8.0'
+implementation 'st.orm:storm-spring:1.8.1'
 ----
 Maven (Kotlin)::
 +
@@ -1615,7 +1615,7 @@ Maven (Kotlin)::
 <dependency>
     <groupId>st.orm</groupId>
     <artifactId>storm-kotlin-spring</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <scope>compile</scope>
 </dependency>
 ----
@@ -1623,7 +1623,7 @@ Gradle (Kotlin)::
 +
 [source,groovy]
 ----
-implementation 'st.orm:storm-kotlin-spring:1.8.0'
+implementation 'st.orm:storm-kotlin-spring:1.8.1'
 ----
 ====
 

--- a/README.adoc
+++ b/README.adoc
@@ -1431,6 +1431,11 @@ EntityRepository, a DSL query, or a SQL template. This observed state is used as
 Dirty checking is only applied when updates are executed through an EntityRepository. Manual SQL updates, bulk
 statements, or custom queries bypass dirty checking entirely and may leave in-memory entities stale.
 
+Unless configured otherwise, entity observation is automatically disabled for `READ_UNCOMMITTED` transactions. At this
+isolation level, the application expects to see uncommitted changes from other transactions. Caching observed state
+would mask these changes, contradicting the requested isolation semantics. When observation is disabled, dirty checking
+treats all entities as dirty, resulting in full-row updates.
+
 Dirty checking affects both whether an UPDATE is issued and how that UPDATE is constructed. This behavior is
 controlled by UpdateMode and by the dirty checking strategy.
 

--- a/README.adoc
+++ b/README.adoc
@@ -96,7 +96,7 @@ Java::
 record City(@PK Integer id,
             String name,
             long population
-) implements Entity<City, Integer> {}
+) implements Entity<Integer> {}
 
 record User(@PK Integer id,
             String email,

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </properties>
     <groupId>st.orm</groupId>
     <artifactId>storm-framework</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <packaging>pom</packaging>
     <name>Storm Framework</name>
     <description>A SQL Template and ORM framework, focusing on modernizing and simplifying database programming.</description>
@@ -169,17 +169,17 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                    <autoPublish>true</autoPublish>
-                    <waitUntil>uploaded</waitUntil>
-                </configuration>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.sonatype.central</groupId>-->
+<!--                <artifactId>central-publishing-maven-plugin</artifactId>-->
+<!--                <version>0.7.0</version>-->
+<!--                <extensions>true</extensions>-->
+<!--                <configuration>-->
+<!--                    <publishingServerId>central</publishingServerId>-->
+<!--                    <autoPublish>true</autoPublish>-->
+<!--                    <waitUntil>uploaded</waitUntil>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -169,17 +169,17 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.sonatype.central</groupId>-->
-<!--                <artifactId>central-publishing-maven-plugin</artifactId>-->
-<!--                <version>0.7.0</version>-->
-<!--                <extensions>true</extensions>-->
-<!--                <configuration>-->
-<!--                    <publishingServerId>central</publishingServerId>-->
-<!--                    <autoPublish>true</autoPublish>-->
-<!--                    <waitUntil>uploaded</waitUntil>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>uploaded</waitUntil>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-core</artifactId>

--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -290,15 +290,14 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
     }
 
     /**
-     * Returns the entity cache for the current transaction, or null.
+     * Returns the entity cache for the current transaction, if available.
      *
-     * @return the entity cache for the current transaction, or null.
+     * @return the entity cache for the current transaction, or empty if not available.
      * @since 1.7
      */
     protected Optional<EntityCache<E, ID>> entityCache() {
         //noinspection unchecked
         return TRANSACTION_TEMPLATE.currentContext()
-                .filter(ctx -> !ctx.isReadOnly())
                 .map(ctx -> (EntityCache<E, ID>) ctx.entityCache(model().type()));
     }
 

--- a/storm-core/src/main/java/st/orm/core/spi/TransactionContext.java
+++ b/storm-core/src/main/java/st/orm/core/spi/TransactionContext.java
@@ -16,6 +16,7 @@
 package st.orm.core.spi;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import st.orm.Entity;
 
 /**
@@ -33,7 +34,19 @@ public interface TransactionContext {
 
     /**
      * Returns a transaction-local cache for entities of the given type, keyed by primary key.
+     *
+     * <p>Returns {@code null} if entity caching is disabled for this transaction. This can happen when the
+     * transaction's isolation level is below the configured minimum for entity caching. At low isolation levels
+     * (e.g., {@code READ_UNCOMMITTED}), entity caching is disabled to prevent the cache from masking changes
+     * that the application expects to see.</p>
+     *
+     * <p>When {@code null} is returned, dirty checking will treat all entities as dirty, resulting in full-row
+     * updates.</p>
+     *
+     * @param entityType the entity type for which to retrieve the cache.
+     * @return the entity cache, or {@code null} if caching is disabled for this transaction.
      */
+    @Nullable
     EntityCache<? extends Entity<?>, ?> entityCache(@Nonnull Class<? extends Entity<?>> entityType);
 
     /**

--- a/storm-core/src/main/java/st/orm/core/spi/WeakInterner.java
+++ b/storm-core/src/main/java/st/orm/core/spi/WeakInterner.java
@@ -87,6 +87,31 @@ public final class WeakInterner {
     }
 
     /**
+     * Retrieves a cached entity by its type and primary key, if available.
+     *
+     * <p>This method enables early cache lookups before constructing nested objects. If an entity with the given
+     * type and primary key was previously interned and is still reachable, it is returned.</p>
+     *
+     * @param entityType the entity class.
+     * @param pk the primary key value.
+     * @param <E> the entity type.
+     * @return the cached entity, or {@code null} if not found or already garbage collected.
+     */
+    public <E extends Entity<?>> E get(@Nonnull Class<E> entityType, @Nonnull Object pk) {
+        drainQueue();
+        Ref<?> ref = Ref.of(entityType, pk);
+        WeakReference<Entity<?>> existing = entityMap.get(ref);
+        if (existing != null) {
+            Entity<?> result = existing.get();
+            if (result != null) {
+                //noinspection unchecked
+                return (E) result;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Interns an entity using its primary key (via {@link Ref}) for efficient lookup.
      *
      * <p>This avoids expensive deep equality checks on complex entity objects. The entity is stored with a weak

--- a/storm-core/src/main/java/st/orm/core/template/impl/UncheckedSqlTemplateException.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/UncheckedSqlTemplateException.java
@@ -15,7 +15,10 @@
  */
 package st.orm.core.template.impl;
 
+import jakarta.annotation.Nonnull;
 import st.orm.core.template.SqlTemplateException;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Runtime wrapper for {@link SqlTemplateException}.
@@ -37,8 +40,8 @@ final class UncheckedSqlTemplateException extends RuntimeException {
      *
      * @param e the checked exception to wrap
      */
-    public UncheckedSqlTemplateException(SqlTemplateException e) {
-        super(e);
+    public UncheckedSqlTemplateException(@Nonnull SqlTemplateException e) {
+        super(requireNonNull(e));
         this.cause = e;
     }
 

--- a/storm-core/src/test/java/st/orm/core/RepositoryPreparedStatementIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/RepositoryPreparedStatementIntegrationTest.java
@@ -74,6 +74,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.newSetFromMap;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -1619,7 +1620,7 @@ public class RepositoryPreparedStatementIntegrationTest {
                 .select()
                 .getResultList();
         assertEquals(14, visits.size());
-        var identitySet = visits.stream().map(it -> it.pet()).collect(Collectors.toCollection(() -> newSetFromMap(new IdentityHashMap<>())));
+        var identitySet = visits.stream().map(it -> it.pet()).collect(toCollection(() -> newSetFromMap(new IdentityHashMap<>())));
         var pkSet = visits.stream().map(it -> it.pet().id()).collect(toSet());
         assertEquals(pkSet.size(), identitySet.size());
     }
@@ -1632,7 +1633,7 @@ public class RepositoryPreparedStatementIntegrationTest {
                 .select()
                 .getResultList();
         assertEquals(14, visits.size());
-        var identitySet = visits.stream().map(it -> it.pet()).collect(Collectors.toCollection(() -> newSetFromMap(new IdentityHashMap<>())));
+        var identitySet = visits.stream().map(it -> it.pet()).collect(toCollection(() -> newSetFromMap(new IdentityHashMap<>())));
         var pkSet = visits.stream().map(it -> it.pet().id()).collect(toSet());
         assertEquals(pkSet.size(), identitySet.size());
     }
@@ -1645,7 +1646,7 @@ public class RepositoryPreparedStatementIntegrationTest {
                 .select()
                 .getResultList();
         assertEquals(14, visits.size());
-        var identitySet = visits.stream().map(it -> it.pet()).collect(Collectors.toCollection(() -> newSetFromMap(new IdentityHashMap<>())));
+        var identitySet = visits.stream().map(it -> it.pet()).collect(toCollection(() -> newSetFromMap(new IdentityHashMap<>())));
         var pkSet = visits.stream().map(it -> it.pet().id()).collect(toSet());
         assertEquals(pkSet.size(), identitySet.size());
     }

--- a/storm-foundation/pom.xml
+++ b/storm-foundation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-foundation</artifactId>

--- a/storm-foundation/src/main/java/st/orm/DynamicUpdate.java
+++ b/storm-foundation/src/main/java/st/orm/DynamicUpdate.java
@@ -64,6 +64,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *   <li>Manual or bulk SQL updates bypass dirty checking and may leave cached entities stale.</li>
  *   <li>Field-level updates are a performance optimization and may fall back to full-row updates to preserve batching
  *       efficiency. This does not affect dirty detection.</li>
+ *   <li>Unless configured otherwise, entity observation is automatically disabled for {@code READ_UNCOMMITTED}
+ *       transactions. At this isolation level, the application expects to see uncommitted changes from other
+ *       transactions. Caching observed state would mask these changes, contradicting the requested isolation
+ *       semantics. When observation is disabled, all entities are treated as dirty, resulting in full-row
+ *       updates.</li>
  * </ul>
  *
  * @since 1.7

--- a/storm-foundation/src/main/java/st/orm/Operator.java
+++ b/storm-foundation/src/main/java/st/orm/Operator.java
@@ -20,6 +20,12 @@ import jakarta.annotation.Nullable;
 
 /**
  * Represents a comparison operator in a SQL query.
+ *
+ * <p><strong>Caching contract:</strong> Operators may participate in template caching where the operator instance
+ * becomes part of the cache key for a compiled SQL shape. Custom operator implementations must therefore implement
+ * stable {@link Object#equals(Object)} and {@link Object#hashCode()} semantics. Two operators must be considered equal
+ * (and have the same hash code) if they produce the same SQL shape, so that equivalent templates map to the same cached
+ * compilation result.</p>
  */
 @SuppressWarnings({"SwitchStatementWithTooFewBranches", "unused"})
 public interface Operator {

--- a/storm-foundation/src/main/java/st/orm/Ref.java
+++ b/storm-foundation/src/main/java/st/orm/Ref.java
@@ -59,8 +59,9 @@ public interface Ref<T extends Data> {
         class DetachedEntity<TE extends Entity<?>> extends AbstractRef<TE> {
             private final TE entity;
 
-            DetachedEntity(TE entity) {
+            DetachedEntity(@Nonnull TE entity) {
                 requireNonNull(entity, "Entity cannot be null.");
+                requireNonNull(entity.id(), "Entity ID cannot be null.");
                 this.entity = entity;
             }
 

--- a/storm-jackson/pom.xml
+++ b/storm-jackson/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-jackson</artifactId>

--- a/storm-java21/pom.xml
+++ b/storm-java21/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-java21</artifactId>

--- a/storm-kotlin-spring/pom.xml
+++ b/storm-kotlin-spring/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-kotlin-spring</artifactId>

--- a/storm-kotlin-spring/src/main/kotlin/st/orm/spring/impl/SpringTransactionContext.kt
+++ b/storm-kotlin-spring/src/main/kotlin/st/orm/spring/impl/SpringTransactionContext.kt
@@ -38,6 +38,34 @@ import kotlin.math.min
 import kotlin.reflect.KClass
 
 /**
+ * Minimum transaction isolation level required for entity caching to be enabled.
+ *
+ * Transactions with an isolation level below this threshold will not use entity caching, which means dirty checking
+ * will treat all entities as dirty (resulting in full-row updates). This prevents the entity cache from masking
+ * changes that the application expects to see at lower isolation levels.
+ *
+ * The default value is [TRANSACTION_READ_COMMITTED], meaning entity caching is disabled only for
+ * `READ_UNCOMMITTED` transactions. This can be overridden using the system property
+ * `storm.entityCache.minIsolationLevel`.
+ *
+ * Valid values: `NONE`, `READ_UNCOMMITTED`, `READ_COMMITTED`, `REPEATABLE_READ`, `SERIALIZABLE`, or the
+ * corresponding JDBC integer constants (0, 1, 2, 4, 8).
+ */
+private val MIN_ISOLATION_LEVEL_FOR_CACHE: Int = run {
+    val value = System.getProperty("storm.entityCache.minIsolationLevel")?.trim()?.uppercase()
+    when {
+        value.isNullOrBlank() -> TRANSACTION_READ_COMMITTED
+        value == "NONE" || value == "0" -> TRANSACTION_NONE
+        value == "READ_UNCOMMITTED" || value == "1" -> TRANSACTION_READ_UNCOMMITTED
+        value == "READ_COMMITTED" || value == "2" -> TRANSACTION_READ_COMMITTED
+        value == "REPEATABLE_READ" || value == "4" -> TRANSACTION_REPEATABLE_READ
+        value == "SERIALIZABLE" || value == "8" -> TRANSACTION_SERIALIZABLE
+        else -> value.toIntOrNull()
+            ?: throw PersistenceException("Invalid value for storm.entityCache.minIsolationLevel: '$value'.")
+    }
+}
+
+/**
  * Internal implementation of transaction context management for Spring-managed transactions.
  * This class provides thread-local transaction context tracking and management capabilities.
  *
@@ -183,8 +211,18 @@ internal class SpringTransactionContext : TransactionContext {
 
     /**
      * Returns a transaction-local cache for entities of the given type, keyed by primary key.
+     *
+     * Returns `null` if the transaction's isolation level is below the configured minimum for entity caching
+     * (see [MIN_ISOLATION_LEVEL_FOR_CACHE]). At low isolation levels, entity caching is disabled to prevent
+     * the cache from masking changes that the application expects to see.
      */
-    override fun entityCache(entityType: Class<out Entity<*>>): EntityCache<out Entity<*>, *> {
+    override fun entityCache(entityType: Class<out Entity<*>>): EntityCache<out Entity<*>, *>? {
+        val isolationLevel = currentState.transactionDefinition?.isolationLevel
+        // Spring uses ISOLATION_DEFAULT (-1) when no specific isolation level is set.
+        // In that case, we assume the database default (typically READ_COMMITTED or higher) and enable caching.
+        if (isolationLevel != null && isolationLevel >= 0 && isolationLevel < MIN_ISOLATION_LEVEL_FOR_CACHE) {
+            return null
+        }
         @Suppress("UNCHECKED_CAST")
         return currentState.entityCacheMap.getOrPut(entityType.kotlin) {
             EntityCacheImpl<Entity<Any>, Any>()

--- a/storm-kotlin-validator/pom.xml
+++ b/storm-kotlin-validator/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>

--- a/storm-kotlin/pom.xml
+++ b/storm-kotlin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-kotlin</artifactId>

--- a/storm-kotlin/src/main/kotlin/st/orm/template/impl/JdbcTransactionContext.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/impl/JdbcTransactionContext.kt
@@ -30,6 +30,34 @@ import javax.sql.DataSource
 import kotlin.reflect.KClass
 
 /**
+ * Minimum transaction isolation level required for entity caching to be enabled.
+ *
+ * Transactions with an isolation level below this threshold will not use entity caching, which means dirty checking
+ * will treat all entities as dirty (resulting in full-row updates). This prevents the entity cache from masking
+ * changes that the application expects to see at lower isolation levels.
+ *
+ * The default value is [TRANSACTION_READ_COMMITTED], meaning entity caching is disabled only for
+ * `READ_UNCOMMITTED` transactions. This can be overridden using the system property
+ * `storm.entityCache.minIsolationLevel`.
+ *
+ * Valid values: `NONE`, `READ_UNCOMMITTED`, `READ_COMMITTED`, `REPEATABLE_READ`, `SERIALIZABLE`, or the
+ * corresponding JDBC integer constants (0, 1, 2, 4, 8).
+ */
+private val MIN_ISOLATION_LEVEL_FOR_CACHE: Int = run {
+    val value = System.getProperty("storm.entityCache.minIsolationLevel")?.trim()?.uppercase()
+    when {
+        value.isNullOrBlank() -> TRANSACTION_READ_COMMITTED
+        value == "NONE" || value == "0" -> TRANSACTION_NONE
+        value == "READ_UNCOMMITTED" || value == "1" -> TRANSACTION_READ_UNCOMMITTED
+        value == "READ_COMMITTED" || value == "2" -> TRANSACTION_READ_COMMITTED
+        value == "REPEATABLE_READ" || value == "4" -> TRANSACTION_REPEATABLE_READ
+        value == "SERIALIZABLE" || value == "8" -> TRANSACTION_SERIALIZABLE
+        else -> value.toIntOrNull()
+            ?: throw PersistenceException("Invalid value for storm.entityCache.minIsolationLevel: '$value'.")
+    }
+}
+
+/**
  * A JDBC transaction context implementation that provides lightweight transaction management based on JDBC.
  * This supports various transaction propagation behaviors.
  *
@@ -156,8 +184,16 @@ internal class JdbcTransactionContext : TransactionContext {
 
     /**
      * Returns a transaction-local cache for entities of the given type, keyed by primary key.
+     *
+     * Returns `null` if the transaction's isolation level is below the configured minimum for entity caching
+     * (see [MIN_ISOLATION_LEVEL_FOR_CACHE]). At low isolation levels, entity caching is disabled to prevent
+     * the cache from masking changes that the application expects to see.
      */
-    override fun entityCache(entityType: Class<out Entity<*>>): EntityCache<out Entity<*>, *> {
+    override fun entityCache(entityType: Class<out Entity<*>>): EntityCache<out Entity<*>, *>? {
+        val isolationLevel = currentState.isolationLevel
+        if (isolationLevel != null && isolationLevel < MIN_ISOLATION_LEVEL_FOR_CACHE) {
+            return null
+        }
         @Suppress("UNCHECKED_CAST")
         return currentState.entityCacheMap.getOrPut(entityType.kotlin) {
             EntityCacheImpl<Entity<Any>, Any>()

--- a/storm-kotlinx-serialization/pom.xml
+++ b/storm-kotlinx-serialization/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-kotlinx-serialization</artifactId>

--- a/storm-mariadb/pom.xml
+++ b/storm-mariadb/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-mariadb</artifactId>

--- a/storm-metamodel-ksp/pom.xml
+++ b/storm-metamodel-ksp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-metamodel-ksp</artifactId>

--- a/storm-metamodel-processor/pom.xml
+++ b/storm-metamodel-processor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-metamodel-processor</artifactId>

--- a/storm-mssqlserver/pom.xml
+++ b/storm-mssqlserver/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-mssqlserver</artifactId>

--- a/storm-mysql/pom.xml
+++ b/storm-mysql/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-mysql</artifactId>

--- a/storm-oracle/pom.xml
+++ b/storm-oracle/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-oracle</artifactId>

--- a/storm-postgresql/pom.xml
+++ b/storm-postgresql/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-postgresql</artifactId>

--- a/storm-spring/pom.xml
+++ b/storm-spring/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>st.orm</groupId>
         <artifactId>storm-framework</artifactId>
-        <version>1.8.0</version>
+        <version>1.8.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>storm-spring</artifactId>


### PR DESCRIPTION
Entity Cache
* Enabled in read-only transactions.
* Disabled for READ_UNCOMMITTED to respect isolation semantics.
* Caching provides optimization without affecting correctness; versioning remains advised for concurrent updates.

Performance
* Cache / interner lookup extracts primary key before construction, avoiding full entity equality checks.
* Interner uses primary key based lookups instead of equality checks for entities.
* Interner is used when entity cache is not applicable and is scoped to the result set to prevent duplicate objects.
* Queries returning the same entity within a result set or transaction benefit from caching / interning.

Relates to #55