### PR TITLE
Fix Schema-First / Entity-First workflow diagram in AI docs

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -125,23 +125,24 @@ Beyond the data model, Storm provides dedicated tooling for AI-assisted workflow
 Storm fully supports both directions of working: starting from the database schema and generating entities to match, or starting from the entity model and generating the migration scripts to create the schema. Both approaches share the same development cycle; they just enter it at a different point.
 
 ```
-            Entity-first                          Schema-first
-            starts here                           starts here
+           Entity-first                          Schema-first
+           starts here                           starts here
                  │                                     │
                  ▼                                     ▼
         ┌─────────────────┐                   ┌─────────────────┐
-        │  Define/update  │──────────────────▶│ Generate/update │
-        │    entities     │                   │    migration    │
-        │                 │                   │                 │
-        │   [You / AI]    │                   │   [You / AI]    │
-        └─────────────────┘                   └─────────────────┘
-                 ▲                                     │
-                 │                                     ▼
-        ┌─────────────────┐                   ┌─────────────────┐
-        │    Validate     │◀──────────────────│  Apply schema   │
-        │                 │                   │                 │
-        │    [Storm]      │                   │  [Flyway / H2]  │
-        └─────────────────┘                   └─────────────────┘
+        │  Define/update  │◀─────────────────▶│ Generate/update │     ┐
+        │     entities    │                   │    migration    │     ├─ You / AI  (generate)
+        └────────┬────────┘                   └────────┬────────┘     ┘
+                 │                                     │
+                 └──────────────────┬──────────────────┘
+                                    ▼
+                     ┌─────────────────────────────┐                  ┐
+                     │         Apply schema        │                  ├─ Flyway / H2  (apply)
+                     └──────────────┬──────────────┘                  ┘
+                                    ▼
+                           ┌─────────────────┐                        ┐
+                           │     Validate    │                        ├─ Storm  (verify)
+                           └─────────────────┘                        ┘
 ```
 
 The AI generates and updates code (entities, migrations, queries). Storm validates correctness (`ORMTemplate.validateSchema()`, `SqlCapture`). The cycle repeats whenever either side changes: a schema change triggers entity updates; an entity change triggers a new migration. Schema validation closes the loop by proving that entities and schema agree after every change.

--- a/website/versioned_docs/version-1.11.0/ai.md
+++ b/website/versioned_docs/version-1.11.0/ai.md
@@ -155,23 +155,24 @@ Beyond the data model, Storm provides dedicated tooling for AI-assisted workflow
 Storm fully supports both directions of working: starting from the database schema and generating entities to match, or starting from the entity model and generating the migration scripts to create the schema. Both approaches share the same development cycle; they just enter it at a different point.
 
 ```
-            Entity-first                          Schema-first
-            starts here                           starts here
+           Entity-first                          Schema-first
+           starts here                           starts here
                  │                                     │
                  ▼                                     ▼
         ┌─────────────────┐                   ┌─────────────────┐
-        │  Define/update  │──────────────────▶│ Generate/update │
-        │    entities     │                   │    migration    │
-        │                 │                   │                 │
-        │   [You / AI]    │                   │   [You / AI]    │
-        └─────────────────┘                   └─────────────────┘
-                 ▲                                     │
-                 │                                     ▼
-        ┌─────────────────┐                   ┌─────────────────┐
-        │    Validate     │◀──────────────────│  Apply schema   │
-        │                 │                   │                 │
-        │    [Storm]      │                   │  [Flyway / H2]  │
-        └─────────────────┘                   └─────────────────┘
+        │  Define/update  │◀─────────────────▶│ Generate/update │     ┐
+        │     entities    │                   │    migration    │     ├─ You / AI  (generate)
+        └────────┬────────┘                   └────────┬────────┘     ┘
+                 │                                     │
+                 └──────────────────┬──────────────────┘
+                                    ▼
+                     ┌─────────────────────────────┐                  ┐
+                     │         Apply schema        │                  ├─ Flyway / H2  (apply)
+                     └──────────────┬──────────────┘                  ┘
+                                    ▼
+                           ┌─────────────────┐                        ┐
+                           │     Validate    │                        ├─ Storm  (verify)
+                           └─────────────────┘                        ┘
 ```
 
 The AI generates and updates code (entities, migrations, queries). Storm validates correctness (`ORMTemplate.validateSchema()`, `SqlCapture`). The cycle repeats whenever either side changes: a schema change triggers entity updates; an entity change triggers a new migration. Schema validation closes the loop by proving that entities and schema agree after every change.

