### PR TITLE
docs: landing-page SEO, current-only sitemap, de-emphasize AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,6 @@
 - **Performance**: Template caching, transaction-scoped entity caching, and zero-overhead dirty checking (thanks to immutability) ensure efficient database interactions. Batch processing, lazy streams, and upserts are built in.
 - **Universal Database Compatibility**: Fully compatible with all SQL databases, it offers flexibility and broad applicability across various database systems.
 
-Storm also includes an AI-assisted workflow for database development. It gives AI tools full schema awareness through a local MCP server, guides them with Storm-specific skills, and closes the loop with automated tests. The AI generates code, but the final checks are done by running code against the schema and captured SQL, not by trusting LLM reasoning.
-
-To set up the AI workflow in your project:
-
-```bash
-npm install -g @storm-orm/cli
-storm init
-```
-
-This installs Storm's rules, skills, and optional local MCP setup for supported AI coding tools. See [AI-Assisted Development](docs/ai.md) for the full workflow.
-
 ## Why Storm?
 
 Storm draws inspiration from established ORMs such as Hibernate, but is built from scratch around a clear design philosophy: capturing exactly what you want to do using the minimum amount of code, optimized for Kotlin and modern Java.
@@ -52,25 +41,6 @@ Storm embraces SQL rather than abstracting it away. It simplifies database inter
 | SQL hidden behind abstraction layers | SQL-first design—stay close to the database |
 
 **Storm is ideal for** developers who understand that the best solutions emerge when object model and database model work in harmony. If you value a database-first approach where records naturally mirror your schema, Storm is built for you. Custom mappings are supported when needed, but the real elegance comes from alignment, not abstraction.
-
-## AI Workflow
-
-AI tools can write a lot of database code quickly, but subtle mistakes are still common: wrong joins, missing constraints, stale schema assumptions, or queries that compile but do the wrong thing.
-
-Storm addresses that in two ways.
-
-First, it improves generation quality. A local MCP server gives the AI full schema awareness without exposing credentials or data, and Storm skills teach the AI how to create entities, queries, repositories, and migrations that follow Storm's conventions.
-
-Second, it verifies the result with automated tests. Storm can validate that generated entities still match the schema and that generated queries behave as intended. These checks run in unit tests, so the final gate is actual code execution rather than model self-evaluation.
-
-The workflow is simple:
-
-1. You prompt the AI.
-2. The AI uses Storm skills and local schema context to generate code.
-3. Storm verifies the generated entities and queries in tests.
-4. You review the result and keep moving with more confidence.
-
-This is the core idea: AI generates database code, and Storm closes the loop with context and verification.
 
 ## Choose Your Language
 
