### PR TITLE
ci: fix Java Javadoc aggregate so /api/java deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,11 +42,18 @@ jobs:
 
       - name: Generate Javadoc (aggregate)
         run: |
+          # The aggregate covers the Java API only. Kotlin modules (Ktor and the
+          # compiler-plugin variants) have no module descriptor; mixing these
+          # "unnamed" modules with the named Java modules makes javadoc:aggregate
+          # fail ("named and unnamed modules"), which — with failOnError=false —
+          # silently produced no output and left /api/java 404. Exclude them here
+          # (Kotlin APIs are documented separately via KDoc under /api/kotlin).
+          # NOTE: add any future storm-compiler-plugin-<kotlin> variant below.
           mvn javadoc:aggregate -q \
             -Dmaven.javadoc.failOnError=false \
             -DadditionalJOption=--enable-preview \
             -Ddoclint=none \
-            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-jackson3'
+            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-jackson3,!:storm-ktor,!:storm-ktor-test,!:storm-compiler-plugin-2.0,!:storm-compiler-plugin-2.1,!:storm-compiler-plugin-2.2,!:storm-compiler-plugin-2.3,!:storm-compiler-plugin-2.4'
 
       - name: Copy Javadoc to website/static/api/java
         run: |
@@ -54,8 +61,11 @@ jobs:
           # The aggregate report goal writes under the reporting output dir:
           # target/site/apidocs on Maven 3.x, target/reports/apidocs on Maven 4.x.
           copied=""
+          # Require index.html specifically: a failed aggregate can still leave
+          # an empty apidocs dir, and a plain -d check would treat that as success
+          # and deploy an empty /api/java.
           for src in target/site/apidocs target/reports/apidocs; do
-            if [ -d "$src" ]; then
+            if [ -f "$src/index.html" ]; then
               cp -r "$src"/* website/static/api/java/
               copied="$src"
               break


### PR DESCRIPTION
## Problem
`https://orm.st/api/java/index.html` (and the whole `/api/java/` tree) 404s — the Javadoc is never published, while `/api/kotlin/*` works.

## Root cause
The "Generate Javadoc (aggregate)" step in `docs.yml` fails:

```
[ERROR] Creating an aggregated report for both named and unnamed modules is not possible.
[ERROR] Fix the following projects:
 - storm-compiler-plugin-2.0 … 2.4, storm-ktor, storm-ktor-test
```

The aggregate pulls in Kotlin modules (Ktor + the compiler-plugin variants) that have **no module descriptor**. `javadoc:aggregate` can't mix these *unnamed* modules with the *named* Java modules. Because `-Dmaven.javadoc.failOnError=false` is set, the step still reports **success** while producing **no output**, so the copy step deploys an empty `/api/java`. (Confirmed: `gh-pages` has no `api/java` directory.)

## Fix
1. **Exclude the non-Java modules** from the aggregate `-pl` list: `storm-ktor`, `storm-ktor-test`, and `storm-compiler-plugin-2.0…2.4`. Every remaining source module has a `module-info.java` (all *named*), so aggregation succeeds. These Kotlin APIs are already published as KDoc under `/api/kotlin`.
2. **Harden the copy guard** to require `index.html` (not just the directory), so a future empty/failed aggregate fails the build loudly instead of silently shipping an empty `/api/java`.

## Verification
Verified every remaining module is named (`find -name module-info.java`). Running a local `mvn install` + `javadoc:aggregate` with the new exclusions to confirm `index.html` is produced. Once merged, the push to `main` triggers the docs deploy; with the hardened guard, if anything is still off it will fail rather than silently 404.