### PR TITLE
ci: derive Maven release version from the git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,14 @@ jobs:
         env:
           CENTRAL_USER_TOKEN: ${{ secrets.CENTRAL_USER_TOKEN }}
 
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
       - name: Publish all modules to Maven Central
-        run: mvn clean deploy -Prelease -Dgpg.passphrase="${GPG_PASSPHRASE}" -DskipTests -B
+        # The version comes from the tag: -Drevision overrides the ${revision} property and the
+        # flatten-maven-plugin (resolveCiFriendliesOnly) writes it into the published poms. No manual pom bump needed.
+        run: mvn clean deploy -Prelease -Drevision="${{ steps.version.outputs.VERSION }}" -Dgpg.passphrase="${GPG_PASSPHRASE}" -DskipTests -B
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <revision>1.11.5</revision>
+        <!-- Dev default for local/CI builds. Releases override this via -Drevision=<tag> (see .github/workflows/release.yml). -->
+        <revision>0.0.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>


### PR DESCRIPTION
## Summary

Automates the Maven release version so it is driven by the git tag, removing the manual `pom.xml` bump.

The `publish` job now extracts the version from the tag and passes it to the deploy:

```
mvn clean deploy -Prelease -Drevision="${TAG#v}" ...
```

Tagging `v1.11.6` builds and publishes `1.11.6`. Because the root pom uses CI-friendly versions (`<version>${revision}</version>`) with `flatten-maven-plugin` in `resolveCiFriendliesOnly` mode, `-Drevision` is resolved into the published poms — no `${revision}` literal leaks into the artifacts. The `publish-npm` and `version-docs` jobs already derive their version from the tag, so after this change all three artifacts (Maven, npm, docs) are tag-driven.

## pom `<revision>`

`<revision>` becomes a dev sentinel `0.0.0-SNAPSHOT`, used only for local and CI builds; releases override it from the tag. This keeps the in-repo value from going stale and makes it clear that non-release builds are not a real version.

## Verification

- Local/CI (no `-Drevision`): `project.version` resolves to `0.0.0-SNAPSHOT`; full 30-module reactor build succeeds.
- Release (`-Drevision=1.11.6`): `project.version` resolves to `1.11.6`, and the flattened published pom contains `<version>1.11.6</version>`.