### PR TITLE
feat(website): add landing front page; serve docs under /docs

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -26,6 +26,24 @@ const config: Config = {
 
   plugins: [
     [staticVersionReplace, { version: stormVersion }],
+    // Redirect the old root-level doc URLs (which used to serve at `/`) to their
+    // new `/docs/...` homes, so existing links, bookmarks, and SEO keep working
+    // now that the landing page owns `/`.
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        createRedirects(existingPath: string) {
+          // Every doc now lives under `/docs/`; map `/docs/x` <- `/x`.
+          // The docs index (`/docs/`) is intentionally NOT redirected from `/`,
+          // because `/` is the landing page.
+          if (existingPath.startsWith('/docs/')) {
+            const rest = existingPath.slice('/docs/'.length);
+            if (rest) return ['/' + rest];
+          }
+          return undefined;
+        },
+      },
+    ],
     // Privacy-friendly analytics (Plausible). Injects the site-specific
     // loader plus the init snippet into <head> on every page.
     function plausibleAnalyticsPlugin() {
@@ -59,7 +77,13 @@ const config: Config = {
       {
         docs: {
           path: '../docs',
-          routeBasePath: '/',
+          // Docs are namespaced under `/docs` so the landing page
+          // (src/pages/index.js) owns `/`. Keep this as `/docs`: reverting to `/`
+          // would let the docs reclaim the homepage and hide the landing.
+          // Doc versioning (`docusaurus docs:version`) only writes to
+          // versioned_docs/ — it never touches src/pages — so the front page
+          // is safe across doc generation.
+          routeBasePath: '/docs',
           sidebarPath: './sidebars.ts',
           versions: {
             current: {
@@ -114,9 +138,9 @@ const config: Config = {
         {
           title: 'Docs',
           items: [
-            {label: 'Getting Started', to: '/getting-started'},
-            {label: 'Entities', to: '/entities'},
-            {label: 'Queries', to: '/queries'},
+            {label: 'Getting Started', to: '/docs/getting-started'},
+            {label: 'Entities', to: '/docs/entities'},
+            {label: 'Queries', to: '/docs/queries'},
           ],
         },
         {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.7.0",
+        "@docusaurus/plugin-client-redirects": "3.9.2",
         "@docusaurus/preset-classic": "^3.7.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.3.1",
@@ -3579,6 +3580,30 @@
         "react-dom": "*"
       }
     },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.2.tgz",
+      "integrity": "sha512-lUgMArI9vyOYMzLRBUILcg9vcPTCyyI2aiuXq/4npcMVqOr6GfmwtmBYWSbNMlIUM0147smm4WhpXD0KFboffw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@docusaurus/plugin-content-blog": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.2.tgz",
@@ -6333,9 +6358,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -12944,9 +12969,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -15459,9 +15484,9 @@
       }
     },
     "node_modules/react-loadable-ssr-addon-v5-slorber": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.1.tgz",
-      "integrity": "sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+      "integrity": "sha512-GXfh9VLwB5ERaCsU6RULh7tkemeX15aNh6wuMEBtfdyMa7fFG8TXrhXlx1SoEK2Ty/l6XIkzzYIQmyaWW3JgdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.3"
@@ -16324,15 +16349,15 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
-      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
         "mime-types": "2.1.18",
-        "minimatch": "3.1.2",
+        "minimatch": "3.1.5",
         "path-is-inside": "1.0.2",
         "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.7.0",
+    "@docusaurus/plugin-client-redirects": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
@@ -22,8 +23,16 @@
     "typescript": "~5.7.0"
   },
   "browserslist": {
-    "production": [">0.5%", "not dead", "not op_mini all"],
-    "development": ["last 3 chrome version", "last 3 firefox version", "last 5 safari version"]
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 3 chrome version",
+      "last 3 firefox version",
+      "last 5 safari version"
+    ]
   },
   "engines": {
     "node": ">=18.0"

--- a/website/plugins/read-storm-version.js
+++ b/website/plugins/read-storm-version.js
@@ -26,4 +26,24 @@ if (revisionMatch) {
   version = versionMatch ? versionMatch[1] : '0.0.0';
 }
 
+// The published documentation must never render a development/snapshot version
+// (e.g. `0.0.0-SNAPSHOT`, which is the pom <revision> between releases). The repo
+// itself is allowed to carry a SNAPSHOT revision, but the docs site is deployed
+// from `main` on every push — so when the resolved version is a snapshot or the
+// `0.0.0` placeholder, fall back to the latest RELEASED docs version from
+// versions.json. That keeps install snippets like
+// `st.orm:storm-bom:<version>` showing a real, installable version on the site.
+if (!version || /snapshot/i.test(version) || /^0\.0\.0\b/.test(version)) {
+  try {
+    const versions = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '../versions.json'), 'utf-8')
+    );
+    if (Array.isArray(versions) && versions.length > 0) {
+      version = versions[0]; // versions.json is newest-first
+    }
+  } catch (e) {
+    // No versions.json yet (e.g. before the first release) — keep what we have.
+  }
+}
+
 module.exports = version;

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,0 +1,438 @@
+import React, {useEffect} from 'react';
+import Head from '@docusaurus/Head';
+
+// The Storm landing page. The markup/CSS/JS are kept verbatim from the
+// hand-built design (landing-drafts/2-live.html) and mounted here so it serves
+// at `/`, in front of the docs (which now live under `/docs`). The <style> is
+// rendered inside the component so it only applies while this page is mounted
+// and never leaks into the docs theme.
+
+const CSS = `
+  :root{
+    --bg:#070709; --panel:#0f0f14; --panel-2:#0b0b0f; --statusbg:#08080b;
+    --border:#20202a; --border-soft:#17171f;
+    --text:#eaeaf0; --muted:#8a8a96; --faint:#565662;
+    --accent:#818cf8; --accent-2:#a78bfa; --green:#5eead4;
+    --kw:#c4b5fd; --type:#7dd3fc; --str:#86efac; --com:#5a616e; --fn:#f0abfc; --num:#fcd34d; --anno:#fbbf24; --plain:#cfd0d8;
+    --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
+    --sans:"Inter",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+  }
+  html{background:var(--bg)}
+  body{margin:0;background:var(--bg);color:var(--text);font-family:var(--sans);-webkit-font-smoothing:antialiased;
+    background-image:radial-gradient(1100px 540px at 18% -10%,rgba(129,140,248,.14),transparent 62%);}
+  .storm-home a{color:inherit;text-decoration:none}
+  .storm-home *{box-sizing:border-box}
+  .storm-home .wrap{max-width:1120px;margin:0 auto;padding:0 24px}
+
+  .storm-home nav{position:sticky;top:0;z-index:20;backdrop-filter:blur(12px);background:rgba(7,7,9,.7);border-bottom:1px solid var(--border-soft)}
+  .storm-home .nav{display:flex;align-items:center;justify-content:space-between;height:62px}
+  .storm-home .brand{display:flex;align-items:center;gap:9px;font-weight:600;letter-spacing:-.01em}
+  .storm-home .logo{height:26px;width:auto;display:block;position:relative;top:-2px;filter:drop-shadow(0 0 10px rgba(129,140,248,.35))}
+  .storm-home .brand b{font-family:var(--mono);font-weight:700}
+  .storm-home .tech-tag{font-family:var(--mono);font-size:11px;color:var(--faint);letter-spacing:.02em;border-left:1px solid var(--border);padding-left:12px}
+  .storm-home .nav-links{display:flex;align-items:center;gap:24px;font-size:14px;color:var(--muted)}
+  .storm-home .nav-links a:hover{color:var(--text)}
+  .storm-home .btn{display:inline-flex;align-items:center;gap:8px;height:40px;padding:0 18px;border-radius:9px;font-size:14.5px;
+    font-weight:550;border:1px solid var(--border);background:var(--panel);transition:.16s;cursor:pointer}
+  .storm-home .btn:hover{border-color:#34343d;transform:translateY(-1px)}
+  .storm-home .btn.primary{background:var(--accent);color:#0a0a0f;border-color:var(--accent);font-weight:600}
+  .storm-home .btn.primary:hover{background:#9aa3ff}
+
+  /* hero — left aligned */
+  .storm-home header{padding:46px 0 34px}
+  .storm-home h1{font-size:clamp(42px,7vw,78px);line-height:.97;letter-spacing:-.04em;font-weight:800;margin:0}
+  .storm-home .grad{background:linear-gradient(100deg,#a78bfa,#818cf8 50%,#7dd3fc);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .storm-home .sub{max-width:600px;margin:24px 0 0;color:var(--muted);font-size:18px;line-height:1.62}
+  .storm-home .cta{display:flex;gap:14px;margin-top:32px;flex-wrap:wrap}
+
+  /* editor */
+  .storm-home .stage{margin:54px 0 0;max-width:880px}
+  .storm-home .editor{border:1px solid var(--border);border-radius:16px;overflow:hidden;background:var(--panel);
+    box-shadow:0 50px 110px -45px rgba(0,0,0,.85),0 0 0 1px rgba(129,140,248,.06),0 0 80px -30px rgba(129,140,248,.22)}
+  .storm-home .ebar{display:flex;align-items:center;gap:8px;height:46px;padding:0 16px;border-bottom:1px solid var(--border-soft);background:rgba(255,255,255,.014)}
+  .storm-home .dot{width:11px;height:11px;border-radius:50%}.storm-home .dot.r{background:#ff5f57}.storm-home .dot.y{background:#febc2e}.storm-home .dot.g{background:#28c840}
+  .storm-home .fname{margin-left:10px;font-family:var(--mono);font-size:12.5px;color:var(--faint)}
+  .storm-home .langtag{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--faint);letter-spacing:.05em}
+  .storm-home .sqlbtn{margin-left:auto;display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:11.5px;
+    color:var(--accent);border:1px solid rgba(129,140,248,.3);border-radius:7px;padding:4px 10px;cursor:pointer;transition:.16s;user-select:none}
+  .storm-home .sqlbtn:hover{background:rgba(129,140,248,.12);border-color:rgba(129,140,248,.5)}
+  .storm-home .sqlbtn.on{background:rgba(129,140,248,.16);color:#aab2ff}
+  .storm-home .sqlbtn .ico{width:13px;height:13px;opacity:.9}
+  .storm-home .sqlconsole{display:none;border-top:1px solid var(--border-soft);background:var(--statusbg)}
+  .storm-home .editor.show-sql .sqlconsole{display:block}
+  .storm-home #sqlpanel{margin:0;padding:14px 18px 18px;font-family:var(--mono);font-size:12.5px;line-height:1.75;white-space:pre;overflow-x:auto;color:var(--plain)}
+  .storm-home .statusbar .sqllabel{display:none;align-items:center;gap:9px;font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint)}
+  .storm-home .statusbar .sqllabel .ar{color:var(--accent)}
+  .storm-home .editor.show-sql .statusbar #status,
+  .storm-home .editor.show-sql .statusbar .right{display:none}
+  .storm-home .editor.show-sql .statusbar .sqllabel{display:inline-flex}
+  .storm-home .sqlk{color:var(--accent)}
+  .storm-home .sqlq{color:var(--num)}
+  .storm-home .sqlc{color:var(--com)}
+
+  .storm-home .codearea{display:flex;min-height:460px;background:linear-gradient(180deg,var(--panel),var(--panel-2))}
+  .storm-home .gutter{padding:22px 0;width:48px;text-align:right;color:#3b3b46;font-family:var(--mono);font-size:13px;
+    line-height:26px;user-select:none;border-right:1px solid var(--border-soft);flex:none}
+  .storm-home .gutter div{padding-right:15px}
+  .storm-home #code{margin:0;padding:22px 24px;font-family:var(--mono);font-size:14px;line-height:26px;white-space:pre;overflow-x:auto;flex:1}
+  .storm-home .cursor{display:inline-block;width:8px;height:1.05em;background:var(--accent);vertical-align:text-bottom;
+    margin-bottom:1px;animation:storm-blink 1s steps(2,start) infinite;border-radius:1px}
+  @keyframes storm-blink{50%{opacity:0}}
+
+  .storm-home .statusbar{display:flex;align-items:center;justify-content:space-between;height:38px;padding:0 18px;
+    border-top:1px solid var(--border-soft);background:var(--statusbg);font-family:var(--mono);font-size:12px;color:var(--muted)}
+  .storm-home #status{display:inline-flex;align-items:center;gap:9px;opacity:0;transform:translateY(2px);transition:opacity .4s ease,transform .4s ease}
+  .storm-home #status.show{opacity:1;transform:none}
+  .storm-home #status .ck{width:14px;height:14px;color:var(--green)}
+  .storm-home .statusbar .right{color:var(--faint);letter-spacing:.05em}
+
+  .storm-home .scenes{display:flex;gap:8px;margin-top:22px;flex-wrap:wrap}
+  .storm-home .scenes .s{font-family:var(--mono);font-size:11.5px;color:var(--faint);border:1px solid var(--border-soft);
+    border-radius:999px;padding:5px 13px;transition:.2s;cursor:pointer}
+  .storm-home .scenes .s:hover{color:var(--muted);border-color:var(--border)}
+  .storm-home .scenes .s.on{color:var(--accent);border-color:rgba(129,140,248,.4);background:rgba(129,140,248,.08)}
+
+  .storm-home .code-k{color:var(--kw)}.storm-home .code-t{color:var(--type)}.storm-home .code-s{color:var(--str)}.storm-home .code-c{color:var(--com)}
+  .storm-home .code-f{color:var(--fn)}.storm-home .code-n{color:var(--num)}.storm-home .code-a{color:var(--anno)}.storm-home .code-pl{color:var(--plain)}.storm-home .code-m{color:var(--muted)}
+
+  .storm-home section{padding:92px 0}
+  .storm-home .dbstrip{padding:30px 0}
+  .storm-home .db-label{text-align:center;font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--faint);margin-bottom:18px}
+  .storm-home .dbs{display:flex;flex-wrap:wrap;gap:10px;justify-content:center}
+  .storm-home .dbs span{font-family:var(--mono);font-size:13px;color:var(--muted);background:var(--panel-2);border:1px solid var(--border-soft);border-radius:8px;padding:7px 14px}
+  .storm-home .three{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
+  .storm-home .card{border:1px solid var(--border-soft);border-radius:14px;padding:26px;background:var(--panel-2)}
+  .storm-home .card h3{margin:0 0 9px;font-size:17px;font-weight:600;letter-spacing:-.01em}
+  .storm-home .card p{margin:0;color:var(--muted);font-size:14.5px;line-height:1.65}
+  .storm-home .card .ic{width:34px;height:34px;border-radius:9px;display:grid;place-items:center;color:var(--accent);
+    background:rgba(129,140,248,.1);border:1px solid rgba(129,140,248,.2);margin-bottom:16px}
+  .storm-home .endcta{text-align:center}
+  .storm-home .endcta h2{font-size:clamp(32px,5vw,54px);letter-spacing:-.035em;font-weight:800;margin:0 0 18px}
+  .storm-home footer{border-top:1px solid var(--border-soft);padding:36px 0;color:var(--faint);font-size:13.5px}
+  .storm-home .foot{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px}
+  .storm-home .foot .links{display:flex;gap:22px;font-family:var(--mono)}.storm-home .foot a{color:var(--muted)}.storm-home .foot a:hover{color:var(--text)}
+  @media(max-width:920px){.storm-home .tech-tag{display:none}}
+  @media(max-width:760px){.storm-home .three{grid-template-columns:1fr}.storm-home .nav-links a:not(.gh){display:none}}
+`;
+
+const BODY = `
+<nav><div class="wrap nav">
+  <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span><span class="tech-tag">Kotlin 2.0–2.4 · Java 21+ · Apache 2.0</span></div>
+  <div class="nav-links">
+    <a href="/docs/">Docs</a>
+    <a href="/docs/getting-started">Getting Started</a>
+    <a class="gh" href="https://github.com/storm-orm/storm-framework">GitHub</a>
+    <a href="/docs/getting-started" class="btn primary" style="height:36px">Get started</a>
+  </div>
+</div></nav>
+
+<header><div class="wrap">
+  <h1>Radically Simple.<br><span class="grad">Predictable Persistence.</span></h1>
+  <p class="sub" style="max-width:940px">A clear data-model mapping keeps your entities reusable and your repositories extensible. Your codebase grows stronger as it scales, where traditional ORMs make your code more complex and repetitive.</p>
+
+  <div class="stage">
+    <div class="editor">
+      <div class="ebar">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span class="fname" id="fname">Entities.kt</span>
+        <span class="sqlbtn" id="sqlbtn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/></svg><span id="sqlbtntext">Show SQL</span></span>
+      </div>
+      <div class="codearea">
+        <div class="gutter" id="gutter"></div>
+        <pre id="code"></pre>
+      </div>
+      <div class="statusbar">
+        <span id="status"><svg class="ck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M20 6 9 17l-5-5"/></svg><span id="statustext"></span></span>
+        <span class="right">UTF-8 · Kotlin 2.0</span>
+        <span class="sqllabel"><span class="ar">↳</span> generated sql</span>
+      </div>
+      <div class="sqlconsole">
+        <pre id="sqlpanel"></pre>
+      </div>
+    </div>
+    <div class="scenes" id="scenes"></div>
+  </div>
+</div></header>
+
+<section style="padding-top:48px;padding-bottom:30px"><div class="wrap">
+  <div class="three">
+    <div class="card">
+      <div class="ic"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12h18M3 6h18M3 18h18"/></svg></div>
+      <h3>Direct database control</h3>
+      <p>Every query is explicit and predictable. Nested predicates and entity graphs compile to a single efficient query, eliminating hidden queries and N+1.</p>
+    </div>
+    <div class="card">
+      <div class="ic"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg></div>
+      <h3>Stateless and Immutable</h3>
+      <p>Immutable data classes. No proxies, no flush, no hidden state. What you see is what you get. Safe to cache, share, and serialize across every layer.</p>
+    </div>
+    <div class="card">
+      <div class="ic"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2 4 6v6c0 5 3.5 8 8 10 4.5-2 8-5 8-10V6z"/></svg></div>
+      <h3>Type-safe and injection-safe</h3>
+      <p>Compile-time detection of column and type errors. Automatic conversion of interpolated values into bind parameters.</p>
+    </div>
+  </div>
+</div></section>
+
+<div class="wrap dbstrip">
+  <div class="db-label">Optimized for all major SQL databases</div>
+  <div class="dbs">
+    <span>PostgreSQL</span><span>MySQL</span><span>MariaDB</span><span>Oracle</span><span>SQL&nbsp;Server</span><span>SQLite</span><span>H2</span>
+  </div>
+</div>
+
+<section class="endcta" style="padding-top:30px"><div class="wrap">
+  <h2>Enjoy writing code that is worth reading.</h2>
+  <p class="sub" style="margin:0 auto 30px;text-align:center;max-width:940px">Concise entities and one-line queries keep you productive. Immutable records simplify your architecture by letting the same types flow through your application layers. Your persistence layer stays out of your way.</p>
+  <div class="cta" style="justify-content:center">
+    <a href="/docs/getting-started" class="btn primary">Get started →</a>
+    <a href="https://github.com/storm-orm/storm-framework" class="btn">Star on GitHub</a>
+  </div>
+</div></section>
+
+<footer><div class="wrap foot">
+  <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /></div>
+  <div class="links"><a href="/">orm.st</a><a href="https://github.com/storm-orm/storm-framework">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
+</div></footer>
+`;
+
+export default function Home() {
+  useEffect(() => {
+    const K=(x)=>({x,c:'code-k'}),T=(x)=>({x,c:'code-t'}),S=(x)=>({x,c:'code-s'}),C=(x)=>({x,c:'code-c'}),
+          F=(x)=>({x,c:'code-f'}),N=(x)=>({x,c:'code-n'}),A=(x)=>({x,c:'code-a'}),P=(x)=>({x,c:'code-pl'});
+
+    const SCENES=[
+      { name:'1 · entities', file:'Entities.kt',
+        caption:"the most concise way to define your entities",
+        code:[ C("// Records mirror your schema.\n"),
+          K("data class "),T("City"),P("(\n"),
+          P("    "),A("@PK"),P(" "),K("val "),P("id: "),T("Int"),P(" = "),N("0"),P(",\n"),
+          P("    "),K("val "),P("name: "),T("String"),P(",\n"),
+          P("    "),K("val "),P("population: "),T("Int"),P(",\n"),
+          P("    "),K("val "),P("country: "),T("String"),P(",\n"),
+          P(") : "),T("Entity"),P("<"),T("Int"),P(">\n\n"),
+          C("// Foreign entities are available in queries and results.\n"),
+          K("data class "),T("User"),P("(\n"),
+          P("    "),A("@PK"),P(" "),K("val "),P("id: "),T("Int"),P(" = "),N("0"),P(",\n"),
+          P("    "),K("val "),P("email: "),T("String"),P(",\n"),
+          P("    "),K("val "),P("name: "),T("String"),P(",\n"),
+          P("    "),A("@FK"),P(" "),K("val "),P("city: "),T("City"),P(",\n"),
+          P(") : "),T("Entity"),P("<"),T("Int"),P(">") ] },
+
+      { name:'2 · query', file:'UserService.kt',
+        caption:"one-line queries to get all the data you need · no N+1",
+        code:[ C("// A user's city is loaded in the same query.\n"),
+          K("val "),P("user = userRepository."),F("getById"),P("("),N("1"),P(")\n"),
+          K("val "),P("cityName = user.city.name"),P("   "),C('// already loaded — no N+1, no lazy-init\n\n'),
+          C("// Filter across the graph, fully type-safe using the static metamodel.\n"),
+          K("val "),P("users = userRepository."),F("findAll"),P("(User_.city.name "),K("eq "),S('"Sunnyvale"'),P(")") ] },
+
+      { name:'3 · repository', file:'UserRepository.kt',
+        caption:"your own type-safe queries · CRUD inherited",
+        code:[ C("// Custom return types are just records — define them in-place.\n"),
+          K("data class "),T("CityCount"),P("("),K("val "),P("city: "),T("City"),P(", "),K("val "),P("count: "),T("Long"),P(")\n\n"),
+          C("// Extend EntityRepository — all CRUD comes for free.\n"),
+          K("interface "),T("UserRepository"),P(" : "),T("EntityRepository"),P("<"),T("User"),P(", "),T("Int"),P("> {\n"),
+          P("    "),K("fun "),F("findByCity"),P("(city: "),T("City"),P(") = "),F("findAll"),P("(User_.city "),K("eq "),P("city)\n\n"),
+          C("    // Query builder with SQL templates for the aggregate.\n"),
+          P("    "),K("fun "),F("topCities"),P("(country: "),T("String"),P(", limit: "),T("Int"),P(") =\n"),
+          P("        "),F("select"),P("("),T("CityCount"),P("::"),K("class"),P(") { "),S('"${City::class}, COUNT(*)"'),P(" }\n"),
+          P("            ."),F("where"),P("(User_.city.country "),K("eq "),P("country)\n"),
+          P("            ."),F("groupBy"),P("(User_.city)\n"),
+          P("            ."),F("orderByDescending"),P(" { "),S('"COUNT(*)"'),P(" }\n"),
+          P("            ."),F("limit"),P("(limit)\n"),
+          P("            .resultList\n"),
+          P("}") ] },
+
+      { name:'4 · insert', file:'Seed.kt',
+        caption:"explicit writes — one transaction",
+        code:[ C("// Writes are explicit. One transaction.\n"),
+          F("transaction"),P(" {\n"),
+          P("    "),K("val "),P("city = orm "),K("insert "),T("City"),P("(name = "),S('"Sunnyvale"'),P(", population = "),N("161_884"),P(", country = "),S('"US"'),P(")\n"),
+          P("    orm "),K("insert "),T("User"),P("(email = "),S('"bob@acme.io"'),P(", name = "),S('"Bob"'),P(", city = city)\n"),
+          P("}") ] },
+
+      { name:'5 · sql', file:'UserService.kt',
+        caption:"full SQL when you want it — never locked in",
+        code:[ C("// Need full control of SQL? Use the powerful template engine behind the ORM.\n// You can also use plain SQL here.\n"),
+          K("val "),P("users = orm."),F("query"),P(" { "),S('"""'),P("\n"),
+          P("    "),K("SELECT "),T("${User::class}"),P("\n"),
+          P("    "),K("FROM "),T("${User::class}"),P("\n"),
+          P("    "),K("WHERE "),T("${User_.city.name}"),P(" = "),T("$city"),P("\n"),
+          S('"""'),P(" }."),F("resultList"),P("<"),T("User"),P(">()"),P("   "),C("// $city → bind variable, never concatenated") ] },
+    ];
+
+    // Generated SQL per scene (index-aligned with SCENES). Shown via the "Show SQL" toggle.
+    const SQL=[
+      null, // entities — no query, so the Show SQL button is hidden for this scene
+
+      '<span class="sqlc">-- getById(1) — joins the city graph, no N+1</span>\n'+
+      '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
+      '<span class="sqlk">FROM</span> "user" u\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">WHERE</span> u.id = <span class="sqlq">?</span>\n\n'+
+      '<span class="sqlc">-- findAll(User_.city.name eq "Sunnyvale")</span>\n'+
+      '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
+      '<span class="sqlk">FROM</span> "user" u\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">WHERE</span> c.name = <span class="sqlq">?</span>',
+
+      '<span class="sqlc">-- findByCity(city)</span>\n'+
+      '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
+      '<span class="sqlk">FROM</span> "user" u\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">WHERE</span> u.city_id = <span class="sqlq">?</span>\n\n'+
+      '<span class="sqlc">-- topCities(country, limit)</span>\n'+
+      '<span class="sqlk">SELECT</span> c.id, c.name, c.population, c.country, <span class="sqlk">COUNT</span>(*)\n'+
+      '<span class="sqlk">FROM</span> "user" u\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">WHERE</span> c.country = <span class="sqlq">?</span>\n'+
+      '<span class="sqlk">GROUP BY</span> c.id, c.name, c.population, c.country\n'+
+      '<span class="sqlk">ORDER BY</span> <span class="sqlk">COUNT</span>(*) <span class="sqlk">DESC</span>\n'+
+      '<span class="sqlk">LIMIT</span> <span class="sqlq">?</span>',
+
+      '<span class="sqlc">-- two inserts, one transaction</span>\n'+
+      '<span class="sqlk">INSERT INTO</span> city (name, population, country) <span class="sqlk">VALUES</span> (<span class="sqlq">?</span>, <span class="sqlq">?</span>, <span class="sqlq">?</span>)\n'+
+      '<span class="sqlk">INSERT INTO</span> "user" (email, name, city_id) <span class="sqlk">VALUES</span> (<span class="sqlq">?</span>, <span class="sqlq">?</span>, <span class="sqlq">?</span>)',
+
+      '<span class="sqlc">-- ${User::class} expands to columns · $city becomes ?</span>\n'+
+      '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
+      '<span class="sqlk">FROM</span> "user" u\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">WHERE</span> c.name = <span class="sqlq">?</span>',
+    ];
+
+    const esc=s=>s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    const codeEl=document.getElementById('code'), gutEl=document.getElementById('gutter'),
+          fnameEl=document.getElementById('fname'), scenesEl=document.getElementById('scenes'),
+          statusEl=document.getElementById('status'), statusTextEl=document.getElementById('statustext');
+    if(!codeEl) return;
+
+    // "Show SQL" toggle — reveals the generated SQL for the current scene.
+    const editorEl=document.querySelector('.storm-home .editor'), sqlBtn=document.getElementById('sqlbtn'),
+          sqlBtnText=document.getElementById('sqlbtntext'), sqlPanel=document.getElementById('sqlpanel');
+    let showSql=false, curIdx=0;
+    function renderSql(){ sqlPanel.innerHTML=SQL[curIdx]||'<span class="sqlc">-- no query</span>'; }
+    function onSqlClick(){
+      showSql=!showSql;
+      editorEl.classList.toggle('show-sql',showSql);
+      sqlBtn.classList.toggle('on',showSql);
+      sqlBtnText.textContent=showSql?'Hide SQL':'Show SQL';
+      if(showSql) renderSql();
+    }
+    sqlBtn.addEventListener('click',onSqlClick);
+
+    SCENES.forEach((s,i)=>{const d=document.createElement('span');d.className='s';d.textContent=s.name;
+      d.addEventListener('click',()=>runFrom(i,true));scenesEl.appendChild(d);});
+    const tabs=[...scenesEl.children];
+
+    const fullText=(t)=>t.map(x=>x.x).join('');
+    function render(tokens,n,cursor){
+      let out='',count=0,done=false;
+      for(const tk of tokens){
+        if(done)break;
+        const len=tk.x.length;
+        if(count+len<=n){out+='<span class="'+tk.c+'">'+esc(tk.x)+'</span>';count+=len;}
+        else{const rem=n-count;if(rem>0)out+='<span class="'+tk.c+'">'+esc(tk.x.slice(0,rem))+'</span>';done=true;}
+      }
+      if(cursor)out+='<span class="cursor"></span>';
+      return out;
+    }
+    function setGutter(text){const lines=text.split('\n').length;let g='';for(let i=1;i<=lines;i++)g+='<div>'+i+'</div>';gutEl.innerHTML=g;}
+
+    const reduce=window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    let timer=null, gen=0;
+    const wait=(ms)=>new Promise(res=>{const g=gen;timer=setTimeout(()=>{if(g===gen)res();},ms);});
+
+    // Length-independent fast write (~500ms) driven by rAF, so a tab click
+    // fills the snippet in a fixed time regardless of how long it is.
+    function typeFast(tokens,text,duration){
+      return new Promise(resolve=>{
+        const g=gen, start=performance.now();
+        (function frame(now){
+          if(g!==gen){resolve();return;}
+          const t=Math.min(1,(now-start)/duration);
+          codeEl.innerHTML=render(tokens,Math.round(t*text.length),true);
+          if(t<1) requestAnimationFrame(frame); else resolve();
+        })(performance.now());
+      });
+    }
+
+    async function play(idx,fast){
+      const myGen=gen;
+      const sc=SCENES[idx];
+      curIdx=idx;
+      const hasSql=!!SQL[idx];
+      sqlBtn.style.display=hasSql?'':'none';
+      sqlBtn.classList.toggle('on',showSql);
+      sqlBtnText.textContent=showSql?'Hide SQL':'Show SQL';
+      editorEl.classList.toggle('show-sql',hasSql&&showSql);
+      if(hasSql&&showSql) renderSql();
+      tabs.forEach((t,i)=>t.classList.toggle('on',i===idx));
+      fnameEl.textContent=sc.file;
+      statusEl.classList.remove('show');
+      const text=fullText(sc.code);
+      setGutter(text);
+
+      if(reduce){
+        codeEl.innerHTML=render(sc.code,text.length,false);
+        statusTextEl.textContent=sc.caption;statusEl.classList.add('show');
+        return;
+      }
+
+      if(fast){
+        await typeFast(sc.code,text,500);
+      } else {
+        for(let n=0;n<=text.length;n++){
+          codeEl.innerHTML=render(sc.code,n,true);
+          const ch=text[n-1];
+          let d=12+Math.random()*22;
+          if(ch==='\n')d=120; else if(ch===' ')d=8; else if('(){}.,'.includes(ch))d=46;
+          await wait(d);
+        }
+      }
+      if(myGen!==gen) return;
+      codeEl.innerHTML=render(sc.code,text.length,false);
+      await wait(fast?160:360);
+      if(myGen!==gen) return;
+      statusTextEl.textContent=sc.caption;statusEl.classList.add('show');
+      await wait(fast?30000:3500); // 30s dwell on a clicked scene, else normal auto-advance
+    }
+
+    async function runFrom(start,fast){
+      const g=++gen; clearTimeout(timer);
+      let i=start, first=true;
+      while(g===gen){ await play(i, fast&&first); if(g!==gen) return; first=false; i=(i+1)%SCENES.length; }
+    }
+    runFrom(0);
+
+    // Stop the loop and undo DOM mutations when the page unmounts.
+    return () => {
+      gen++;
+      clearTimeout(timer);
+      if(scenesEl) scenesEl.innerHTML='';
+      if(sqlBtn) sqlBtn.removeEventListener('click',onSqlClick);
+    };
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <html lang="en" />
+        <title>Storm — Radically Simple, Predictable Persistence</title>
+        <meta
+          name="description"
+          content="Storm is a modern, type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Predictable persistence with no magic, no N+1, and full SQL control."
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <style dangerouslySetInnerHTML={{__html: CSS}} />
+      <div className="storm-home" dangerouslySetInnerHTML={{__html: BODY}} />
+    </>
+  );
+}

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://orm.st/sitemap.xml


### PR DESCRIPTION
## Summary

Puts a custom landing page **in front of** the Docusaurus docs at https://orm.st.

- **Front page** — new landing at `/` (`website/src/pages/index.js`): animated live-coding hero, the *"Optimized for all major SQL databases"* band, and the feature cards. It has its own nav/footer (no Docusaurus theme chrome).
- **Docs relocated to `/docs`** — `routeBasePath` is now `/docs`, so the landing owns the site root. The version dropdown, sidebar, and footer links all resolve under `/docs`.
- **Redirects** — added `@docusaurus/plugin-client-redirects`; every old root doc URL (`/getting-started`, `/entities`, …) now redirects to its `/docs/...` home, preserving existing links and SEO.
- **Version display fix** — `read-storm-version.js` falls back to the latest released version (from `versions.json`) when the pom `<revision>` is a snapshot, so the published site never shows `0.0.0-SNAPSHOT`.
- **`robots.txt`** — added.

Verified locally with `npm run build`: front page renders at `/`, docs build under `/docs/`, and old root URLs emit redirects.

> The design source mockups (`landing-drafts/`) were intentionally left out of this PR as scratch files.
