### PR TITLE
docs(website): clarify the transactions Show-SQL panel comment

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -339,7 +339,7 @@ export default function Home() {
       '<span class="sqlk">ORDER BY</span> <span class="sqlk">COUNT</span>(*) <span class="sqlk">DESC</span>\n'+
       '<span class="sqlk">LIMIT</span> <span class="sqlq">?</span>',
 
-      '<span class="sqlc">-- same two inserts either way; the options wrap them in one tx</span>\n'+
+      '<span class="sqlc">-- the second block wraps these two inserts in one configured transaction:</span>\n'+
       '<span class="sqlc">-- transaction(REQUIRES_NEW, REPEATABLE_READ, timeoutSeconds = 5)</span>\n'+
       '<span class="sqlk">SET TRANSACTION ISOLATION LEVEL REPEATABLE READ</span>\n'+
       '<span class="sqlk">BEGIN</span>\n'+


### PR DESCRIPTION
## Summary

Follow-up to #153. The transactions scene's **Show SQL** panel opened with a cryptic note:

> `-- same two inserts either way; the options wrap them in one tx`

Both editor code blocks run the same two inserts, so the panel shows them once — but that meta-comment read as confusing. This replaces it with a clearer line:

> `-- the second block wraps these two inserts in one configured transaction:`

The rest of the panel (the `transaction(REQUIRES_NEW, REPEATABLE_READ, timeoutSeconds = 5)` signature, `SET TRANSACTION ISOLATION LEVEL … / BEGIN … / COMMIT`, and the `onCommit` note) is unchanged.

Landing page copy only.