--- a/website/versioned_docs/version-1.11.1/ai.md
+++ b/website/versioned_docs/version-1.11.1/ai.md
@@ -155,23 +155,24 @@ Beyond the data model, Storm provides dedicated tooling for AI-assisted workflow
 Storm fully supports both directions of working: starting from the database schema and generating entities to match, or starting from the entity model and generating the migration scripts to create the schema. Both approaches share the same development cycle; they just enter it at a different point.
 
 ```
-            Entity-first                          Schema-first
-            starts here                           starts here
+           Entity-first                          Schema-first
+           starts here                           starts here
                  │                                     │
                  ▼                                     ▼
         ┌─────────────────┐                   ┌─────────────────┐
-        │  Define/update  │──────────────────▶│ Generate/update │
-        │    entities     │                   │    migration    │
-        │                 │                   │                 │
-        │   [You / AI]    │                   │   [You / AI]    │
-        └─────────────────┘                   └─────────────────┘
-                 ▲                                     │
-                 │                                     ▼
-        ┌─────────────────┐                   ┌─────────────────┐
-        │    Validate     │◀──────────────────│  Apply schema   │
-        │                 │                   │                 │
-        │    [Storm]      │                   │  [Flyway / H2]  │
-        └─────────────────┘                   └─────────────────┘
+        │  Define/update  │◀─────────────────▶│ Generate/update │     ┐
+        │     entities    │                   │    migration    │     ├─ You / AI  (generate)
+        └────────┬────────┘                   └────────┬────────┘     ┘
+                 │                                     │
+                 └──────────────────┬──────────────────┘
+                                    ▼
+                     ┌─────────────────────────────┐                  ┐
+                     │         Apply schema        │                  ├─ Flyway / H2  (apply)
+                     └──────────────┬──────────────┘                  ┘
+                                    ▼
+                           ┌─────────────────┐                        ┐
+                           │     Validate    │                        ├─ Storm  (verify)
+                           └─────────────────┘                        ┘
 ```
 
 The AI generates and updates code (entities, migrations, queries). Storm validates correctness (`ORMTemplate.validateSchema()`, `SqlCapture`). The cycle repeats whenever either side changes: a schema change triggers entity updates; an entity change triggers a new migration. Schema validation closes the loop by proving that entities and schema agree after every change.

--- a/website/versioned_docs/version-1.11.2/ai.md
+++ b/website/versioned_docs/version-1.11.2/ai.md
@@ -125,23 +125,24 @@ Beyond the data model, Storm provides dedicated tooling for AI-assisted workflow
 Storm fully supports both directions of working: starting from the database schema and generating entities to match, or starting from the entity model and generating the migration scripts to create the schema. Both approaches share the same development cycle; they just enter it at a different point.
 
 ```
-            Entity-first                          Schema-first
-            starts here                           starts here
+           Entity-first                          Schema-first
+           starts here                           starts here
                  │                                     │
                  ▼                                     ▼
         ┌─────────────────┐                   ┌─────────────────┐
-        │  Define/update  │──────────────────▶│ Generate/update │
-        │    entities     │                   │    migration    │
-        │                 │                   │                 │
-        │   [You / AI]    │                   │   [You / AI]    │
-        └─────────────────┘                   └─────────────────┘
-                 ▲                                     │
-                 │                                     ▼
-        ┌─────────────────┐                   ┌─────────────────┐
-        │    Validate     │◀──────────────────│  Apply schema   │
-        │                 │                   │                 │
-        │    [Storm]      │                   │  [Flyway / H2]  │
-        └─────────────────┘                   └─────────────────┘
+        │  Define/update  │◀─────────────────▶│ Generate/update │     ┐
+        │     entities    │                   │    migration    │     ├─ You / AI  (generate)
+        └────────┬────────┘                   └────────┬────────┘     ┘
+                 │                                     │
+                 └──────────────────┬──────────────────┘
+                                    ▼
+                     ┌─────────────────────────────┐                  ┐
+                     │         Apply schema        │                  ├─ Flyway / H2  (apply)
+                     └──────────────┬──────────────┘                  ┘
+                                    ▼
+                           ┌─────────────────┐                        ┐
+                           │     Validate    │                        ├─ Storm  (verify)
+                           └─────────────────┘                        ┘
 ```
 
 The AI generates and updates code (entities, migrations, queries). Storm validates correctness (`ORMTemplate.validateSchema()`, `SqlCapture`). The cycle repeats whenever either side changes: a schema change triggers entity updates; an entity change triggers a new migration. Schema validation closes the loop by proving that entities and schema agree after every change.

