### PR TITLE
Fix launch-readiness issues: broken install command, links, analytics, community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,121 @@
+name: Bug Report
+description: Report a bug in Storm ORM
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: input
+    id: storm-version
+    attributes:
+      label: Storm version
+      description: Which version of Storm are you using?
+      placeholder: "e.g., 1.9.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: modules
+    attributes:
+      label: Module(s) affected
+      description: Select the Storm module(s) related to this issue.
+      multiple: true
+      options:
+        - storm-core
+        - storm-java21
+        - storm-kotlin
+        - storm-spring
+        - storm-kotlin-spring
+        - storm-postgresql
+        - storm-mysql
+        - storm-mariadb
+        - storm-oracle
+        - storm-mssqlserver
+        - storm-jackson2
+        - storm-jackson3
+        - storm-kotlinx-serialization
+        - storm-kotlin-validator
+        - storm-metamodel-processor
+        - storm-metamodel-ksp
+        - storm-foundation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: jdk-version
+    attributes:
+      label: JDK version
+      description: Which JDK version are you using?
+      placeholder: "e.g., OpenJDK 21.0.2"
+    validations:
+      required: true
+
+  - type: input
+    id: database-version
+    attributes:
+      label: Database and version
+      description: Which database and version are you using?
+      placeholder: "e.g., PostgreSQL 16.1"
+    validations:
+      required: false
+
+  - type: input
+    id: spring-boot-version
+    attributes:
+      label: Spring Boot version
+      description: Which version of Spring Boot are you using (if applicable)?
+      placeholder: "e.g., 3.5.6 (leave blank if not using Spring)"
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Describe the steps needed to reproduce the issue.
+      placeholder: |
+        1. Define entity record/data class...
+        2. Call repository method...
+        3. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include any error messages or stack traces.
+    validations:
+      required: true
+
+  - type: textarea
+    id: minimal-reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Code snippet, link to a minimal repo, or failing test case.
+      render: java
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here (e.g., JDBC driver version, connection pool, relevant configuration).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/storm-orm/storm-framework/discussions
+    about: Use GitHub Discussions for questions and general help

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: Problem description
+      description: Describe the problem this feature would solve. What are you trying to accomplish and what limitations are you running into?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you would like to see. Include API examples if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternative solutions or workarounds you have considered.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: modules
+    attributes:
+      label: Module(s) affected
+      description: Select the Storm module(s) this feature would apply to.
+      multiple: true
+      options:
+        - storm-core
+        - storm-java21
+        - storm-kotlin
+        - storm-spring
+        - storm-kotlin-spring
+        - storm-postgresql
+        - storm-mysql
+        - storm-mariadb
+        - storm-oracle
+        - storm-mssqlserver
+        - storm-jackson2
+        - storm-jackson3
+        - storm-kotlinx-serialization
+        - storm-kotlin-validator
+        - storm-metamodel-processor
+        - storm-metamodel-ksp
+        - storm-foundation
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, code examples, or references about the feature request here.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Description
+
+<!-- Describe the changes in this PR -->
+
+## Related Issue
+
+<!-- Link to the related issue: Fixes #123, Relates to #456 -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+
+## Checklist
+
+- [ ] My code follows the project's code style
+- [ ] I have added tests that cover my changes
+- [ ] All new and existing tests pass (`mvn verify`)
+- [ ] I have updated relevant documentation
+- [ ] My changes generate no new compiler warnings
+
+## Module(s) Affected
+
+<!-- List the Storm modules affected by this change -->
+
+## Breaking Changes
+
+<!-- If this is a breaking change, describe the impact and migration path -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+storm@zantvoort.biz. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ST/ORM
 
 [![Maven Central](https://img.shields.io/maven-central/v/st.orm/storm-core.svg)](https://central.sonatype.com/namespace/st.orm)
-[![CI](https://github.com/storm-repo/storm-framework/actions/workflows/ci.yml/badge.svg)](https://github.com/storm-repo/storm-framework/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/storm-repo/storm-framework/graph/badge.svg)](https://codecov.io/gh/storm-repo/storm-framework)
+[![CI](https://github.com/storm-orm/storm-framework/actions/workflows/ci.yml/badge.svg)](https://github.com/storm-orm/storm-framework/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/storm-orm/storm-framework/graph/badge.svg)](https://codecov.io/gh/storm-orm/storm-framework)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Docs](https://img.shields.io/badge/docs-storm--framework-blue)](https://storm-repo.github.io/storm-framework/)
+[![Docs](https://img.shields.io/badge/docs-orm.st-blue)](https://orm.st)
 [![Kotlin 2.0+](https://img.shields.io/badge/Kotlin-2.0%2B-purple)](https://kotlinlang.org/)
 [![Java 21+](https://img.shields.io/badge/Java-21%2B-blue)](https://openjdk.org/projects/jdk/21/)
 
@@ -219,7 +219,7 @@ dependencies {
 
 ## Documentation
 
-Full documentation is available at [storm-repo.github.io/storm-framework](https://storm-repo.github.io/storm-framework/).
+Full documentation is available at [orm.st](https://orm.st).
 
 ### Core Concepts
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The Storm team takes security vulnerabilities seriously. We appreciate your efforts to responsibly disclose your findings.
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via email to **security@zantvoort.biz**.
+
+Include as much of the following information as possible to help us understand and resolve the issue quickly:
+
+- Type of vulnerability (e.g., SQL injection, remote code execution, information disclosure)
+- Full paths of the source file(s) related to the vulnerability
+- The Storm module(s) affected
+- Step-by-step instructions to reproduce the issue
+- Proof of concept or exploit code (if available)
+- Impact assessment of the vulnerability
+
+## Response Timeline
+
+- **Acknowledgment:** We will acknowledge receipt of your vulnerability report within **48 hours**.
+- **Status update:** We will provide an initial assessment and status update within **7 days**.
+- **Resolution:** We aim to release a fix for confirmed vulnerabilities as quickly as possible, depending on the severity and complexity of the issue.
+
+You will be kept informed of our progress throughout the process.
+
+## Supported Versions
+
+We provide security updates for the following versions:
+
+| Version | Supported |
+| ------- | --------- |
+| Current release | Yes |
+| Previous minor release | Yes |
+| Older versions | No |
+
+If you are using an unsupported version, we recommend upgrading to a supported release to receive security fixes.
+
+## Safe Harbor
+
+We support safe harbor for security researchers who:
+
+- Make a good faith effort to avoid privacy violations, destruction of data, and disruption of services.
+- Only interact with accounts you own or with explicit permission of the account holder.
+- Do not exploit a security issue you discover for any reason other than to report it.
+- Provide us with a reasonable amount of time to resolve the issue before disclosing it publicly.
+- Do not submit a high volume of low-quality reports.
+
+We will not take legal action against researchers who discover and report security vulnerabilities in accordance with this policy. We consider security research conducted in compliance with this policy to be authorized, and we will work with you to understand and resolve the issue quickly.
+
+## Disclosure Policy
+
+When a security vulnerability is confirmed and resolved, we will:
+
+1. Release a patched version as soon as possible.
+2. Publish a security advisory on GitHub with details about the vulnerability and the fix.
+3. Credit the reporter (unless anonymity is requested).
+
+## Contact
+
+For any questions about this security policy, please contact **storm@zantvoort.biz**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Traditional ORMs carry invisible complexity (managed entity state, implicit flus
 **Get started in seconds:**
 
 ```bash
-npx @storm/cli
+npx @storm-orm/cli
 ```
 
 This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's patterns, conventions, and slash commands. See [AI-Assisted Development](ai.md) for details.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
   url: 'https://orm.st',
   baseUrl: '/',
 
-  organizationName: 'storm-repo',
+  organizationName: 'storm-orm',
   projectName: 'storm-framework',
 
   onBrokenLinks: 'warn',
@@ -26,6 +26,31 @@ const config: Config = {
 
   plugins: [
     [staticVersionReplace, { version: stormVersion }],
+    // Privacy-friendly analytics (Plausible). Injects the site-specific
+    // loader plus the init snippet into <head> on every page.
+    function plausibleAnalyticsPlugin() {
+      return {
+        name: 'plausible-analytics',
+        injectHtmlTags() {
+          return {
+            headTags: [
+              {
+                tagName: 'script',
+                attributes: {
+                  async: true,
+                  src: 'https://plausible.io/js/pa-tkVl2-A9dQBBULkKCv59f.js',
+                },
+              },
+              {
+                tagName: 'script',
+                innerHTML:
+                  "window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()",
+              },
+            ],
+          };
+        },
+      };
+    },
   ],
 
   presets: [
@@ -42,7 +67,7 @@ const config: Config = {
               path: 'next',
             },
           },
-          editUrl: 'https://github.com/storm-repo/storm-framework/edit/main/docs/',
+          editUrl: 'https://github.com/storm-orm/storm-framework/edit/main/docs/',
           beforeDefaultRemarkPlugins: [
             [remarkStormVersion, { version: stormVersion }],
           ],
@@ -56,6 +81,8 @@ const config: Config = {
   ],
 
   themeConfig: {
+    // TODO(campaign): replace with a purpose-built 1200x630 social card.
+    image: 'img/storm.png',
     navbar: {
       title: 'Storm',
       logo: {
@@ -75,7 +102,7 @@ const config: Config = {
           label: 'Documentation',
         },
         {
-          href: 'https://github.com/storm-repo/storm-framework',
+          href: 'https://github.com/storm-orm/storm-framework',
           label: 'GitHub',
           position: 'right',
         },
@@ -95,7 +122,7 @@ const config: Config = {
         {
           title: 'More',
           items: [
-            {label: 'GitHub', href: 'https://github.com/storm-repo/storm-framework'},
+            {label: 'GitHub', href: 'https://github.com/storm-orm/storm-framework'},
             {label: 'Maven Central', href: 'https://central.sonatype.com/namespace/st.orm'},
           ],
         },

--- a/website/versioned_docs/version-1.11.1/index.md
+++ b/website/versioned_docs/version-1.11.1/index.md
@@ -34,7 +34,7 @@ Traditional ORMs carry invisible complexity (managed entity state, implicit flus
 **Get started in seconds:**
 
 ```bash
-npx @storm/cli
+npx @storm-orm/cli
 ```
 
 This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's patterns, conventions, and slash commands. See [AI-Assisted Development](ai.md) for details.

--- a/website/versioned_docs/version-1.11.2/index.md
+++ b/website/versioned_docs/version-1.11.2/index.md
@@ -34,7 +34,7 @@ Traditional ORMs carry invisible complexity (managed entity state, implicit flus
 **Get started in seconds:**
 
 ```bash
-npx @storm/cli
+npx @storm-orm/cli
 ```
 
 This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's patterns, conventions, and slash commands. See [AI-Assisted Development](ai.md) for details.

--- a/website/versioned_docs/version-1.11.3/index.md
+++ b/website/versioned_docs/version-1.11.3/index.md
@@ -34,7 +34,7 @@ Traditional ORMs carry invisible complexity (managed entity state, implicit flus
 **Get started in seconds:**
 
 ```bash
-npx @storm/cli
+npx @storm-orm/cli
 ```
 
 This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's patterns, conventions, and slash commands. See [AI-Assisted Development](ai.md) for details.


### PR DESCRIPTION
Last-mile fixes ahead of the public launch. **Merging this redeploys orm.st** (docs.yml on push to `main`).

## What this fixes
- **Broken primary CTA.** The homepage "Get started in seconds" command was `npx @storm/cli` — a package that does **not exist** on npm (the real one is `@storm-orm/cli`). Fixed in `docs/index.md` *and* the versioned snapshots `1.11.1`–`1.11.3`, because the root `/` serves the latest versioned copy (`1.11.3`), not the Next docs.
- **404 docs links.** README "Docs" badge and "Full documentation" link pointed at `storm-repo.github.io/storm-framework/` (404). Now → `https://orm.st`.
- **Org unification.** CI/codecov badges and Docusaurus org/edit/footer links moved from the old `storm-repo` alias to canonical **`storm-orm`** (matches the `@storm-orm` npm scope).
- **Community health files now ship.** `SECURITY.md`, new `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), issue templates, and the PR template existed locally but were never pushed. Issue templates also drop the removed `storm-jackson` module for `storm-jackson2`/`storm-jackson3`.
- **Analytics.** Plausible wired via an `injectHtmlTags` plugin (verified present in the built HTML).
- **Social card.** Baseline `themeConfig.image` so links to orm.st render a preview (stopgap; a proper 1200×630 card is a follow-up — marked with a TODO).

Site build verified locally (`npm run build` → SUCCESS) with the new plugin.

## Manual follow-ups (cannot be done in-repo)
- [ ] Add `orm.st` as a site in Plausible so the snippet records data.
- [ ] Upload a custom GitHub social-preview image (Settings → Social preview).
- [ ] Decide on `FUNDING.yml`.

## Not in this PR (tracked in RELEASE_READINESS.md)
Real `src/pages/index.tsx` landing page leading with **"Radically Simple"**, published Javadoc/KDoc API site, `storm-examples` repo, benchmarks. GitHub `homepageUrl` + topics were already set directly via the API.