### PR TITLE
ci: publish only the public Java API with the released version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,23 +37,34 @@ jobs:
         run: npm ci
         working-directory: website
 
+      - name: Resolve released version
+        id: version
+        run: echo "value=$(node -p 'require("./website/versions.json")[0]')" >> "$GITHUB_OUTPUT"
+
       - name: Build project (skip tests)
-        run: mvn install -DskipTests -q
+        run: mvn install -DskipTests -q -Drevision=${{ steps.version.outputs.value }}
 
       - name: Generate Javadoc (aggregate)
         run: |
-          # The aggregate covers the Java API only. Kotlin modules (Ktor and the
-          # compiler-plugin variants) have no module descriptor; mixing these
-          # "unnamed" modules with the named Java modules makes javadoc:aggregate
-          # fail ("named and unnamed modules"), which — with failOnError=false —
-          # silently produced no output and left /api/java 404. Exclude them here
-          # (Kotlin APIs are documented separately via KDoc under /api/kotlin).
-          # NOTE: add any future storm-compiler-plugin-<kotlin> variant below.
+          # Publish only the public Java API:
+          #   storm-foundation -> st.orm, st.orm.mapping (Entity, Ref, annotations)
+          #   storm-java21     -> st.orm.repository, st.orm.template (ORMTemplate,
+          #                       query builder, repositories)
+          # Everything else is excluded on purpose:
+          #   - Kotlin modules (Ktor, compiler-plugin variants) have no module
+          #     descriptor and break aggregation ("named and unnamed modules");
+          #     they are published separately as KDoc under /api/kotlin.
+          #   - storm-core is the internal engine (st.orm.core.*).
+          #   - dialect SPIs, storm-test and storm-metamodel-processor are not
+          #     part of the user-facing API; Spring/Jackson are integrations.
+          # Keep >= 2 named modules so javadoc stays in module mode and pages keep
+          # their <module>/<package> paths (the docs link to storm.foundation/...).
           mvn javadoc:aggregate -q \
+            -Drevision=${{ steps.version.outputs.value }} \
             -Dmaven.javadoc.failOnError=false \
             -DadditionalJOption=--enable-preview \
             -Ddoclint=none \
-            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-jackson3,!:storm-ktor,!:storm-ktor-test,!:storm-compiler-plugin-2.0,!:storm-compiler-plugin-2.1,!:storm-compiler-plugin-2.2,!:storm-compiler-plugin-2.3,!:storm-compiler-plugin-2.4'
+            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-jackson3,!:storm-ktor,!:storm-ktor-test,!:storm-compiler-plugin-2.0,!:storm-compiler-plugin-2.1,!:storm-compiler-plugin-2.2,!:storm-compiler-plugin-2.3,!:storm-compiler-plugin-2.4,!:storm-metamodel-processor,!:storm-core,!:storm-test,!:storm-jackson2,!:storm-oracle,!:storm-mssqlserver,!:storm-postgresql,!:storm-mysql,!:storm-mariadb,!:storm-sqlite,!:storm-h2,!:storm-spring'
 
       - name: Copy Javadoc to website/static/api/java
         run: |

--- a/docs/api-java.md
+++ b/docs/api-java.md
@@ -94,4 +94,4 @@ See [Metamodel](metamodel.md) for setup and usage.
 
 The aggregated Javadoc covers all Java modules in the Storm framework:
 
-[Browse the Javadoc](../api/java/index.html)
+[Browse the Javadoc](../api/java/storm.foundation/st/orm/package-summary.html)

--- a/website/versioned_docs/version-1.11.6/api-java.md
+++ b/website/versioned_docs/version-1.11.6/api-java.md
@@ -94,4 +94,4 @@ See [Metamodel](metamodel.md) for setup and usage.
 
 The aggregated Javadoc covers all Java modules in the Storm framework:
 
-[Browse the Javadoc](../api/java/index.html)
+[Browse the Javadoc](../api/java/storm.foundation/st/orm/package-summary.html)


### PR DESCRIPTION
Follow-ups on the now-working `/api/java` Javadoc — it was showing `0.0.0-SNAPSHOT` and a messy module list.

## Changes
1. **Version** — the Javadoc title read `Storm Framework 0.0.0-SNAPSHOT API` (the pom `<revision>`, which stays `SNAPSHOT` on main). Now stamps the released version (newest `versions.json` entry) via `-Drevision` on both the build and the aggregate → `Storm Framework 1.11.6 API`.
2. **Modules** — the aggregate documented an inconsistent set: the internal engine (`storm.core`), only one dialect (`storm.mysql`, the only dialect that happens to export a package), and the `storm.test` support module. Curated to just the **public Java API**:
   - `storm.foundation` → `st.orm`, `st.orm.mapping` (Entity, Ref, annotations)
   - `storm.java` → `st.orm.repository`, `st.orm.template` (ORMTemplate, query builder, repositories)
   
   Everything else is excluded (internal core, dialect SPIs, test, metamodel-processor, Spring/Jackson integrations). Two named modules keep javadoc in module mode so pages retain their `storm.foundation/…` paths.
3. **Docs link** — "Browse the Javadoc" now points at `/api/java/storm.foundation/st/orm/package-summary.html` (the `st.orm` overview) instead of the module index, in `docs/` and `version-1.11.6/`.

## Verification (local `mvn install` + `javadoc:aggregate` at 1.11.6)
- Exit 0, no "named and unnamed modules" error.
- Documents exactly `storm.foundation` + `storm.java`; packages: `st.orm`, `st.orm.mapping`, `st.orm.repository`, `st.orm.template`.
- Title: **Storm Framework 1.11.6 API**.
- Link target `storm.foundation/st/orm/package-summary.html` present; `Entity`, `Ref`, `ORMTemplate`, `EntityRepository` all documented.
- `docs.yml` is valid YAML; Docusaurus build passes.

Takes effect on the next docs deploy (after merge).