### PR TITLE
fix(cli): escape MCP server name before building TOML regex

### DIFF
--- a/storm-cli/storm.mjs
+++ b/storm-cli/storm.mjs
@@ -833,6 +833,11 @@ function mcpServerName(alias) {
   return alias === 'default' ? 'storm-schema' : `storm-schema-${alias}`;
 }
 
+// Escape regex metacharacters so dynamic values (e.g. a user-supplied alias) can be safely embedded in a RegExp.
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // ─── Content (fetched from orm.st at runtime) ───────────────────────────────
 
 const SKILLS_BASE_URL = 'https://orm.st/skills';
@@ -1688,7 +1693,7 @@ function registerMcp(toolConfig, alias, connectionPath, created, appended) {
         appended.push('.codex/config.toml');
       } else {
         // Replace existing entry with updated args.
-        const regex = new RegExp(`\\[mcp_servers\\.${serverName}\\][\\s\\S]*?(?=\\n\\[|$)`);
+        const regex = new RegExp(`\\[mcp_servers\\.${escapeRegExp(serverName)}\\][\\s\\S]*?(?=\\n\\[|$)`);
         const updated = existing.replace(regex, tomlEntry.trimStart().trimEnd());
         if (updated !== existing) {
           writeFileSync(tomlPath, updated);
@@ -1735,7 +1740,7 @@ function unregisterMcp(toolConfig, alias) {
     const tomlPath = join(process.cwd(), '.codex', 'config.toml');
     if (!existsSync(tomlPath)) return false;
     const existing = readFileSync(tomlPath, 'utf-8');
-    const regex = new RegExp(`\\n?\\[mcp_servers\\.${serverName}\\][\\s\\S]*?(?=\\n\\[|$)`, 'g');
+    const regex = new RegExp(`\\n?\\[mcp_servers\\.${escapeRegExp(serverName)}\\][\\s\\S]*?(?=\\n\\[|$)`, 'g');
     const updated = existing.replace(regex, '');
     if (updated !== existing) {
       writeFileSync(tomlPath, updated);


### PR DESCRIPTION
## Summary

Fixes the CodeQL alert [`js/regex-injection`](https://github.com/storm-orm/storm-framework/security/code-scanning/9) in `storm-cli/storm.mjs`.

The Codex MCP register/unregister paths built a `RegExp` from the server name, which is derived from the user-supplied `--alias` command-line argument (`mcpServerName(alias)` → `storm-schema-<alias>`). Interpolating it directly into a regex allowed regex injection: a crafted alias (e.g. containing `.*`) could change which `[mcp_servers.*]` section of `.codex/config.toml` is matched and removed.

## Fix

Add an `escapeRegExp` helper and apply it at both `RegExp` construction sites (the alert flagged the `unregisterMcp` site at line 1738; the identical pattern in `registerMcp` is fixed too):

```js
function escapeRegExp(value) {
  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
}
```

## Verification

- `node --check storm-cli/storm.mjs` passes.
- Normal aliases still remove only their own section.
- A malicious `.*` alias no longer matches/removes unrelated content.
- An alias containing metacharacters (e.g. `a.b`) matches its literal section.