### PR TITLE
chore: FK-first join order, skills guidance polish, Spring Boot 4 auto-config compat

### DIFF
--- a/docs/polymorphism.md
+++ b/docs/polymorphism.md
@@ -796,8 +796,8 @@ With `@Discriminator`, the discriminator column is read directly from the base t
 ```sql
 SELECT p.id, p.dtype, p.name, c.indoor, d.weight
 FROM pet p
-LEFT JOIN cat c ON p.id = c.id
-LEFT JOIN dog d ON p.id = d.id
+LEFT JOIN cat c ON c.id = p.id
+LEFT JOIN dog d ON d.id = p.id
 ```
 
 Without `@Discriminator`, Storm generates a `CASE` expression that resolves the concrete type by checking which extension table has a matching row:
@@ -809,9 +809,9 @@ SELECT p.id,
             WHEN b.id IS NOT NULL THEN 'Bird' END,
        p.name, c.indoor, d.weight
 FROM pet p
-LEFT JOIN cat c ON p.id = c.id
-LEFT JOIN dog d ON p.id = d.id
-LEFT JOIN bird b ON p.id = b.id
+LEFT JOIN cat c ON c.id = p.id
+LEFT JOIN dog d ON d.id = p.id
+LEFT JOIN bird b ON b.id = p.id
 ```
 
 Unlike Single-Table, DML operations for Joined Table entities are multi-statement: they involve more than one table. Storm executes all statements within the current transaction to ensure atomicity. Each operation follows a specific order to respect foreign key constraints between the base and extension tables.
@@ -891,8 +891,8 @@ When querying Visit with a join to Pet, Storm generates:
 SELECT v.*, p.id, p.dtype, p.name, c.indoor, d.weight
 FROM visit v
 INNER JOIN pet p ON v.pet_id = p.id
-LEFT JOIN cat c ON p.id = c.id
-LEFT JOIN dog d ON p.id = d.id
+LEFT JOIN cat c ON c.id = p.id
+LEFT JOIN dog d ON d.id = p.id
 ```
 
 ### Hydration

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -138,7 +138,7 @@ Use `@ProjectionQuery` to define a projection backed by custom SQL:
     SELECT b.id, COUNT(*) AS item_count, SUM(i.price) AS total_price
     FROM basket b
     JOIN basket_item bi ON bi.basket_id = b.id