@@ -214,6 +184,17 @@ dependencies {
     <scope>runtime</scope>
 </dependency>
 ```
+
+## AI-Assisted Development
+
+Storm's stateless, immutable model is a natural fit for AI coding tools: what you see in the source is exactly what runs — no proxies, lazy loading, or hidden persistence-context rules to trip up generated code. An optional workflow gives AI tools full schema awareness through a local MCP server, guides them with Storm-specific skills, and closes the loop by verifying generated entities and queries with real tests rather than trusting model reasoning.
+
+```bash
+npm install -g @storm-orm/cli
+storm init
+```
+
+See [AI-Assisted Development](docs/ai.md) for the full workflow.
 
 ## Documentation
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -96,6 +96,23 @@ const config: Config = {
             [remarkStormVersion, { version: stormVersion }],
           ],
         },
+        sitemap: {
+          // Only advertise the current (latest) docs version to crawlers.
+          // Old numbered versions and the unreleased `/docs/next` dev docs are
+          // near-duplicate content that splits ranking signal across ~10 copies
+          // of each page. They stay reachable via the version dropdown; we just
+          // keep them out of the sitemap so Google consolidates on the canonical
+          // (unversioned) `/docs/*` pages.
+          createSitemapItems: async (params) => {
+            const {defaultCreateSitemapItems, ...rest} = params;
+            const items = await defaultCreateSitemapItems(rest);
+            return items.filter(
+              (item) =>
+                !item.url.includes('/docs/next') &&
+                !/\/docs\/\d+\.\d+\.\d+(\/|$)/.test(item.url),
+            );
+          },
+        },
         blog: false,
         theme: {
           customCss: './src/css/custom.css',

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -205,7 +205,7 @@ const BODY = `
 </div>
 
 <section class="endcta" style="padding-top:30px"><div class="wrap">
-  <h2>Enjoy writing code that is worth reading.</h2>
+  <h2>Write code worth reading.</h2>
   <p class="sub" style="margin:0 auto 30px;text-align:center;max-width:940px">Concise entities and one-line queries keep you productive. Immutable records simplify your architecture by letting the same types flow through your application layers. Storm is built for engineers who care about beautiful code.</p>
   <div class="cta" style="justify-content:center">
     <a href="/docs/getting-started" class="btn primary">Get started →</a>
@@ -496,11 +496,65 @@ export default function Home() {
     <>
       <Head>
         <html lang="en" />
-        <title>Storm — Radically Simple, Predictable Persistence</title>
+        <title>Storm — Type-safe ORM for Kotlin & Java 21+</title>
         <meta
           name="description"
-          content="Storm is a modern, type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Predictable persistence with no magic, no N+1, and full SQL control."
+          content="Type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Concise entities, one-line queries, immutable records — every query explicit, no proxies, no N+1."
         />
+        {/* Open Graph / Twitter: default og:title is just the site name
+            ("Storm Framework") and og:description is absent, so set the
+            keyword-rich title + description used when the page is shared. */}
+        <meta property="og:type" content="website" />
+        <meta
+          property="og:title"
+          content={'Storm — Type-safe ORM for Kotlin & Java 21+'}
+        />
+        <meta
+          property="og:description"
+          content="Type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Concise entities, one-line queries, immutable records — every query explicit, no proxies, no N+1."
+        />
+        <meta
+          name="twitter:title"
+          content={'Storm — Type-safe ORM for Kotlin & Java 21+'}
+        />
+        <meta
+          name="twitter:description"
+          content="Type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Concise entities, one-line queries, immutable records — every query explicit, no proxies, no N+1."
+        />
+        {/* Structured data so search engines can identify Storm as a
+            developer tool for Kotlin/Java and consolidate it with its GitHub
+            and Maven Central listings (helps knowledge-graph + rich results). */}
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'SoftwareApplication',
+            name: 'Storm',
+            alternateName: 'Storm ORM',
+            applicationCategory: 'DeveloperApplication',
+            operatingSystem: 'JVM (Kotlin, Java)',
+            description:
+              'Storm is a type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Define concise, immutable entities and write one-line queries — nested predicates and entity graphs compile to a single efficient query, eliminating hidden queries and N+1. Drop to full SQL templates whenever you want; never locked in.',
+            featureList: [
+              'Direct database control — every query explicit, no hidden N+1',
+              'Stateless, immutable records — no proxies, no flush, no hidden state',
+              'Type-safe and injection-safe — compile-time column and type checks, automatic bind parameters',
+              'One-line queries with an optional full SQL template engine',
+              'Works with PostgreSQL, MySQL, MariaDB, Oracle, SQL Server, SQLite and H2',
+              'Integrates with Spring Boot 3.x/4.x and Ktor',
+            ],
+            url: 'https://orm.st',
+            sameAs: [
+              'https://github.com/storm-orm/storm-framework',
+              'https://central.sonatype.com/namespace/st.orm',
+            ],
+            offers: {'@type': 'Offer', price: '0', priceCurrency: 'USD'},
+            author: {
+              '@type': 'Organization',
+              name: 'Storm',
+              url: 'https://github.com/storm-orm',
+            },
+          })}
+        </script>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link


### PR DESCRIPTION
Improves discoverability for "kotlin"/"orm"/"java" search terms and realigns the README with the landing page.

## Website (`website/`)

**Sitemap → current version only.** The default Docusaurus sitemap listed every doc version + `/docs/next` — ~10 near-duplicate copies of each page (457 URLs), splitting ranking signal. Added a version-agnostic `createSitemapItems` filter that keeps only the current unversioned `/docs/*` pages. Result: **457 → 49 URLs**, 0 `/next`, 0 numbered versions. Old versions stay reachable via the dropdown; they're just no longer advertised to crawlers. The filter matches patterns (not version numbers), so it keeps working automatically on every release.

**Landing-page SEO.**
- Keyword-rich `<title>`: *Storm — Type-safe ORM for Kotlin & Java 21+* (was pure branding).
- Added Open Graph / Twitter `title` + `description` (default `og:title` was just "Storm Framework"; `og:description` was absent).
- Added `SoftwareApplication` JSON-LD with `featureList` and `sameAs` links to GitHub + Maven Central, so search engines can identify Storm as a Kotlin/Java dev tool and consolidate its listings.
- SEO copy is sourced from the actual landing-page copy (concise entities, one-line queries, immutable records, no N+1, full SQL when you want it) rather than the README/tagline boilerplate.

## README

De-emphasizes AI to match the landing page's value-first framing: removed the AI paragraph + `storm init` block from the intro and the ~18-line "AI Workflow" section, replaced by one concise "AI-Assisted Development" section after Quick Start. Section order now mirrors the site: Why Storm? → Choose Your Language → Quick Start → AI-Assisted Development → Documentation.

## Verification

`npm run build` passes; verified in `build/`: title, OG/Twitter tags, valid JSON-LD (+featureList), and sitemap = 49 URLs / 0 next / 0 numbered.

Note: GitHub repo topics (`java-orm`, `hibernate-alternative`, `sql-first`) were also added directly to the repo (not part of this diff).