### PR TITLE
docs: restructure entry-point AI section and tidy content

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ val users = orm.findAll(User_.city.name eq "Sunnyvale")
 interface UserRepository : EntityRepository<User, Int> {
     fun findByCityName(name: String) = findAll(User_.city.name eq name)
 }
-val users = userRepository.findByCityName("Sunnyvale")
 
 // Block DSL — build queries with where, orderBy, joins, pagination
 val users = userRepository.select {
@@ -119,7 +118,7 @@ users.collect { user -> println(user.name) }
 
 // Programmatic transactions
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm insert User(email = "bob@example.com", name = "Bob", city = city)
 }
 ```
@@ -140,7 +139,6 @@ interface UserRepository extends EntityRepository<User, Integer> {
         return select().where(User_.city.name, EQUALS, name).getResultList();
     }
 }
-List<User> users = userRepository.findByCityName("Sunnyvale");
 
 // Query Builder for more complex operations
 List<User> users = orm.entity(User.class)

--- a/docs/first-entity.md
+++ b/docs/first-entity.md
@@ -49,7 +49,7 @@ record User(@PK Integer id,
 
 In Java, record components are nullable by default. Use `@Nonnull` on fields that must always have a value. Primitive types (`int`, `long`, etc.) are inherently non-nullable.
 
-The `@Builder` annotation is from [Lombok](https://projectlombok.org/) and is optional. It generates a builder that lets you construct entities without specifying the primary key, and creates modified copies via `toBuilder()`. Without Lombok, you can pass `null` as the primary key (e.g., `new City(null, "Sunnyvale", 155_000)`) or define a convenience constructor that omits it. See [Modifying Entities](entities.md#modifying-entities) for details.
+The `@Builder` annotation is from [Lombok](https://projectlombok.org/) and is optional. It generates a builder that lets you construct entities without specifying the primary key, and creates modified copies via `toBuilder()`. Without Lombok, you can pass `null` as the primary key (e.g., `new City(null, "Sunnyvale", 161_884)`) or define a convenience constructor that omits it. See [Modifying Entities](entities.md#modifying-entities) for details.
 
 </TabItem>
 </Tabs>
@@ -113,7 +113,7 @@ Storm's Kotlin API provides infix operators for a concise syntax:
 
 ```kotlin
 // Insert a city -- the returned object has the database-generated ID
-val city = orm insert City(name = "Sunnyvale", population = 155_000)
+val city = orm insert City(name = "Sunnyvale", population = 161_884)
 
 // Insert a user that references the city
 val user = orm insert User(
@@ -135,7 +135,7 @@ var users = orm.entity(User.class);
 // Insert a city -- the returned object has the database-generated ID
 City city = cities.insertAndFetch(City.builder()
         .name("Sunnyvale")
-        .population(155_000)
+        .population(161_884)
         .build());
 
 // Insert a user that references the city
@@ -234,7 +234,7 @@ Storm provides a `transaction` block that commits on success and rolls back on e
 
 ```kotlin
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm insert User(email = "bob@example.com", name = "Bob", city = city)
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,6 @@ import TabItem from '@theme/TabItem';
 
 # ST/ORM
 
-:::tip Give your AI tool access to your database schema
-Storm includes a schema-aware MCP server that exposes your table definitions, column types, and foreign keys to AI coding tools like Claude Code, Cursor, Copilot and Codex. Run `npx @storm-orm/cli` for full Storm ORM support including AI skills, conventions, and schema access. Using Python, Go, Ruby, or another language? Run `npx @storm-orm/cli mcp` to set up the MCP server standalone.
-:::
-
 **Storm** is a modern, high-performance ORM for Kotlin 2.0+ and Java 21+, built around a powerful SQL template engine. It focuses on simplicity, type safety, and predictable performance through immutable models and compile-time metadata.
 
 **Key benefits:**
@@ -24,20 +20,6 @@ Storm includes a schema-aware MCP server that exposes your table definitions, co
 - **Stateless**: Avoids hidden complexities and "magic" with stateless, record-based entities, ensuring simplicity and eliminating lazy initialization and transaction issues downstream.
 - **Performance**: Template caching, transaction-scoped entity caching, and zero-overhead dirty checking (thanks to immutability) ensure efficient database interactions. Batch processing, lazy streams, and upserts are built in.
 - **Universal Database Compatibility**: Fully compatible with all SQL databases, it offers flexibility and broad applicability across various database systems.
-
-## Built for the AI Era
-
-Storm is the ORM that AI coding assistants get right. Its stateless, immutable entities mean what you see in the source code is exactly what exists at runtime: no hidden proxies, no lazy loading surprises, no persistence context rules that trip up AI-generated code. When you ask your AI tool to write a query, define an entity, or build a repository, the output is straightforward data classes and explicit SQL, the same code a senior developer would write by hand.
-
-Traditional ORMs carry invisible complexity (managed entity state, implicit flushes, bytecode-enhanced proxies) that AI tools have no reliable way to reason about. Storm eliminates these failure modes entirely. Combined with its compile-time metamodel that catches errors before runtime, Storm and AI coding tools form a natural partnership.
-
-**Get started in seconds:**
-
-```bash
-npx @storm-orm/cli
-```
-
-This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's patterns, conventions, and slash commands. See [AI-Assisted Development](ai.md) for details.
 
 ## Why Storm?
 
@@ -83,7 +65,6 @@ val users = orm.findAll(User_.city.name eq "Sunnyvale")
 interface UserRepository : EntityRepository<User, Int> {
     fun findByCityName(name: String) = findAll(User_.city.name eq name)
 }
-val users = userRepository.findByCityName("Sunnyvale")
 
 // Block DSL — build queries with where, orderBy, joins, pagination
 val users = userRepository.select {
@@ -108,7 +89,7 @@ users.collect { user -> println(user.name) }
 
 // Programmatic transactions
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm insert User(email = "bob@example.com", name = "Bob", city = city)
 }
 ```
@@ -130,7 +111,6 @@ interface UserRepository extends EntityRepository<User, Integer> {
         return select().where(User_.city.name, EQUALS, name).getResultList();
     }
 }