-    JOIN item i ON i.id = bi.item_id
+    JOIN item i ON bi.item_id = i.id
     GROUP BY b.id
 """)
 data class BasketSummary(
@@ -156,7 +156,7 @@ data class BasketSummary(
     SELECT b.id, COUNT(*) AS item_count, SUM(i.price) AS total_price
     FROM basket b
     JOIN basket_item bi ON bi.basket_id = b.id
-    JOIN item i ON i.id = bi.item_id
+    JOIN item i ON bi.item_id = i.id
     GROUP BY b.id
     """)
 record BasketSummary(

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplatePreparation.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplatePreparation.java
@@ -791,8 +791,8 @@ class TemplatePreparation {
      * JoinedTruck subtypes, this produces:</p>
      *
      * <pre>
-     * LEFT JOIN joined_car jc ON jv.id = jc.id
-     * LEFT JOIN joined_truck jt ON jv.id = jt.id
+     * LEFT JOIN joined_car jc ON jc.id = jv.id
+     * LEFT JOIN joined_truck jt ON jt.id = jv.id
      * </pre>
      *
      * @param sealedType  the sealed entity interface (the base/FROM table).
@@ -822,7 +822,8 @@ class TemplatePreparation {
         for (Class<?> subtype : permitted) {
             Class<? extends Data> extensionType = (Class<? extends Data>) subtype;
             String extensionAlias = aliasMapper.generateAlias(extensionType, null, template.dialect());
-            // Build ON clause: baseAlias.pk = extensionAlias.pk (supports compound PKs).
+            // Build ON clause: extensionAlias.pk = baseAlias.pk (supports compound PKs). The extension table's PK
+            // doubles as the FK to the base table, so the FK side goes first, consistent with JoinProcessor.
             StringBuilder onClause = new StringBuilder();
             for (int i = 0; i < pkColumnNames.size(); i++) {
                 if (i > 0) {
@@ -830,7 +831,7 @@ class TemplatePreparation {
                 }
                 String pkCol = pkColumnNames.get(i).qualified(template.dialect());
                 onClause.append(dialectTemplate.process("\0.\0 = \0.\0",
-                        baseAlias, pkCol, extensionAlias, pkCol));
+                        extensionAlias, pkCol, baseAlias, pkCol));
             }
             joins.add(new Join(
                     new TableSource(extensionType),

--- a/storm-kotlin-spring-boot-starter/src/main/kotlin/st/orm/spring/boot/autoconfigure/StormTransactionAutoConfiguration.kt
+++ b/storm-kotlin-spring-boot-starter/src/main/kotlin/st/orm/spring/boot/autoconfigure/StormTransactionAutoConfiguration.kt
@@ -17,7 +17,6 @@ package st.orm.spring.boot.autoconfigure
 
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
 import org.springframework.context.annotation.Import
 import org.springframework.transaction.PlatformTransactionManager
 import st.orm.spring.SpringTransactionConfiguration
@@ -26,8 +25,20 @@ import st.orm.spring.SpringTransactionConfiguration
  * Auto-configuration that activates [SpringTransactionConfiguration] when a [PlatformTransactionManager] is available.
  *
  * This replaces the need for `@EnableTransactionIntegration` in Spring Boot applications.
+ *
+ * The ordering hints reference DataSourceTransactionManagerAutoConfiguration by name rather than by
+ * class literal: the class moved to the modular spring-boot-jdbc jar in Spring Boot 4, and a class
+ * literal to whichever location is absent would fail annotation introspection. Name-based hints are
+ * ignored when the class is not on the classpath, so both locations can be listed safely.
  */
-@AutoConfiguration(after = [DataSourceTransactionManagerAutoConfiguration::class])
+@AutoConfiguration(
+    afterName = [
+        // Spring Boot 3.x location.
+        "org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration",
+        // Spring Boot 4.x location.
+        "org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration",
+    ],
+)
 @ConditionalOnBean(PlatformTransactionManager::class)
 @Import(SpringTransactionConfiguration::class)
 open class StormTransactionAutoConfiguration

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -341,23 +341,23 @@ export default function Home() {
       '<span class="sqlc">-- getById(1) — joins the city graph, no N+1</span>\n'+
       '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
       '<span class="sqlk">FROM</span> "user" u\n'+
-      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
       '<span class="sqlk">WHERE</span> u.id = <span class="sqlq">?</span>\n\n'+
       '<span class="sqlc">-- findAll(User_.city.name eq "Sunnyvale")</span>\n'+
       '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
       '<span class="sqlk">FROM</span> "user" u\n'+
-      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
       '<span class="sqlk">WHERE</span> c.name = <span class="sqlq">?</span>',
 
       '<span class="sqlc">-- findByCity(city)</span>\n'+
       '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
       '<span class="sqlk">FROM</span> "user" u\n'+
-      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
       '<span class="sqlk">WHERE</span> u.city_id = <span class="sqlq">?</span>\n\n'+
       '<span class="sqlc">-- usersPerCity(country)</span>\n'+
       '<span class="sqlk">SELECT</span> c.id, c.name, c.population, c.country, <span class="sqlk">COUNT</span>(*)\n'+
       '<span class="sqlk">FROM</span> "user" u\n'+
-      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
       '<span class="sqlk">WHERE</span> c.country = <span class="sqlq">?</span>\n'+
       '<span class="sqlk">GROUP BY</span> u.city_id',
 
@@ -377,7 +377,7 @@ export default function Home() {
       '<span class="sqlc">-- ${User::class} expands to columns · $city becomes ?</span>\n'+
       '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
       '<span class="sqlk">FROM</span> "user" u\n'+
-      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> c.id = u.city_id\n'+
+      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
       '<span class="sqlk">WHERE</span> c.name = <span class="sqlq">?</span>',
     ];
 

--- a/website/static/skills/storm-demo.md
+++ b/website/static/skills/storm-demo.md
@@ -54,6 +54,16 @@ stormRepositories {
 routing { ... }
 ```
 
+**Transactions (Kotlin):** Whenever Kotlin is used, the demo uses Storm's programmatic transactions — never `@Transactional`. Services are `suspend` and open suspend `transaction { }` blocks, with `suspend` propagated as close to the start of the call stack as possible. Spring MVC controllers stay non-suspend and bridge with `runBlocking { }` at the handler — the entry point; with virtual threads enabled the blocking bridge is cheap. Transactions belong at the service level (the business operation) — never in controllers; controllers that only read directly from repositories do not open transactions. A service that assembles a multi-query view can use `transaction(readOnly = true) { }`, like the home page service. Storm's Spring transaction integration is incompatible with suspend mode and must be excluded:
+```yaml
+spring:
+  autoconfigure:
+    exclude:
+      - st.orm.spring.boot.autoconfigure.StormTransactionAutoConfiguration
+```
+
+**Layering:** The web application follows controller → service → repository strictly. Controllers inject services only — never repositories — and handle HTTP concerns (params, model, status codes). Services own the transaction boundaries and return view-model data classes. Repositories own all queries.
+
 Use the Storm skills (/storm-setup) for correct dependency configuration.
 
 ### Database
@@ -133,7 +143,7 @@ The data import runs once at application startup — check whether data already 
 
 1. Download TSV.gz files from https://datasets.imdbws.com/ (cache locally so restarts don't re-download)
 2. Stream, decompress, parse TSV (handle `\N` as null)
-3. Convert each row into an entity instance and use Storm's batch insert (`orm insert listOf(...)` or `orm.entity(...).insert(flow, chunkSize)`) to bulk-load the data. This demonstrates Storm's write path with real volume.
+3. Use Flow-based processing for the bulk load: parse each row into an entity inside a Kotlin `Flow` and hand it to Storm's suspending batch insert (`repository.insert(flow, batchSize)`, e.g. batch size 1000). Parsing and inserting happen in a single streaming pass with fixed-size JDBC batches — do NOT materialize full entity lists and insert them afterwards. The importer entry point (`ApplicationRunner`) wraps the import in `runBlocking { }` — the only place `runBlocking` is allowed is a non-suspend framework entry point — and the whole import runs inside one suspend `transaction { }` so a failed import rolls back completely. This demonstrates Storm's coroutine-friendly write path with real volume. (Id-to-entity maps needed by later import steps can be filled as a side effect while the flow streams.)
 4. Import order: titles → persons → principals → ratings
 5. Filter: only movies (`titleType = 'movie'`) with at least 1000 votes to keep the dataset manageable
 
@@ -150,7 +160,7 @@ Build these pages. The UI must be polished — clean typography, consistent spac
 5. **Person detail** — Filmography via repository query, with the person's movies sorted by rating. Show aggregate stats: number of movies, average rating across their filmography (demonstrates `selectCount` and aggregation queries).
 6. **Top movies** — Filterable by genre, sortable by rating or year (demonstrate query composition with conditional predicates inside `select { }`).
 7. **Watchlist** — A personal watchlist feature. Add a `watchlist` table (movie FK + timestamp). The movie detail page has a toggle button (add/remove) that demonstrates Storm's `insert`/`remove`/`exists` cycle. The home page shows a "My Watchlist" section if any entries exist. A dedicated watchlist page shows all saved movies with pagination (`.page()`), demonstrating offset-based pagination alongside keyset scrolling used elsewhere.
-8. **Statistics** — A stats page showing aggregate data: movies per decade (GROUP BY), top genres by average rating (GROUP BY + HAVING), most prolific actors (COUNT + ORDER BY). Use QueryBuilder for joins, where, groupBy, having, orderBy, and limit — only the SELECT clause needs a template string for computed expressions like `COUNT(*)` or `AVG(rating)`. Do NOT write the entire query as a raw SQL template. Map results to custom data classes via `select(ResultType::class, template)`.
+8. **Statistics** — A stats page showing aggregate data: movies per decade (GROUP BY), top genres by average rating (GROUP BY + HAVING), most prolific actors (COUNT + ORDER BY). Use QueryBuilder for joins, where, groupBy, having, orderBy, and limit — only the SELECT clause needs a template string for computed expressions like `COUNT(*)` or `AVG(rating)`. Do NOT write the entire query as a raw SQL template. Map results to custom data classes via `select(ResultType::class, template)` — plain data classes without the `Data` marker (`Data` is reserved for table-backed types; a `Data` result type would be picked up by schema validation and need `@DbIgnore`). Define these result classes in the repository file whose queries return them and document them as query result shapes (not backed by a table or view) — the model package holds only table-backed types.
 
 ### UI Requirements
 

--- a/website/static/skills/storm-entity-from-schema.md
+++ b/website/static/skills/storm-entity-from-schema.md
@@ -29,7 +29,7 @@ Generation/update rules:
 - `describe_table` reports unique constraints (top-level `uniqueConstraints` array with constraint name and column list) and FK cascade rules (onDelete/onUpdate). Both are exposed for context only. **Storm does not model cascade behavior or enforce uniqueness** — these are database-level concerns. Do not generate annotations or code for cascade rules.
 - @Version for version columns (confirm with user).
 - When updating, preserve existing field order and custom annotations. Only add/modify what changed.
-- Use `@DbIgnore` on fields or types that should be excluded from schema validation.
+- Use `@DbIgnore` on fields or types that should be excluded from schema validation. Note: ad-hoc query result types (aggregation DTOs) should not need this — write them as plain data classes/records without the `Data` marker instead of declaring `Data` and then suppressing validation with `@DbIgnore`.
 - Use `@PK(constraint = false)` if the table intentionally has no PK constraint in the database.
 - Use `@FK(constraint = false)` if a FK column intentionally has no FK constraint in the database.
 - Use `@UK(constraint = false)` if a unique field intentionally has no unique constraint in the database.

--- a/website/static/skills/storm-json-java.md
+++ b/website/static/skills/storm-json-java.md
@@ -29,7 +29,12 @@ record User(@PK Integer id,
 Use JSON aggregation functions to load one-to-many relationships in a single query:
 
 ```java
-record RolesByUser(User user, @Json List<Role> roles) implements Data {}
+/**
+ * Query result shape: a user with their roles aggregated from JSON. Not
+ * backed by a database table or view, so it is a plain record —
+ * deliberately not a Data type.
+ */
+record RolesByUser(User user, @Json List<Role> roles) {}
 
 var results = orm.entity(User.class)
     .select(RolesByUser.class, RAW."\{User.class}, JSON_OBJECTAGG(\{Role.class})")

--- a/website/static/skills/storm-json-kotlin.md
+++ b/website/static/skills/storm-json-kotlin.md
@@ -34,7 +34,12 @@ data class User(
 Use JSON aggregation functions to load one-to-many relationships in a single query:
 
 ```kotlin
-data class RolesByUser(val user: User, @Json val roles: List<Role>) : Data
+/**
+ * Query result shape: a user with their roles aggregated from JSON. Not
+ * backed by a database table or view, so it is a plain data class —
+ * deliberately not a Data type.
+ */
+data class RolesByUser(val user: User, @Json val roles: List<Role>)
 
 val results = orm.entity(User::class)
     .select(RolesByUser::class) { "${User::class}, JSON_OBJECTAGG(${Role::class})" }

--- a/website/static/skills/storm-query-java.md
+++ b/website/static/skills/storm-query-java.md
@@ -22,6 +22,8 @@ Ask what data they need, filters, ordering, or pagination.
 
 **DI preference:** In Spring Boot projects, repositories should be constructor-injected (see /storm-repository-java). Use `orm.entity(T.class)` and `orm.repository(T.class)` lookups only in standalone (non-DI) contexts and tests. In DI environments, write queries on injected repository instances.
 
+**Layering rule:** Follow the codebase's existing convention first — if handlers already use repositories directly, or a service layer is consistently in place, match that style rather than introduce a competing one. Absent a clear stance (new code, greenfield), promote the layered architecture: controller → service → repository, where controllers never inject repositories — all data access flows through services, which own the transaction boundaries (e.g. `@Transactional` on service methods) and return view-model types. Whatever the stance, do not mix styles: layer-skipping controllers undermine the service layer's cross-cutting concerns (transactions, caching, authorization).
+
 ## API Design: Builder Methods vs Convenience Methods
 
 Repository/entity methods fall into two categories:
@@ -118,10 +120,16 @@ List<CitySummary> citySummaries = orm.entity(City.class)
 
 **Computed aggregates (COUNT, AVG, SUM, etc.):** When the SELECT clause needs expressions that QueryBuilder can't produce, use `select(ResultType.class, RAW."template")` for the SELECT only — keep joins, groupBy, having, orderBy, and limit in code.
 
+**`Data` means "represents a table".** Only types that map to a database table implement `Data` (or its subinterfaces `Entity`/`Projection`). Ad-hoc query result types — aggregation DTOs, computed shapes — are plain records with no marker at all. Storm maps result columns to any suitable record, including nested entity and `Ref<T>` components. Implementing `Data` on a result type pulls it into Storm's type discovery, so schema validation (`validateSchema()` without arguments, or startup schema validation) fails with `TABLE_NOT_FOUND` — which then requires `@DbIgnore` to suppress. `implements Data` + `@DbIgnore` on a result type is an anti-pattern (opting in and immediately opting out); a plain record expresses the intent directly. Define result types next to the code that produces them — typically in or beside the repository whose queries return them; the entity package is reserved for table-backed types — and document them as query result shapes (not backed by a table or view) so readers immediately see why they carry no marker.
+
 **Important:** The `RAW."template"` provides the SELECT list only — not a full SQL query. If you put a full `SELECT ... FROM ... WHERE ...` inside, Storm wraps it as a scalar subquery, causing errors. For full custom SQL, use `orm.query(RAW."...").getResultList(T.class)` (see /storm-sql-java).
 
 ```java
-record CityUserCount(@FK City city, long userCount) implements Data {}
+/**
+ * Query result shape: user count per city. Not backed by a database table
+ * or view, so it is a plain record — deliberately not a Data type.
+ */
+record CityUserCount(City city, long userCount) {}
 
 List<CityUserCount> cityCounts = orm.entity(City.class)
     .select(CityUserCount.class, RAW."\{City.class}, COUNT(*)")
@@ -130,7 +138,7 @@ List<CityUserCount> cityCounts = orm.entity(City.class)
     .getResultList();
 
 // More complex example with WHERE, HAVING, and ORDER BY — all in code:
-record CityUserStats(String cityName, double averageAge, long userCount) implements Data {}
+record CityUserStats(String cityName, double averageAge, long userCount) {}
 
 int minUsers = 10;
 List<CityUserStats> topCities = orm.entity(City.class)
@@ -142,7 +150,7 @@ List<CityUserStats> topCities = orm.entity(City.class)
     .getResultList();
 
 // Multi-field groupBy — always use the varargs metamodel form:
-record CityActiveCount(@FK Ref<City> city, boolean active, long userCount) implements Data {}
+record CityActiveCount(@FK Ref<City> city, boolean active, long userCount) {}
 
 List<CityActiveCount> counts = orm.entity(User.class)
     .select(CityActiveCount.class, RAW."\{User_.city}, \{User_.active}, COUNT(*)")

--- a/website/static/skills/storm-query-kotlin.md
+++ b/website/static/skills/storm-query-kotlin.md
@@ -22,6 +22,8 @@ Ask what data they need, filters, ordering, or pagination.
 
 **Repository rule:** All database queries must live in repository interfaces, not inline in services or other classes. In Spring Boot or Ktor projects, repositories are constructor-injected (see /storm-repository-kotlin). Use `orm.entity<T>()` and `orm.repository<T>()` lookups only in standalone (non-DI) contexts and tests.
 
+**Layering rule:** Follow the codebase's existing convention first — if handlers already use repositories directly, or a service layer is consistently in place, match that style rather than introduce a competing one. Absent a clear stance (new code, greenfield), promote the layered architecture: controller → service → repository, where controllers never inject repositories — all data access flows through services, which own the transaction boundaries and return view-model types. Whatever the stance, do not mix styles: layer-skipping controllers undermine the service layer's cross-cutting concerns (transactions, caching, authorization).
+
 **Code-first WHERE clauses:** Always express WHERE conditions using metamodel-based predicates (`eq`, `isFalse()`, `isNotNull()`, etc.) instead of template strings. Only fall back to template expressions for conditions that predicates cannot express (e.g., `COALESCE`, date arithmetic, aggregate functions). When a WHERE clause mixes expressible and inexpressible conditions, split it: use code-based predicates for what you can, templates only for what you must. Multiple `where()` calls are AND-combined automatically. FK paths through the object graph (e.g., `User_.city eq city`) do not require explicit joins.
 
 ```kotlin
@@ -191,10 +193,16 @@ val citySummaries = orm.entity(City::class)
 
 **Computed aggregates (COUNT, AVG, SUM, etc.):** When the SELECT clause needs expressions that QueryBuilder can't produce, use `select(ResultType::class) { template }` for the SELECT only — keep joins, groupBy, having, orderBy, and limit in code.
 
+**`Data` means "represents a table".** Only types that map to a database table implement `Data` (or its subtypes `Entity`/`Projection`). Ad-hoc query result types — aggregation DTOs, computed shapes — are plain data classes with no marker at all. Storm maps result columns to any suitable data class, including nested entity and `Ref<T>` components. Implementing `Data` on a result type pulls it into Storm's type discovery, so schema validation (`validateSchema()` without arguments, or `storm.validation.schema-mode` at startup) fails with `TABLE_NOT_FOUND` — which then requires `@DbIgnore` to suppress. `: Data` + `@DbIgnore` on a result type is an anti-pattern (opting in and immediately opting out); a plain data class expresses the intent directly. Define result types next to the code that produces them — typically top-level in the repository file whose queries return them; the model package is reserved for table-backed types — and document them as query result shapes (not backed by a table or view) so readers immediately see why they carry no marker.
+
 **Important:** The `{ template }` provides the SELECT list only — not a full SQL query. If you put a full `SELECT ... FROM ... WHERE ...` inside, Storm wraps it as a scalar subquery, causing errors. For full custom SQL, use `orm.query { }.resultList<T>()` (see /storm-sql-kotlin).
 
 ```kotlin
-data class CityUserCount(val city: City, val userCount: Long) : Data
+/**
+ * Query result shape: user count per city. Not backed by a database table
+ * or view, so it is a plain data class — deliberately not a Data type.
+ */
+data class CityUserCount(val city: City, val userCount: Long)
 
 val cityCounts = orm.entity<City>()
     .select(CityUserCount::class) { "${City::class}, COUNT(*)" }
@@ -203,7 +211,7 @@ val cityCounts = orm.entity<City>()
     .resultList
 
 // More complex example with WHERE, HAVING, and ORDER BY — all in code:
-data class CityUserStats(val cityName: String, val averageAge: Double, val userCount: Long) : Data
+data class CityUserStats(val cityName: String, val averageAge: Double, val userCount: Long)
 
 val minUsers = 10
 val topCities = orm.entity<City>()
@@ -215,7 +223,7 @@ val topCities = orm.entity<City>()
     .resultList
 
 // Multi-field groupBy — always use the varargs metamodel form:
-data class CityActiveCount(val city: Ref<City>, val active: Boolean, val userCount: Long) : Data
+data class CityActiveCount(val city: Ref<City>, val active: Boolean, val userCount: Long)
 
 val counts = orm.entity<User>()
     .select(CityActiveCount::class) { "${User_.city}, ${User_.active}, COUNT(*)" }
@@ -414,6 +422,8 @@ users.removeAll()
 ```
 
 ## Block-Based Query DSL
+
+**Prefer the chained API for linear queries.** A straight filter/order/limit pipeline reads best as a chain — `select(predicate).orderBy(...).limit(...).resultList`, or `select().where { template }...` when the condition needs a template. Reach for the `select { }` block only when you truly need the block structure: conditional predicates or joins (`if`/`when` inside the block), or queries with many clauses where the scoped layout helps.
 
 Use `select { }` / `delete { }` to build queries without chaining. Both are **builder methods** that return `QueryBuilder` -- they never execute immediately. Inside the block, use scope methods like `where()`, `orderBy()`, `limit()` to construct the query. Then call a terminal operation to execute:
 

--- a/website/static/skills/storm-repository-java.md
+++ b/website/static/skills/storm-repository-java.md
@@ -24,9 +24,21 @@ Do NOT import from `st.orm.core.*` — those are Storm's internal core-engine pa
 
 Ask: which entity, what custom queries?
 
+**Result types:** Custom query result types (aggregation DTOs, computed shapes) are plain records — they do NOT implement `Data`, which is reserved for table-backed types. Define them in or beside the repository whose queries return them (not in the entity package), and document each one as a query result shape:
+
+```java
+/**
+ * Query result shape: user count per city. Not backed by a database table
+ * or view, so it is a plain record — deliberately not a Data type.
+ */
+record CityUserCount(City city, long userCount) {}
+```
+
 Detect the project's framework from its build file (pom.xml or build.gradle): look for `storm-spring-boot-starter` or `spring-boot-starter` (Spring Boot) or neither (standalone). Use the detected framework to suggest the appropriate repository registration pattern.
 
 **DI preference:** In Spring Boot projects, always prefer constructor-injected repositories over `orm.entity(T.class)` or `orm.repository(T.class)` lookups. Repository lookup via `orm` is for standalone (non-DI) use and tests only. In DI environments, repositories are beans — inject them.
+
+**Layering rule:** Follow the codebase's existing convention first — if handlers already use repositories directly, or a service layer is consistently in place, match that style rather than introduce a competing one. Absent a clear stance (new code, greenfield), promote the layered architecture: controller → service → repository, where controllers never inject repositories — all data access flows through services, which own the transaction boundaries (e.g. `@Transactional` on service methods) and return view-model types. Whatever the stance, do not mix styles: layer-skipping controllers undermine the service layer's cross-cutting concerns (transactions, caching, authorization).
 
 ## Getting a Repository
 
@@ -84,7 +96,7 @@ Key rules:
 8. **Prefer entity/metamodel-based methods over templates.** Use `.innerJoin(Entity.class).on(OtherEntity.class)` for joins unless it cannot be expressed with entity classes. Only fall back to template lambdas when QueryBuilder cannot express the query.
    **Template joins are a code smell.** If you need a template-based ON clause (`.innerJoin(T.class).on(RAW."...")`) or a full `orm.query(RAW."...")` to express a join that follows a database FK constraint, the entity model is missing an `@FK` annotation. Fix the entity first — add `@FK` (with `Ref<T>` for PK fields, full entity for non-PK fields) — then the join becomes `.innerJoin(Entity.class).on(OtherEntity.class)`, pure code with no templates. Template joins are only justified when there is genuinely no FK constraint in the database.
 9. **Use `Ref` for map keys and set membership**: Prefer `Ref<Entity>` (via `.ref()`) for map keys, set membership, and identity-based lookups. `Ref` provides identity-based `equals`/`hashCode` on the primary key.
-10. **Prefer typed parameters over raw IDs.** Repository method signatures should accept entity or `Ref<Entity>` parameters for FK fields — not raw IDs like `String` or `int`. Raw IDs are untyped and lose the entity association. Convert IDs to `Ref` at the system boundary (controller/route handler) using `Ref.of(Entity.class, id)`.
+10. **Prefer typed parameters over raw IDs — full entities by default.** Repository method signatures take the full entity for FK parameters when callers naturally hold one (the common case): predicates accept entities directly, so no ref conversion is needed at the call sites. `Ref<Entity>` parameters remain fine — use them for identity-only flows, where callers hold refs (e.g. from `Ref<T>` fields) or only an id, converted at the system boundary using `Ref.of(Entity.class, id)`. Never accept raw IDs like `String` or `int` — they are untyped and lose the entity association.
 11. **Typed ID from `Ref`:** Use `Ref.entityId(ref)` to extract a type-safe ID. For projections, use `Ref.projectionId(ref)`. Avoid `ref.id()` — it returns `Object` and requires an unsafe cast.
 
 ## API Design: Prefer the Simplest Approach

--- a/website/static/skills/storm-repository-kotlin.md
+++ b/website/static/skills/storm-repository-kotlin.md
@@ -25,6 +25,18 @@ Ask: which entity, what custom queries?
 
 **Repository rule:** All database queries must live in repository interfaces, not inline in services or other classes. Services orchestrate by calling repository methods — they never build queries directly. When a skill or tool generates a query, always place it in the appropriate repository interface.
 
+**Layering rule:** Follow the codebase's existing convention first — if handlers already use repositories directly, or a service layer is consistently in place, match that style rather than introduce a competing one. Absent a clear stance (new code, greenfield), promote the layered architecture: controller → service → repository, where controllers never inject repositories — all data access flows through services, which own the transaction boundaries and return view-model types. Whatever the stance, do not mix styles: layer-skipping controllers undermine the service layer's cross-cutting concerns (transactions, caching, authorization).
+
+**Result types:** Custom query result types (aggregation DTOs, computed shapes) are plain data classes — they do NOT implement `Data`, which is reserved for table-backed types. Define them top-level in the repository file whose queries return them (not in the model package), and document each one as a query result shape:
+
+```kotlin
+/**
+ * Query result shape: user count per city. Not backed by a database table
+ * or view, so it is a plain data class — deliberately not a Data type.
+ */
+data class CityUserCount(val city: City, val userCount: Long)
+```
+
 Detect the project's framework from its build file (pom.xml or build.gradle.kts): look for `storm-kotlin-spring-boot-starter` or `spring-boot-starter` (Spring Boot), `storm-ktor` or `ktor-server-core` (Ktor), or neither (standalone). Use the detected framework to suggest the appropriate repository registration pattern below.
 
 **DI preference:** In Spring Boot or Ktor projects, always prefer constructor-injected repositories over `orm.entity<T>()` or `orm.repository<T>()` lookups. Repository lookup via `orm` is for standalone (non-DI) use and tests only. In DI environments, repositories are beans/components — inject them.
@@ -99,7 +111,7 @@ Key rules:
 8. **Prefer entity/metamodel-based methods over templates.** For joins, use `innerJoin(Entity::class, OnEntity::class)` in the block DSL, or `.innerJoin(Entity::class).on(OnEntity::class)` in the chained API. Only fall back to template lambdas when QueryBuilder cannot express the query.
    **Template joins are a code smell.** If you need a template-based ON clause (`.innerJoin(T::class).on { "..." }`) or a full `orm.query { }` to express a join that follows a database FK constraint, the entity model is missing an `@FK` annotation. Fix the entity first — add `@FK` (with `Ref<T>` for PK fields, full entity for non-PK fields) — then the join becomes `.innerJoin(Entity::class).on(OnEntity::class)`, pure code with no templates. Template joins are only justified when there is genuinely no FK constraint in the database.
 9. **Use `Ref` for map keys and set membership**: Prefer `Ref<Entity>` (via `.ref()`) for map keys, set membership, and identity-based lookups. `Ref` provides identity-based `equals`/`hashCode` on the primary key. When a projection already returns `Ref<T>`, use it directly without calling `.ref()` again.
-10. **Prefer typed parameters over raw IDs.** Repository method signatures should accept entity or `Ref<Entity>` parameters for FK fields — not raw IDs like `String` or `Int`. Raw IDs are untyped and lose the entity association. Convert IDs to `Ref` at the system boundary (controller/route handler) using `refById<T>(id)` (import `st.orm.template.refById`).
+10. **Prefer typed parameters over raw IDs — full entities by default.** Repository method signatures take the full entity for FK parameters when callers naturally hold one (the common case): predicates like `eq` and `inList` accept entities directly, so no `.ref()` conversion is needed at the call sites. `Ref<Entity>` parameters remain fine — use them for identity-only flows, where callers hold refs (e.g. from `Ref<T>` fields) or only an id, converted at the system boundary with `refById<T>(id)` (import `st.orm.template.refById`). Never accept raw IDs like `String` or `Int` — they are untyped and lose the entity association.
 11. **Typed ID from `Ref`:** Use `ref.entityId()` (import `st.orm.template.entityId`) to extract a type-safe ID. Avoid `ref.id()` — it returns `Any` and requires an unsafe cast.
 
 ## API Design: Prefer the Simplest Approach
@@ -273,12 +285,12 @@ val activeUsers: List<User> = users.findAll(User_.active eq true)
 // Compare by entity — use the FK field directly, don't extract the ID
 val cityUsers: List<User> = users.findAll(User_.city eq city)
 
-// Repository methods should accept entity or Ref<T>, not raw IDs:
+// Repository methods take typed parameters — the full entity by default:
 // ✅ fun findByCity(city: City): List<User> = findAll(User_.city eq city)
-// ✅ fun findByCity(city: Ref<City>): List<User> = findAll(User_.city eq city)
+// ✅ fun findByCity(city: Ref<City>): List<User> = findAll(User_.city eq city)  // for identity-only flows
 // ❌ fun findByCity(cityId: Int): List<User> = ...  // untyped, loses entity association
 
-// At the call site (controller/route handler), convert IDs to Ref:
+// For the Ref variant, callers holding only an id convert at the boundary:
 // val users = userRepository.findByCity(refById<City>(cityId))
 
 // Ref variants (return Ref<User> instead of User — lightweight, only loads PK)
@@ -467,20 +479,47 @@ val userRepository = orm.repository<UserRepository>()
 
 ## Transactions
 
+**Respect an existing stance first.** When the codebase has already settled on a convention — declarative `@Transactional` throughout, no coroutines at all, or fully suspend — Storm code should follow that convention rather than introduce a competing style. The preference below applies when the project has not taken a clear stance (new code, greenfield modules).
+
+Prefer Storm's programmatic transactions over declarative `@Transactional` — in every environment, including Spring Boot. The boundary is explicit code, so there are no AOP proxy pitfalls (self-invocation and non-public methods silently skip `@Transactional`), it is coroutine-native, and the `Transaction` receiver exposes `setRollbackOnly()`, `onCommit { }`, and `onRollback { }` as typed API. In Spring Boot, suspend mode requires disabling Storm's Spring transaction integration (see below); Storm then manages transactions directly on the DataSource. Declarative `@Transactional` remains fully supported for teams standardized on it — in that mode, use `transactionBlocking { }` instead of suspend mode.
+
+Use the top-level suspend function `transaction { }` (import `st.orm.template.transaction`). Two placement rules apply, and they are separate concerns. **Transactions open at the service level** — the method that represents one business operation — never in controllers or route handlers, which handle HTTP and delegate. Controllers that only read directly from repositories do not open transactions. (In minimal route-based apps without a service layer, the route handler doubles as the operation boundary.) **`suspend` propagates toward the start of the call stack** — services and any intermediate functions that open a `transaction { }` are `suspend`; never use `runBlocking` merely to wrap a `transaction { }` deeper in the stack — the bridge to blocking code, if one is needed at all, belongs at the entry point. `transaction { }` is NOT a method on `ORMTemplate` — never write `orm.transaction { }` or `call.orm.transaction { }`. The lambda receiver is a `Transaction` — it does NOT provide `entity(...)`; use repositories or `orm` captured from the enclosing scope. Optional parameters: `propagation`, `isolation`, `timeoutSeconds`, and `readOnly` (e.g. `transaction(readOnly = true) { }` around multi-query reads for a consistent snapshot on one connection).
+
+**`runBlocking` belongs at entry points only.** When a non-suspend framework callback starts the call chain (a Spring MVC handler, an `ApplicationRunner`, a `@Scheduled` method, a message listener, a test), bridge with `runBlocking { }` at that entry point and keep everything below it suspend; never bury `runBlocking` inside services or repositories. In coroutine-native servers (Ktor, WebFlux) the handler itself is suspend and no bridge is needed. For Spring MVC, prefer non-suspend handlers with `runBlocking` over suspend handlers: MVC is a blocking servlet stack — with virtual threads the blocking bridge is cheap, whereas suspend MVC handlers require `kotlinx-coroutines-reactor` and route responses through async dispatch machinery that buys nothing there. `transactionBlocking { }` exists for code that is genuinely outside any coroutine context.
+
 ### Spring Boot
-Use `@Transactional` on service methods (standard Spring):
+
+Suspend mode is incompatible with Spring-managed Storm transactions (Spring's transaction context is thread-bound, coroutines are not) — Storm fails fast with "Suspend mode is not supported when spring-managed transactions are enabled". When using suspend `transaction { }`, exclude the integration; keep it (the default) when using `@Transactional` or `transactionBlocking { }` that must join Spring-managed transactions:
+
+```yaml
+spring:
+  autoconfigure:
+    exclude:
+      - st.orm.spring.boot.autoconfigure.StormTransactionAutoConfiguration
+```
+
 ```kotlin
 @Service
 class UserService(private val userRepository: UserRepository) {
-    @Transactional
-    fun createUser(email: String, city: City): User =
+    suspend fun createUser(email: String, city: City): User = transaction {
         userRepository.insertAndFetch(User(email = email, city = city))
+    }
+}
+
+@RestController
+class UserController(private val userService: UserService) {
+    // The MVC handler is the entry point: bridge with runBlocking here and
+    // keep the call chain below it suspend.
+    @PostMapping("/users")
+    fun createUser(@RequestBody request: CreateUserRequest): User = runBlocking {
+        userService.createUser(request.email, request.city)
+    }
 }
 ```
 
-### Ktor / Standalone
+Declarative `@Transactional` on service methods also works (standard Spring) for teams that prefer it.
 
-Use the top-level `transaction { }` function (import `st.orm.template.transaction`). It is a **suspend function**, not a method on `ORMTemplate` — never write `orm.transaction { }` or `call.orm.transaction { }`. The lambda receiver is a `Transaction` (exposing `setRollbackOnly()`, `onCommit { }`, `onRollback { }`) — it does NOT provide `entity(...)`; use repositories or `orm` captured from the enclosing scope:
+### Ktor
 
 ```kotlin
 get("/users") {
@@ -492,9 +531,11 @@ get("/users") {
 }
 ```
 
-Outside a coroutine, use `transactionBlocking { }` instead. Transaction options are available via `withTransactionOptions { }` (isolation via `TransactionIsolation`, propagation via `TransactionPropagation`).
+Transaction options are also available globally via `withTransactionOptions { }` (isolation via `TransactionIsolation`, propagation via `TransactionPropagation`).
 
 ## Block-Based Query DSL
+
+**Prefer the chained API for linear queries.** A straight filter/order/limit pipeline reads best as a chain — `select(predicate).orderBy(...).limit(...).resultList`, or `select().where { template }...` when the condition needs a template. Reach for the `select { }` block only when you truly need the block structure: conditional predicates or joins (`if`/`when` inside the block), or queries with many clauses where the scoped layout helps.
 
 Repository methods can use the `select { }` / `delete { }` DSL for building queries. Both are **builder methods** that return `QueryBuilder` -- they never execute immediately. Inside the block, use scope methods like `where()`, `orderBy()`, `limit()` to construct the query. Then call a terminal operation to execute:
 

--- a/website/static/skills/storm-rules.md
+++ b/website/static/skills/storm-rules.md
@@ -27,7 +27,7 @@ Before suggesting dependencies, patterns, or configuration, detect which framewo
 - **Standalone**: neither Spring Boot nor Ktor detected. The project uses Storm directly with `ORMTemplate.of(dataSource)`.
 
 Adapt your suggestions to the detected framework:
-- **Spring Boot**: use `@Transactional`, constructor injection, `application.yml` for config.
+- **Spring Boot**: use Storm's programmatic transactions — suspend `transaction { }` at the service level (never in controllers), bridged with `runBlocking` only at non-suspend entry points such as MVC handlers (declarative `@Transactional` also works), constructor injection, `application.yml` for config.
 - **Ktor**: use `install(Storm)` plugin, `transaction { }` blocks, `application.conf` (HOCON) for config, `call.orm` for route access.
 - **Standalone**: use `DataSource.orm` or `ORMTemplate.of(dataSource)`, programmatic `transaction { }` blocks.
 

--- a/website/static/skills/storm-sql-java.md
+++ b/website/static/skills/storm-sql-java.md
@@ -60,11 +60,14 @@ Template elements:
 
 ## Aggregate example — the primary use case
 
-Define a custom `Data` type for the result shape, then use a SQL Template for the aggregate:
+Define a plain record for the result shape, then use a SQL Template for the aggregate:
 
 \`\`\`java
-// Custom result type — not an entity, just a data carrier
-record CityUserCount(@FK City city, long userCount) implements Data {}
+/**
+ * Query result shape: user count per city. Not backed by a database table
+ * or view, so it is a plain record — deliberately not a Data type.
+ */
+record CityUserCount(City city, long userCount) {}
 
 // Use select() with custom return type + minimal SQL template for the aggregate only
 List<CityUserCount> cityCounts = orm.entity(City.class)
@@ -76,7 +79,7 @@ List<CityUserCount> cityCounts = orm.entity(City.class)
 
 The join, grouping, and result retrieval are all code-based. Only the `COUNT(*)` aggregate — which QueryBuilder cannot express — uses a SQL template fragment. This keeps the template to the absolute minimum.
 
-The `Data` interface marks types for SQL generation without CRUD. It tells Storm how to map the result columns to the record fields.
+Storm maps the result columns positionally onto the result type's components — entity components, `Ref<T>` components, and scalars all work without any marker interface. Do not implement `Data` on result types — it is reserved for table-backed types, and a `Data` result type would be picked up by schema validation (requiring `@DbIgnore` to suppress).
 
 **`Ref<T>` in result types:** When a SELECT clause references a FK field (`\{User_.city}`) rather than a full entity (`\{City.class}`), use `Ref<T>` in the result type — not the raw ID type and not the full entity. `Ref<City>` maps correctly to the FK column value. Use the full entity type only when selecting all its columns via `\{City.class}`.
 

--- a/website/static/skills/storm-sql-kotlin.md
+++ b/website/static/skills/storm-sql-kotlin.md
@@ -60,11 +60,14 @@ Template elements:
 
 ## Aggregate example — the primary use case
 
-Define a custom `Data` type for the result shape, then use a SQL Template for the aggregate:
+Define a plain data class for the result shape, then use a SQL Template for the aggregate:
 
 ```kotlin
-// Custom result type — not an entity, just a data carrier
-data class CityUserCount(val city: City, val userCount: Long) : Data
+/**
+ * Query result shape: user count per city. Not backed by a database table
+ * or view, so it is a plain data class — deliberately not a Data type.
+ */
+data class CityUserCount(val city: City, val userCount: Long)
 
 // Use select() with custom return type + minimal SQL template for the aggregate only
 val cityCounts = orm.entity(City::class)
@@ -76,7 +79,7 @@ val cityCounts = orm.entity(City::class)
 
 The join, grouping, and result retrieval are all code-based. Only the `COUNT(*)` aggregate — which QueryBuilder cannot express — uses a SQL template fragment. This keeps the template to the absolute minimum.
 
-The `Data` interface marks types for SQL generation without CRUD. It tells Storm how to map the result columns to the record fields.
+Storm maps the result columns positionally onto the result type's components — entity components, `Ref<T>` components, and scalars all work without any marker interface. Do not implement `Data` on result types — it is reserved for table-backed types, and a `Data` result type would be picked up by schema validation (requiring `@DbIgnore` to suppress).
 
 **`Ref<T>` in result types:** When a SELECT clause references a FK field (`${User_.city}`) rather than a full entity (`${City::class}`), use `Ref<T>` in the result type — not the raw ID type and not the full entity. `Ref<City>` maps correctly to the FK column value. Use the full entity type only when selecting all its columns via `${City::class}`.
 

--- a/website/static/skills/storm-validate.md
+++ b/website/static/skills/storm-validate.md
@@ -19,6 +19,7 @@ Compare Storm entities against the live database schema.
 Respect suppression annotations:
 - Skip types annotated with `@DbIgnore` or `@ProjectionQuery`
 - Skip fields annotated with `@DbIgnore`
+- If a type carries both `Data` and `@DbIgnore` and is only used as a query result shape (an aggregation DTO), suggest rewriting it as a plain data class/record without the `Data` marker — that removes it from validation scope altogether instead of suppressing it
 - `@PK(constraint = false)` suppresses missing PK constraint warning
 - `@UK(constraint = false)` suppresses missing unique constraint warning
 - Composite (multi-column) DB unique constraints that are not modeled in the entity do NOT produce a warning — modeling them requires structural changes that should be a deliberate choice

--- a/website/versioned_docs/version-1.11.6/polymorphism.md
+++ b/website/versioned_docs/version-1.11.6/polymorphism.md
@@ -796,8 +796,8 @@ With `@Discriminator`, the discriminator column is read directly from the base t
 ```sql
 SELECT p.id, p.dtype, p.name, c.indoor, d.weight
 FROM pet p
-LEFT JOIN cat c ON p.id = c.id
-LEFT JOIN dog d ON p.id = d.id
+LEFT JOIN cat c ON c.id = p.id
+LEFT JOIN dog d ON d.id = p.id
 ```
 
 Without `@Discriminator`, Storm generates a `CASE` expression that resolves the concrete type by checking which extension table has a matching row:
@@ -809,9 +809,9 @@ SELECT p.id,
             WHEN b.id IS NOT NULL THEN 'Bird' END,
        p.name, c.indoor, d.weight
 FROM pet p
-LEFT JOIN cat c ON p.id = c.id
-LEFT JOIN dog d ON p.id = d.id
-LEFT JOIN bird b ON p.id = b.id
+LEFT JOIN cat c ON c.id = p.id
+LEFT JOIN dog d ON d.id = p.id
+LEFT JOIN bird b ON b.id = p.id
 ```
 
 Unlike Single-Table, DML operations for Joined Table entities are multi-statement: they involve more than one table. Storm executes all statements within the current transaction to ensure atomicity. Each operation follows a specific order to respect foreign key constraints between the base and extension tables.
@@ -891,8 +891,8 @@ When querying Visit with a join to Pet, Storm generates:
 SELECT v.*, p.id, p.dtype, p.name, c.indoor, d.weight
 FROM visit v
 INNER JOIN pet p ON v.pet_id = p.id
-LEFT JOIN cat c ON p.id = c.id
-LEFT JOIN dog d ON p.id = d.id
+LEFT JOIN cat c ON c.id = p.id
+LEFT JOIN dog d ON d.id = p.id
 ```
 
 ### Hydration

--- a/website/versioned_docs/version-1.11.6/projections.md
+++ b/website/versioned_docs/version-1.11.6/projections.md
@@ -138,7 +138,7 @@ Use `@ProjectionQuery` to define a projection backed by custom SQL:
     SELECT b.id, COUNT(*) AS item_count, SUM(i.price) AS total_price
     FROM basket b
     JOIN basket_item bi ON bi.basket_id = b.id
-    JOIN item i ON i.id = bi.item_id
+    JOIN item i ON bi.item_id = i.id
     GROUP BY b.id
 """)
 data class BasketSummary(
@@ -156,7 +156,7 @@ data class BasketSummary(
     SELECT b.id, COUNT(*) AS item_count, SUM(i.price) AS total_price
     FROM basket b
     JOIN basket_item bi ON bi.basket_id = b.id
-    JOIN item i ON i.id = bi.item_id
+    JOIN item i ON bi.item_id = i.id
     GROUP BY b.id
     """)
 record BasketSummary(


### PR DESCRIPTION
Mostly docs and cosmetics: aligns all generated SQL and documentation examples on a single join-condition ordering rule, polishes the AI skills guidance, and future-proofs the transaction auto-configuration ordering hints.

## FK-first join order

Storm's join emitters now agree on one convention: **the referencing (FK) column goes on the left, the referenced key on the right** — mirroring `FOREIGN KEY (city_id) REFERENCES city (id)` DDL and rendering each relationship identically regardless of join direction.

- `JoinProcessor` and `getTemplateTarget` already emitted FK-first; `addJoinedExtensionJoins` (JOINED inheritance) was the odd one out and now emits `extension.pk = base.pk` (the extension PK doubles as the FK to the base table). Purely cosmetic — join semantics are unchanged.
- The landing page SQL panels showed `ON c.id = u.city_id`, which Storm never generated; corrected to `ON u.city_id = c.id`.
- `polymorphism.md` updated to the new extension-join order; the `projections.md` custom-SQL example now uses FK-first joins consistently (current docs + 1.11.6 snapshot).

## Skills guidance polish

- Query result shapes (aggregation DTOs) are plain records/data classes; `Data` + `@DbIgnore` on result types is called out as an anti-pattern.
- Layering rule: follow the codebase's existing convention, otherwise promote controller → service → repository; never mix styles.
- Kotlin transactions: programmatic suspend `transaction { }` at the service level, `runBlocking` only at non-suspend entry points.
- Demo skill: Flow-based streaming bulk import; prefer the chained query API for linear queries; FK repository parameters take full entities by default.

## Spring Boot 4 compat

`StormTransactionAutoConfiguration` now references `DataSourceTransactionManagerAutoConfiguration` via `afterName` with both the 3.x and 4.x class locations, since the class moves to the modular spring-boot-jdbc jar in Spring Boot 4 and a class literal to an absent location breaks annotation introspection.

## Testing

- `JoinedEntityCrudIntegrationTest`, `PolymorphicIntegrationTest`, `JoinedEntityCallbackIntegrationTest`: 137 tests, 0 failures
- `storm-kotlin-spring-boot-starter`: 15 tests, 0 failures