### PR TITLE
ci: restrict GITHUB_TOKEN permissions for the release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read   # Checkout only; deploy auth comes from Central/GPG secrets, not GITHUB_TOKEN.
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Fixes the CodeQL code-scanning alert [`actions/missing-workflow-permissions`](https://github.com/storm-orm/storm-framework/security/code-scanning/1): the `publish` job in `.github/workflows/release.yml` had no explicit `permissions` block, so it inherited the repository's default `GITHUB_TOKEN` scope.

The job only checks out the repository and deploys to Maven Central using the Central/GPG secrets (not `GITHUB_TOKEN`), so least privilege is `contents: read`:

```yaml
  publish:
    runs-on: ubuntu-latest
    permissions:
      contents: read
```

The other two jobs already declare their own permissions (`publish-npm`: `id-token: write` + `contents: read`; `version-docs`: `contents: write`), so after this change every job in the workflow has an explicit, least-privilege permissions block.

No functional change to the release.