-List<User> users = userRepository.findByCityName("Sunnyvale");
 
 // Query Builder for more complex operations
 List<User> users = orm.entity(User.class)
@@ -149,6 +129,18 @@ List<User> users = orm.query(RAW."""
 
 </TabItem>
 </Tabs>
+
+## AI Assisted Development
+
+Storm is the ORM that AI coding assistants get right. Its stateless, immutable entities mean what you see in the source code is exactly what exists at runtime: no hidden proxies, no lazy loading surprises, no persistence context rules that trip up AI-generated code. When you ask your AI tool to write a query, define an entity, or build a repository, the output is straightforward data classes and explicit SQL, the same code a senior developer would write by hand.
+
+**Get started in seconds:**
+
+```bash
+npx @storm-orm/cli
+```
+
+This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's patterns, conventions, and slash commands. See [more on ai](ai.md) for details.
 
 ## Quick Start
 

--- a/docs/upserts.md
+++ b/docs/upserts.md
@@ -50,7 +50,7 @@ Upserts participate in transactions like any other Storm operation. When you nee
 
 ```kotlin
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm upsert User(
         email = "alice@example.com",
         name = "Alice",

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -81,7 +81,6 @@ val users = orm.findAll(User_.city.name eq "Sunnyvale")
 interface UserRepository : EntityRepository<User, Int> {
     fun findByCityName(name: String) = findAll(User_.city.name eq name)
 }
-val users = userRepository.findByCityName("Sunnyvale")
 
 // Block DSL — build queries with where, orderBy, joins, pagination
 val users = userRepository.select {
@@ -106,7 +105,7 @@ users.collect { user -> println(user.name) }
 
 // Programmatic transactions
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm insert User(email = "bob@example.com", name = "Bob", city = city)
 }
 ```
@@ -127,7 +126,6 @@ interface UserRepository extends EntityRepository<User, Integer> {
         return select().where(User_.city.name, EQUALS, name).getResultList();
     }
 }
-List<User> users = userRepository.findByCityName("Sunnyvale");
 
 // Query Builder for more complex operations
 List<User> users = orm.entity(User.class)
@@ -599,7 +597,7 @@ record User(@PK Integer id,
 
 In Java, record components are nullable by default. Use `@Nonnull` on fields that must always have a value. Primitive types (`int`, `long`, etc.) are inherently non-nullable.
 
-The `@Builder` annotation is from [Lombok](https://projectlombok.org/) and is optional. It generates a builder that lets you construct entities without specifying the primary key, and creates modified copies via `toBuilder()`. Without Lombok, you can pass `null` as the primary key (e.g., `new City(null, "Sunnyvale", 155_000)`) or define a convenience constructor that omits it. See [Modifying Entities](entities.md#modifying-entities) for details.
+The `@Builder` annotation is from [Lombok](https://projectlombok.org/) and is optional. It generates a builder that lets you construct entities without specifying the primary key, and creates modified copies via `toBuilder()`. Without Lombok, you can pass `null` as the primary key (e.g., `new City(null, "Sunnyvale", 161_884)`) or define a convenience constructor that omits it. See [Modifying Entities](entities.md#modifying-entities) for details.
 These entities map to the following database tables:
 
 | Table | Columns |
@@ -646,7 +644,7 @@ Storm's Kotlin API provides infix operators for a concise syntax:
 
 ```kotlin
 // Insert a city -- the returned object has the database-generated ID
-val city = orm insert City(name = "Sunnyvale", population = 155_000)
+val city = orm insert City(name = "Sunnyvale", population = 161_884)
 
 // Insert a user that references the city
 val user = orm insert User(
@@ -667,7 +665,7 @@ var users = orm.entity(User.class);
 // Insert a city -- the returned object has the database-generated ID
 City city = cities.insertAndFetch(City.builder()
         .name("Sunnyvale")
-        .population(155_000)
+        .population(161_884)
         .build());
 
 // Insert a user that references the city
@@ -743,7 +741,7 @@ Storm provides a `transaction` block that commits on success and rolls back on e
 
 ```kotlin
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm insert User(email = "bob@example.com", name = "Bob", city = city)
 }
 ```
@@ -11237,7 +11235,7 @@ Upserts participate in transactions like any other Storm operation. When you nee
 
 ```kotlin
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm upsert User(
         email = "alice@example.com",
         name = "Alice",

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -142,7 +142,7 @@ Kotlin:
 val orm = ORMTemplate.of(dataSource)
 
 // Insert (returns entity with generated ID)
-val city = orm insert City(name = "Sunnyvale", population = 155_000)
+val city = orm insert City(name = "Sunnyvale", population = 161_884)
 
 // Find by ID
 val found: City? = orm.findById<City>(city.id)
@@ -163,7 +163,7 @@ var orm = ORMTemplate.of(dataSource);
 var cities = orm.entity(City.class);
 
 // Insert
-City city = cities.insert(new City(0, "Sunnyvale", 155_000));
+City city = cities.insert(new City(0, "Sunnyvale", 161_884));
 
 // Find by ID
 Optional<City> found = cities.findById(city.id());

--- a/website/versioned_docs/version-1.11.5/first-entity.md
+++ b/website/versioned_docs/version-1.11.5/first-entity.md
@@ -49,7 +49,7 @@ record User(@PK Integer id,
 
 In Java, record components are nullable by default. Use `@Nonnull` on fields that must always have a value. Primitive types (`int`, `long`, etc.) are inherently non-nullable.
 
-The `@Builder` annotation is from [Lombok](https://projectlombok.org/) and is optional. It generates a builder that lets you construct entities without specifying the primary key, and creates modified copies via `toBuilder()`. Without Lombok, you can pass `null` as the primary key (e.g., `new City(null, "Sunnyvale", 155_000)`) or define a convenience constructor that omits it. See [Modifying Entities](entities.md#modifying-entities) for details.
+The `@Builder` annotation is from [Lombok](https://projectlombok.org/) and is optional. It generates a builder that lets you construct entities without specifying the primary key, and creates modified copies via `toBuilder()`. Without Lombok, you can pass `null` as the primary key (e.g., `new City(null, "Sunnyvale", 161_884)`) or define a convenience constructor that omits it. See [Modifying Entities](entities.md#modifying-entities) for details.
 
 </TabItem>
 </Tabs>
@@ -113,7 +113,7 @@ Storm's Kotlin API provides infix operators for a concise syntax:
 
 ```kotlin
 // Insert a city -- the returned object has the database-generated ID
-val city = orm insert City(name = "Sunnyvale", population = 155_000)
+val city = orm insert City(name = "Sunnyvale", population = 161_884)
 
 // Insert a user that references the city
 val user = orm insert User(
@@ -135,7 +135,7 @@ var users = orm.entity(User.class);
 // Insert a city -- the returned object has the database-generated ID
 City city = cities.insertAndFetch(City.builder()
         .name("Sunnyvale")
-        .population(155_000)
+        .population(161_884)
         .build());
 
 // Insert a user that references the city
@@ -234,7 +234,7 @@ Storm provides a `transaction` block that commits on success and rolls back on e
 
 ```kotlin
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm insert User(email = "bob@example.com", name = "Bob", city = city)
 }
 ```

--- a/website/versioned_docs/version-1.11.5/index.md
+++ b/website/versioned_docs/version-1.11.5/index.md
@@ -8,10 +8,6 @@ import TabItem from '@theme/TabItem';
 
 # ST/ORM
 
-:::tip Give your AI tool access to your database schema
-Storm includes a schema-aware MCP server that exposes your table definitions, column types, and foreign keys to AI coding tools like Claude Code, Cursor, Copilot and Codex. Run `npx @storm-orm/cli` for full Storm ORM support including AI skills, conventions, and schema access. Using Python, Go, Ruby, or another language? Run `npx @storm-orm/cli mcp` to set up the MCP server standalone.
-:::
-
 **Storm** is a modern, high-performance ORM for Kotlin 2.0+ and Java 21+, built around a powerful SQL template engine. It focuses on simplicity, type safety, and predictable performance through immutable models and compile-time metadata.
 
 **Key benefits:**
@@ -24,20 +20,6 @@ Storm includes a schema-aware MCP server that exposes your table definitions, co
 - **Stateless**: Avoids hidden complexities and "magic" with stateless, record-based entities, ensuring simplicity and eliminating lazy initialization and transaction issues downstream.
 - **Performance**: Template caching, transaction-scoped entity caching, and zero-overhead dirty checking (thanks to immutability) ensure efficient database interactions. Batch processing, lazy streams, and upserts are built in.
 - **Universal Database Compatibility**: Fully compatible with all SQL databases, it offers flexibility and broad applicability across various database systems.
-
-## Built for the AI Era
-
-Storm is the ORM that AI coding assistants get right. Its stateless, immutable entities mean what you see in the source code is exactly what exists at runtime: no hidden proxies, no lazy loading surprises, no persistence context rules that trip up AI-generated code. When you ask your AI tool to write a query, define an entity, or build a repository, the output is straightforward data classes and explicit SQL, the same code a senior developer would write by hand.
-
-Traditional ORMs carry invisible complexity (managed entity state, implicit flushes, bytecode-enhanced proxies) that AI tools have no reliable way to reason about. Storm eliminates these failure modes entirely. Combined with its compile-time metamodel that catches errors before runtime, Storm and AI coding tools form a natural partnership.
-
-**Get started in seconds:**
-
-```bash
-npx @storm-orm/cli
-```
-
-This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's patterns, conventions, and slash commands. See [AI-Assisted Development](ai.md) for details.
 
 ## Why Storm?
 
@@ -83,7 +65,6 @@ val users = orm.findAll(User_.city.name eq "Sunnyvale")
 interface UserRepository : EntityRepository<User, Int> {
     fun findByCityName(name: String) = findAll(User_.city.name eq name)
 }
-val users = userRepository.findByCityName("Sunnyvale")
 
 // Block DSL — build queries with where, orderBy, joins, pagination
 val users = userRepository.select {
@@ -108,7 +89,7 @@ users.collect { user -> println(user.name) }
 
 // Programmatic transactions
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm insert User(email = "bob@example.com", name = "Bob", city = city)
 }
 ```
@@ -130,7 +111,6 @@ interface UserRepository extends EntityRepository<User, Integer> {
         return select().where(User_.city.name, EQUALS, name).getResultList();
     }
 }
-List<User> users = userRepository.findByCityName("Sunnyvale");
 
 // Query Builder for more complex operations
 List<User> users = orm.entity(User.class)
@@ -149,6 +129,18 @@ List<User> users = orm.query(RAW."""
 
 </TabItem>
 </Tabs>
+
+## AI Assisted Development
+
+Storm is the ORM that AI coding assistants get right. Its stateless, immutable entities mean what you see in the source code is exactly what exists at runtime: no hidden proxies, no lazy loading surprises, no persistence context rules that trip up AI-generated code. When you ask your AI tool to write a query, define an entity, or build a repository, the output is straightforward data classes and explicit SQL, the same code a senior developer would write by hand.
+
+**Get started in seconds:**
+
+```bash
+npx @storm-orm/cli
+```
+
+This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's patterns, conventions, and slash commands. See [more on ai](ai.md) for details.
 
 ## Quick Start
 

--- a/website/versioned_docs/version-1.11.5/upserts.md
+++ b/website/versioned_docs/version-1.11.5/upserts.md
@@ -50,7 +50,7 @@ Upserts participate in transactions like any other Storm operation. When you nee
 
 ```kotlin
 transaction {
-    val city = orm insert City(name = "Sunnyvale", population = 155_000)
+    val city = orm insert City(name = "Sunnyvale", population = 161_884)
     val user = orm upsert User(
         email = "alice@example.com",
         name = "Alice",


### PR DESCRIPTION
## Summary

- **Entry-point AI section** — renamed *"Built for the AI Era"* → *"AI Assisted Development"*, moved it to just above **Quick Start**, removed the "give your AI tool access to your schema" tip and the redundant *"Traditional ORMs carry invisible complexity…"* paragraph, and renamed the inline link to **more on ai**.
- **Examples** — dropped the redundant `findByCityName("Sunnyvale")` usage line from the *Choose Your Language* section (the method definition stays).

Applies to `docs/` (Next) and the latest published snapshot (`version-1.11.5`); historical snapshots left frozen.

> `llms-full.txt` is regenerated from `docs/` by CI on deploy; this PR carries only the population/findByCityName line edits in it, and the deploy fully refreshes it.
