### PR TITLE
Fix @Convert on embedded component field failing on save (#141)

### DIFF
--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -43,6 +43,11 @@
                         --add-opens storm.core/st.orm.core.repository=ALL-UNNAMED
                         --add-opens storm.core/st.orm.core.repository.spring=ALL-UNNAMED
                         --add-opens storm.core/st.orm.core.model=ALL-UNNAMED
+                        <!-- storm.core only `requires static jakarta.persistence`, so the module is not resolved at
+                             runtime. @DataJpaTest boots Hibernate/JPA (on the classpath) which needs
+                             jakarta.persistence at runtime; resolve it explicitly so the JPA tests run on the module
+                             path too. -->
+                        --add-modules jakarta.persistence
                         -Dstorm.ansi_escaping=true
                     </argLine>
                 </configuration>

--- a/storm-core/src/main/java/st/orm/core/template/impl/ModelImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/ModelImpl.java
@@ -15,7 +15,7 @@
  */
 package st.orm.core.template.impl;
 
-import static java.util.Collections.nCopies;
+import static java.util.Collections.unmodifiableList;
 import static java.util.List.copyOf;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.empty;
@@ -42,6 +42,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
@@ -130,6 +131,16 @@ public final class ModelImpl<E extends Data, ID> implements Model<E, ID> {
      */
     private final List<ORMConverter> converters;
 
+    /**
+     * Parent metamodel for each converter group, keyed by the group's 0-based start column index. A converter reads
+     * its value by reflectively invoking the field accessor on the record passed to
+     * {@link ORMConverter#toDatabase(Object)}, so that record must be the one that declares the field. This metamodel
+     * navigates the root record down to the enclosing inline component, or resolves to the root record itself for a
+     * top-level field. Precomputed so the per-row value loop is a single lookup plus {@code getValue}, with no
+     * string/metamodel allocation on the write path.
+     */
+    private final Map<Integer, Metamodel<Data, ?>> converterParents;
+
     public ModelImpl(@Nonnull RecordType recordType,
                      @Nonnull TableName tableName,
                      @Nonnull List<RecordField> fields,
@@ -165,6 +176,7 @@ public final class ModelImpl<E extends Data, ID> implements Model<E, ID> {
         this.discriminatorColumnIndex = initDiscriminatorColumnIndex(typeOverride);
         this.polymorphicFkDiscriminatorColumns = initPolymorphicFkDiscriminatorColumns(this.fields, this.columns);
         this.converters = initConverters(this.fields, this.columns);
+        this.converterParents = initConverterParents(this.converters, this.columns);
         this.primaryKeyField = initPrimaryKeyField(this.recordType);
         this.declaredColumns = initDeclaredColumns(this.columns);
         this.primaryKeyMetamodel = initPrimaryKeyMetamodel(this.declaredColumns);
@@ -225,14 +237,34 @@ public final class ModelImpl<E extends Data, ID> implements Model<E, ID> {
     }
 
     private static List<ORMConverter> initConverters(List<RecordField> fields, List<Column> columns) {
-        var converters = new ArrayList<ORMConverter>(nCopies(columns.size(), null));
+        var converters = new ORMConverter[columns.size()];
         for (int i = 0; i < columns.size(); i++) {
-            var converter = getORMConverter(fields.get(i)).orElse(null);
-            if (converter != null) {
-                converters.set(i, converter);
-            }
+            converters[i] = getORMConverter(fields.get(i)).orElse(null);
         }
-        return converters;
+        return unmodifiableList(Arrays.asList(converters));
+    }
+
+    /**
+     * Precomputes, for each converter-backed column, the metamodel that navigates the root record to the record
+     * declaring the converted field — the enclosing inline component, or the root record itself for a top-level field.
+     * Keyed by column index (0-based) so the value loop resolves a converter group's parent with a single lookup. A
+     * converter group's start column is always converter-backed, so its key is always present.
+     */
+    private static Map<Integer, Metamodel<Data, ?>> initConverterParents(List<ORMConverter> converters,
+                                                                          List<Column> columns) {
+        var parents = new HashMap<Integer, Metamodel<Data, ?>>();
+        for (int i = 0; i < columns.size(); i++) {
+            if (converters.get(i) == null) {
+                continue;
+            }
+            Metamodel<Data, ?> columnMetamodel = columns.get(i).metamodel();
+            String fieldPath = columnMetamodel.fieldPath();
+            int lastDot = fieldPath.lastIndexOf('.');
+            // The parent path is the field path without its final segment; empty resolves to the root record itself.
+            String parentPath = lastDot < 0 ? "" : fieldPath.substring(0, lastDot);
+            parents.put(i, Metamodel.of(columnMetamodel.root(), parentPath));
+        }
+        return Map.copyOf(parents);
     }
 
     private static RecordField initPrimaryKeyField(@Nonnull RecordType recordType) {
@@ -567,7 +599,9 @@ public final class ModelImpl<E extends Data, ID> implements Model<E, ID> {
                 int groupStart = findConverterGroupStart(index - 1, parameterCount);
                 int groupStartIndex = groupStart + 1;
                 if (groupStart != cachedGroupStart) {
-                    cachedValues = converter.toDatabase(record);
+                    // Navigate the root record down to the record that declares the converted field so the converter
+                    // reflects its accessor on the correct instance (the enclosing inline component, or the root).
+                    cachedValues = converter.toDatabase(converterParents.get(groupStart).getValue(record));
                     cachedGroupStart = groupStart;
                     cachedParamCount = parameterCount;
                 }

--- a/storm-core/src/test/java/st/orm/core/EmbeddedConverterIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/EmbeddedConverterIntegrationTest.java
@@ -1,0 +1,112 @@
+package st.orm.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import javax.sql.DataSource;
+import lombok.Builder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.Convert;
+import st.orm.Converter;
+import st.orm.DbColumn;
+import st.orm.DbTable;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.Inline;
+import st.orm.PK;
+import st.orm.Version;
+import st.orm.core.model.City;
+import st.orm.core.template.ORMTemplate;
+
+/**
+ * Regression test for <a href="https://github.com/storm-orm/storm-framework/issues/141">issue #141</a>:
+ * a {@code @Convert} converter declared on a field of an embedded (inline) component must work on save.
+ *
+ * <p>Previously the save failed with a {@code ClassCastException} ({@code object is not an instance of declaring
+ * class}): a converter resolves its value by reflectively invoking the field accessor on the record passed to
+ * {@code ORMConverter.toDatabase}, but {@code ModelImpl} passed the <em>root</em> record. For a top-level field the
+ * root record is the correct receiver, so existing converter tests passed; for a field inside an inline component the
+ * accessor belongs to the component type, so invoking it on the root record threw. The fix navigates the root record
+ * down to the enclosing component instance before invoking the converter.</p>
+ */
+@SuppressWarnings("ALL")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IntegrationConfig.class)
+@DataJpaTest(showSql = false)
+public class EmbeddedConverterIntegrationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    /**
+     * Domain value type stored in the {@code address} column. A converter maps it to/from the database {@code String}.
+     */
+    public record Street(@Nonnull String value) {}
+
+    public static class StreetConverter implements Converter<String, Street> {
+        @Override
+        public String toDatabase(@Nullable Street value) {
+            return value == null ? null : value.value();
+        }
+
+        @Override
+        public Street fromDatabase(@Nullable String dbValue) {
+            return dbValue == null ? null : new Street(dbValue);
+        }
+    }
+
+    /**
+     * Embedded (inline) component holding a field whose value is mapped through {@link StreetConverter}.
+     */
+    @Builder(toBuilder = true)
+    public record AddressWithConverter(
+            @Nonnull @Convert(converter = StreetConverter.class) @DbColumn("address") Street street,
+            @Nonnull @FK City city
+    ) {}
+
+    /**
+     * Entity mapped to the existing {@code owner} table, embedding {@link AddressWithConverter} inline. The converted
+     * {@code street} field maps to the {@code address} column and the {@code @FK City} maps to the {@code city_id}
+     * column.
+     */
+    @Builder(toBuilder = true)
+    @DbTable("owner")
+    public record OwnerWithEmbeddedConverter(
+            @PK Integer id,
+            @Nonnull String firstName,
+            @Nonnull String lastName,
+            @Nonnull @Inline AddressWithConverter address,
+            @Nullable String telephone,
+            @Version int version
+    ) implements Entity<Integer> {}
+
+    @Test
+    void testInsertWithConverterOnEmbeddedComponentField() {
+        var owners = ORMTemplate.of(dataSource).entity(OwnerWithEmbeddedConverter.class);
+        var owner = OwnerWithEmbeddedConverter.builder()
+                .firstName("Ada")
+                .lastName("Lovelace")
+                .address(AddressWithConverter.builder()
+                        .street(new Street("638 Cardinal Ave."))
+                        .city(City.builder().id(1).build())
+                        .build())
+                .telephone("6085551749")
+                .version(0)
+                .build();
+
+        // The insert must succeed and the converted value must round-trip through the embedded component.
+        var inserted = owners.insertAndFetch(owner);
+
+        assertNotNull(inserted.id());
+        var reloaded = owners.getById(inserted.id());
+        assertEquals("638 Cardinal Ave.", reloaded.address().street().value());
+        assertEquals(1, reloaded.address().city().id());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #141. A `@Convert` converter declared on a field of an embedded (`@Inline`) component failed on save with a root-cause `ClassCastException` (`object is not an instance of declaring class`).

A converter resolves its value by reflectively invoking the field accessor on the record passed to `ORMConverter.toDatabase(...)`, but `ModelImpl` always passed the **root** record. For a top-level converted field the root record is the correct receiver, so existing converter tests passed; for a field inside an inline component the accessor belongs to the **component** type, so invoking it on the root record threw. This affected every converter implementation (`DefaultORMConverterImpl` and the Jackson `JsonORMConverterImpl`s), which all reflect the field on the record.

## Fix

`ModelImpl` now navigates the root record down to the record that *declares* the converted field before invoking the converter — the enclosing inline component, or the root record itself for a top-level field. The parent metamodel for each converter group is precomputed once per model (keyed by the group's start column index), so the write path stays a single lookup plus `getValue`, with no per-row string/metamodel allocation.

## Test infrastructure

Adds `--add-modules jakarta.persistence` to the `storm-core` surefire `argLine`. `storm.core` only `requires static jakarta.persistence`, so the module isn't resolved at runtime; `@DataJpaTest` boots Hibernate/JPA (on the classpath), which needs `jakarta.persistence` at runtime. Resolving it explicitly keeps the JPA tests runnable on the module path (e.g. from the IDE), matching how Maven already provides it via the `provided`-scope classpath.

## Tests

- Adds `EmbeddedConverterIntegrationTest` covering the embedded-converter round trip (insert + read back).
- Full reactor build green across all 30 modules (6657 tests, 0 failures/errors), including the Jackson, Kotlin, Spring, and real-database dialect modules.