--- a/website/versioned_docs/version-1.11.3/ai.md
+++ b/website/versioned_docs/version-1.11.3/ai.md
@@ -125,23 +125,24 @@ Beyond the data model, Storm provides dedicated tooling for AI-assisted workflow
 Storm fully supports both directions of working: starting from the database schema and generating entities to match, or starting from the entity model and generating the migration scripts to create the schema. Both approaches share the same development cycle; they just enter it at a different point.
 
 ```
-            Entity-first                          Schema-first
-            starts here                           starts here
+           Entity-first                          Schema-first
+           starts here                           starts here
                  │                                     │
                  ▼                                     ▼
         ┌─────────────────┐                   ┌─────────────────┐
-        │  Define/update  │──────────────────▶│ Generate/update │
-        │    entities     │                   │    migration    │
-        │                 │                   │                 │
-        │   [You / AI]    │                   │   [You / AI]    │
-        └─────────────────┘                   └─────────────────┘
-                 ▲                                     │
-                 │                                     ▼
-        ┌─────────────────┐                   ┌─────────────────┐
-        │    Validate     │◀──────────────────│  Apply schema   │
-        │                 │                   │                 │
-        │    [Storm]      │                   │  [Flyway / H2]  │
-        └─────────────────┘                   └─────────────────┘
+        │  Define/update  │◀─────────────────▶│ Generate/update │     ┐
+        │     entities    │                   │    migration    │     ├─ You / AI  (generate)
+        └────────┬────────┘                   └────────┬────────┘     ┘
+                 │                                     │
+                 └──────────────────┬──────────────────┘
+                                    ▼
+                     ┌─────────────────────────────┐                  ┐
+                     │         Apply schema        │                  ├─ Flyway / H2  (apply)
+                     └──────────────┬──────────────┘                  ┘
+                                    ▼
+                           ┌─────────────────┐                        ┐
+                           │     Validate    │                        ├─ Storm  (verify)
+                           └─────────────────┘                        ┘
 ```
 
 The AI generates and updates code (entities, migrations, queries). Storm validates correctness (`ORMTemplate.validateSchema()`, `SqlCapture`). The cycle repeats whenever either side changes: a schema change triggers entity updates; an entity change triggers a new migration. Schema validation closes the loop by proving that entities and schema agree after every change.


### PR DESCRIPTION
The workflow diagram in the "Schema-First and Entity-First" section was logically inconsistent. As a single cycle, the schema-first entry point reached **Validate** before **Define/update entities** — impossible, since validation compares entities against the live schema, so the entities have to exist first.

## What changed
- Redrawn so both entry points converge on **Validate**.
- Each stage is labeled by actor, making the AI-generates / Storm-verifies split explicit:
  - **You / AI** — generate entities + migration
  - **Flyway / H2** — apply the schema
  - **Storm** — verify (`validateSchema()`)
- Applied to `docs/ai.md` and the `1.11.0`–`1.11.3` versioned snapshots, since the live `/ai` page is served from the latest versioned copy, not `docs/`.

Plain code-fence change; no build impact.