### PR TITLE
feat: enable schema validation by default across Spring and Ktor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -607,13 +607,15 @@ Controls whether record (structural) validation runs when Storm first encounters
 
 ### storm.validation.schema_mode {#schema-validation}
 
-Controls whether schema validation runs at startup (Spring Boot only; for programmatic use, see [Validation](validation.md#programmatic-api)).
+Controls whether schema validation runs at startup (Spring Boot and Ktor; for programmatic use, see [Validation](validation.md#programmatic-api)).
 
 | Value | Behavior |
 |-------|----------|
-| `none` | Schema validation is skipped (default). |
+| `none` | Schema validation is skipped. |
 | `warn` | Mismatches are logged at WARN level; startup continues. |
-| `fail` | Mismatches cause startup to fail with a `PersistenceException`. |
+| `fail` | Mismatches cause startup to fail with a `PersistenceException` (default). |
+
+Validation runs after all singleton beans are initialized, so migrations executed by beans such as Flyway or Liquibase complete first. The Ktor plugin behaves the same way; run migrations in its `migration { }` hook.
 
 ### storm.validation.strict
 

--- a/docs/ktor-integration.md
+++ b/docs/ktor-integration.md
@@ -102,7 +102,13 @@ install(Storm) {
     // Storm config: auto-read from HOCON if not provided
     config = StormConfig.of(mapOf(UPDATE_DEFAULT_MODE to "FIELD"))
 
-    // Schema validation: "none" (default), "warn", or "fail"
+    // Schema migrations: runs after the DataSource is available, before validation
+    migration { dataSource ->
+        Flyway.configure().dataSource(dataSource).load().migrate()
+    }
+
+    // Schema validation: "none", "warn", or "fail".
+    // When omitted, read from storm.validation.schemaMode in the application config; defaults to "fail".
     schemaValidation = "warn"
 
     // Entity callbacks for lifecycle hooks
@@ -118,7 +124,8 @@ install(Storm) {
 |--------|---------|-------------|
 | `dataSource` | Created from HOCON | The JDBC DataSource to use. When omitted, a HikariCP pool is created from `storm.datasource.*` in `application.conf`. |
 | `config` | Read from HOCON | A `StormConfig` with ORM properties. When omitted, properties are read from `storm.*` in `application.conf`. |
-| `schemaValidation` | `"none"` | Validates entity definitions against the database schema at startup. `"warn"` logs mismatches; `"fail"` blocks startup. |
+| `migration(...)` | None | A hook that runs after the DataSource is available and before schema validation. The place for Flyway or Liquibase migrations, guaranteeing validation sees the migrated schema. |
+| `schemaValidation` | From config, else `"fail"` | Validates entity definitions against the database schema during installation. `"fail"` (the default) blocks startup on mismatches; `"warn"` logs them; `"none"` opts out. When not set, the mode is read from `storm.validation.schemaMode` in the application configuration. |
 | `entityCallback(...)` | None | Registers entity lifecycle callbacks for insert, update, and delete operations. |
 | `autoRegisterRepositories` | `true` | Registers all repository interfaces from the compile-time type index during installation, so `repository<T>()` works without further setup. |
 | `repositories(...)` | All indexed | Narrows repository auto-registration to the given packages (including sub-packages). |

--- a/storm-core/src/main/java/st/orm/core/template/impl/SchemaValidator.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SchemaValidator.java
@@ -169,10 +169,12 @@ public final class SchemaValidator {
      * @throws SchemaValidationException if one or more validation errors are detected.
      */
     public void validateOrThrow() throws SchemaValidationException {
-        List<SchemaValidationError> errors = validate();
+        List<Class<? extends Data>> types = TypeDiscovery.getDataTypes();
+        List<SchemaValidationError> errors = validate(types);
         if (!errors.isEmpty()) {
             throw new SchemaValidationException(errors);
         }
+        LOGGER.info("Successfully validated %s Data types against the database schema.".formatted(types.size()));
     }
 
     /**

--- a/storm-kotlin-spring-boot-starter/src/main/java/st/orm/spring/boot/autoconfigure/StormProperties.java
+++ b/storm-kotlin-spring-boot-starter/src/main/java/st/orm/spring/boot/autoconfigure/StormProperties.java
@@ -166,15 +166,21 @@ public class StormProperties {
          * <p>When set to {@code "fail"}, validation errors cause startup to fail with a {@code PersistenceException}.
          * When set to {@code "warn"}, errors are logged as warnings; startup continues.
          * When set to {@code "none"}, record validation is skipped entirely.</p>
+         *
+         * <p>Defaults to {@code "fail"} when not set. Validation runs after all singleton beans are initialized,
+         * so migrations executed by beans such as Flyway or Liquibase complete first.</p>
          */
         private String recordMode;
 
         /**
-         * Schema validation mode: {@code "none"} (default), {@code "warn"}, or {@code "fail"}.
+         * Schema validation mode: {@code "none"}, {@code "warn"}, or {@code "fail"} (default).
          *
          * <p>When set to {@code "fail"}, schema validation runs at startup and blocks if mismatches are found.
          * When set to {@code "warn"}, mismatches are logged at WARN level but startup continues.
          * When set to {@code "none"}, schema validation is skipped entirely.</p>
+         *
+         * <p>Defaults to {@code "fail"} when not set. Validation runs after all singleton beans are initialized,
+         * so migrations executed by beans such as Flyway or Liquibase complete first.</p>
          */
         private String schemaMode;
 

--- a/storm-kotlin-spring-boot-starter/src/main/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfiguration.kt
+++ b/storm-kotlin-spring-boot-starter/src/main/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfiguration.kt
@@ -42,6 +42,8 @@ import javax.sql.DataSource
 @EnableConfigurationProperties(StormProperties::class)
 open class StormAutoConfiguration {
 
+    private val logger = org.slf4j.LoggerFactory.getLogger(StormAutoConfiguration::class.java)
+
     /**
      * Creates an [ORMTemplate] bean using the provided [DataSource] and [StormProperties].
      *
@@ -64,21 +66,29 @@ open class StormAutoConfiguration {
 
     /**
      * Runs schema validation after all singleton beans have been fully initialized. This guarantees that migration
-     * tools like Flyway and Liquibase have completed their work before validation occurs.
+     * tools like Flyway and Liquibase (or any bean-based migration mechanism) have completed their work before
+     * validation occurs.
+     *
+     * Validation defaults to `fail`: every entity and projection is validated against the live database schema and
+     * mismatches abort startup. Set `storm.validation.schema_mode` to `warn` or `none` to relax or opt out.
      */
     @Bean
     open fun stormSchemaValidator(
         dataSource: DataSource,
         properties: StormProperties,
     ): SmartInitializingSingleton = SmartInitializingSingleton {
-        val schemaMode = properties.validation.schemaMode?.trim() ?: return@SmartInitializingSingleton
-        if (schemaMode.isBlank() || schemaMode.equals("none", ignoreCase = true)) {
+        val schemaMode = properties.validation.schemaMode?.trim()?.ifBlank { null } ?: "fail"
+        if (schemaMode.equals("none", ignoreCase = true)) {
             return@SmartInitializingSingleton
         }
         val validator = SchemaValidator.of(dataSource)
         when {
-            schemaMode.equals("fail", ignoreCase = true) -> validator.validateOrThrow()
+            schemaMode.equals("fail", ignoreCase = true) -> {
+                validator.validateOrThrow()
+                logger.info("Storm schema validation passed (mode=fail).")
+            }
             schemaMode.equals("warn", ignoreCase = true) -> validator.validateOrWarn()
+            else -> logger.warn("Unknown schema validation mode: '$schemaMode'. Expected 'none', 'warn', or 'fail'.")
         }
     }
 

--- a/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.kt
+++ b/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.kt
@@ -19,10 +19,13 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import st.orm.Entity
@@ -32,6 +35,7 @@ import st.orm.spring.SpringTransactionConfiguration
 import st.orm.template.ORMTemplate
 import javax.sql.DataSource
 
+@ExtendWith(OutputCaptureExtension::class)
 class StormAutoConfigurationTest {
 
     private val contextRunner = ApplicationContextRunner()
@@ -253,6 +257,22 @@ class StormAutoConfigurationTest {
     }
 
     @Test
+    fun `schema validation defaults to fail mode`(output: CapturedOutput) {
+        // No schema-mode property: validation must run in fail mode by default.
+        // With no entities on the test classpath there is nothing to reject, so
+        // the success log proves the default dispatched into the fail branch.
+        contextRunner
+            .withPropertyValues(
+                "spring.datasource.url=jdbc:h2:mem:schemaDefaultTest;DB_CLOSE_DELAY=-1",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+            )
+            .run { context ->
+                context.getBean(ORMTemplate::class.java) shouldNotBe null
+                output.out.contains("Storm schema validation passed (mode=fail).") shouldBe true
+            }
+    }
+
+    @Test
     fun `schema validation fail mode should start context when no entities are registered`() {
         // With no entities registered, validateOrThrow should succeed (nothing to validate).
         // This exercises the "fail" branch in runSchemaValidation.
@@ -268,8 +288,9 @@ class StormAutoConfigurationTest {
     }
 
     @Test
-    fun `schema validation blank mode should not trigger validation`() {
-        // A blank (whitespace-only) schema-mode should be treated the same as "none".
+    fun `schema validation blank mode falls back to fail default`(output: CapturedOutput) {
+        // A blank (whitespace-only) schema-mode is treated as unset and falls back
+        // to the fail default.
         contextRunner
             .withPropertyValues(
                 "spring.datasource.url=jdbc:h2:mem:schemaBlankTest;DB_CLOSE_DELAY=-1",
@@ -278,6 +299,7 @@ class StormAutoConfigurationTest {
             )
             .run { context ->
                 context.getBean(ORMTemplate::class.java) shouldNotBe null
+                output.out.contains("Storm schema validation passed (mode=fail).") shouldBe true
             }
     }
 

--- a/storm-ktor/pom.xml
+++ b/storm-ktor/pom.xml
@@ -74,6 +74,27 @@
                             </sourceDirs>
                         </configuration>
                     </execution>
+                    <!-- Run the metamodel annotation processor (via kapt) over the Kotlin test
+                         sources so the compile-time type index (META-INF/storm/*.idx) is
+                         generated automatically, exactly as in real applications. -->
+                    <execution>
+                        <id>test-kapt</id>
+                        <goals>
+                            <goal>test-kapt</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                            </sourceDirs>
+                            <annotationProcessorPaths>
+                                <annotationProcessorPath>
+                                    <groupId>st.orm</groupId>
+                                    <artifactId>storm-metamodel-processor</artifactId>
+                                    <version>${project.version}</version>
+                                </annotationProcessorPath>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>test-compile</id>
                         <phase>test-compile</phase>

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
@@ -63,6 +63,10 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
     val dataSource = pluginConfig.dataSource ?: createDataSourceFromConfig(application)
     val stormConfig = pluginConfig.config ?: readStormConfig(application)
 
+    // Run the migration hook (e.g., Flyway) before the ORM template is created and the schema is
+    // validated, so validation always sees the migrated schema.
+    pluginConfig.migration?.invoke(dataSource)
+
     var ormTemplate = st.orm.template.ORMTemplate.of(dataSource, stormConfig)
     if (pluginConfig.entityCallbacks.isNotEmpty()) {
         ormTemplate = ormTemplate.withEntityCallbacks(pluginConfig.entityCallbacks)
@@ -81,14 +85,22 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
     }
     application.attributes.put(RepositoryRegistryKey, repositoryRegistry)
 
-    // Run schema validation.
-    val schemaMode = pluginConfig.schemaValidation.trim().lowercase()
+    // Run schema validation. The mode comes from the plugin configuration, falling back to the
+    // application configuration (storm.validation.schemaMode), matching the Spring Boot starter.
+    val configuredSchemaMode = pluginConfig.schemaValidation
+        ?: application.environment.config.propertyOrNull("storm.validation.schemaMode")?.getString()
+        ?: application.environment.config.propertyOrNull("storm.validation.schema_mode")?.getString()
+        ?: "fail"
+    val schemaMode = configuredSchemaMode.trim().lowercase()
     if (schemaMode != "none" && schemaMode.isNotBlank()) {
         val validator = SchemaValidator.of(dataSource)
         when (schemaMode) {
-            "fail" -> validator.validateOrThrow()
+            "fail" -> {
+                validator.validateOrThrow()
+                application.log.info("Storm schema validation passed (mode=fail).")
+            }
             "warn" -> validator.validateOrWarn()
-            else -> application.log.warn("Unknown schema validation mode: '${pluginConfig.schemaValidation}'. Expected 'none', 'warn', or 'fail'.")
+            else -> application.log.warn("Unknown schema validation mode: '$configuredSchemaMode'. Expected 'none', 'warn', or 'fail'.")
         }
     }
 

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormConfiguration.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormConfiguration.kt
@@ -46,9 +46,38 @@ class StormConfiguration {
     var config: StormConfig? = null
 
     /**
-     * Schema validation mode: `"none"` (default), `"warn"`, or `"fail"`.
+     * Schema validation mode: `"none"`, `"warn"`, or `"fail"`.
+     *
+     * When not set, the mode is read from the application configuration under
+     * `storm.validation.schemaMode` (or `storm.validation.schema_mode`), matching the Spring Boot
+     * starter's property. Defaults to `"fail"`: every entity and projection is validated against the
+     * live database schema during installation, and mismatches abort startup. Run migrations in the
+     * [migration] hook so the schema is up to date before validation, or set this to `"none"` to opt out.
      */
-    var schemaValidation: String = "none"
+    var schemaValidation: String? = null
+
+    internal var migration: ((DataSource) -> Unit)? = null
+
+    /**
+     * Registers a migration hook that runs after the [DataSource] is available but before the
+     * ORM template is created and the schema is validated.
+     *
+     * This is the place to run schema migrations (e.g., Flyway or Liquibase) when the plugin creates
+     * the DataSource from configuration, guaranteeing that schema validation sees the migrated schema:
+     *
+     * ```kotlin
+     * install(Storm) {
+     *     migration { dataSource ->
+     *         Flyway.configure().dataSource(dataSource).load().migrate()
+     *     }
+     * }
+     * ```
+     *
+     * @since 1.12
+     */
+    fun migration(block: (DataSource) -> Unit) {
+        migration = block
+    }
 
     /**
      * Entity callbacks for lifecycle hooks on insert, update, and delete operations.

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormConfigReaderTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormConfigReaderTest.kt
@@ -54,6 +54,7 @@ class StormConfigReaderTest {
     fun `plugin reads config from HOCON environment`() = testApplication {
         environment {
             config = MapApplicationConfig(
+                "storm.validation.schemaMode" to "none", // not exercising schema validation here
                 "storm.datasource.jdbcUrl" to "jdbc:h2:mem:cfgenv-${System.nanoTime()};DB_CLOSE_DELAY=-1",
                 "storm.datasource.driverClassName" to "org.h2.Driver",
                 "storm.datasource.username" to "sa",

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormDataSourceTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormDataSourceTest.kt
@@ -13,6 +13,7 @@ class StormDataSourceTest {
     fun `creates DataSource from HOCON config`() = testApplication {
         environment {
             config = io.ktor.server.config.MapApplicationConfig(
+                "storm.validation.schemaMode" to "none", // not exercising schema validation here
                 "storm.datasource.jdbcUrl" to "jdbc:h2:mem:ds-test-${System.nanoTime()};DB_CLOSE_DELAY=-1",
                 "storm.datasource.driverClassName" to "org.h2.Driver",
                 "storm.datasource.username" to "sa",
@@ -31,6 +32,7 @@ class StormDataSourceTest {
     fun `creates DataSource with all optional HikariCP properties`() = testApplication {
         environment {
             config = io.ktor.server.config.MapApplicationConfig(
+                "storm.validation.schemaMode" to "none", // not exercising schema validation here
                 "storm.datasource.jdbcUrl" to "jdbc:h2:mem:ds-full-${System.nanoTime()};DB_CLOSE_DELAY=-1",
                 "storm.datasource.driverClassName" to "org.h2.Driver",
                 "storm.datasource.username" to "sa",
@@ -52,6 +54,7 @@ class StormDataSourceTest {
     fun `creates DataSource with minimal config`() = testApplication {
         environment {
             config = io.ktor.server.config.MapApplicationConfig(
+                "storm.validation.schemaMode" to "none", // not exercising schema validation here
                 "storm.datasource.jdbcUrl" to "jdbc:h2:mem:ds-minimal-${System.nanoTime()};DB_CLOSE_DELAY=-1",
             )
         }
@@ -65,6 +68,7 @@ class StormDataSourceTest {
     fun `DataSource is closed on application stop`() = testApplication {
         environment {
             config = io.ktor.server.config.MapApplicationConfig(
+                "storm.validation.schemaMode" to "none", // not exercising schema validation here
                 "storm.datasource.jdbcUrl" to "jdbc:h2:mem:ds-close-${System.nanoTime()};DB_CLOSE_DELAY=-1",
                 "storm.datasource.driverClassName" to "org.h2.Driver",
                 "storm.datasource.username" to "sa",
@@ -99,6 +103,7 @@ class StormDataSourceTest {
         testApplication {
             application {
                 install(Storm) {
+                    schemaValidation = "none" // not exercising schema validation here
                     dataSource = simpleDataSource
                 }
                 stormDataSource shouldBe simpleDataSource

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormPluginTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormPluginTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldNotBe
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
+import io.ktor.server.config.MapApplicationConfig
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -166,6 +167,119 @@ class StormPluginTest {
                     install(Storm) {
                         this.dataSource = dataSource
                         schemaValidation = "fail"
+                    }
+                    orm shouldNotBe null
+                }
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `migration hook runs before schema validation`() {
+        // Empty database: default fail-mode schema validation would abort startup,
+        // but the migration hook creates the schema first.
+        val dataSource = createTestDataSource()
+        try {
+            testApplication {
+                application {
+                    install(Storm) {
+                        this.dataSource = dataSource
+                        migration { initializeSchema(dataSource) }
+                    }
+                    orm shouldNotBe null
+                    repository<st.orm.ktor.model.PetRepository>().findAll().size shouldBe 3
+                }
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `schema validation fails startup by default on missing schema`() {
+        // No migration hook and no schema: the fail default must abort startup.
+        val dataSource = createTestDataSource()
+        try {
+            testApplication {
+                application {
+                    try {
+                        install(Storm) {
+                            this.dataSource = dataSource
+                        }
+                        throw AssertionError("Expected schema validation to fail startup")
+                    } catch (expected: st.orm.PersistenceException) {
+                        // Validation ran in fail mode by default.
+                    }
+                }
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `schema validation mode is read from application config`() {
+        val dataSource = createTestDataSource()
+        initializeSchema(dataSource)
+        try {
+            testApplication {
+                environment {
+                    config = MapApplicationConfig("storm.validation.schemaMode" to "fail")
+                }
+                application {
+                    install(Storm) {
+                        this.dataSource = dataSource
+                    }
+                    orm shouldNotBe null
+                }
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `schema validation from config fails startup on missing schema`() {
+        // No schema initialized: "fail" from the application config must
+        // surface as a startup failure, proving the config fallback triggers.
+        val dataSource = createTestDataSource()
+        try {
+            testApplication {
+                environment {
+                    config = MapApplicationConfig("storm.validation.schemaMode" to "fail")
+                }
+                application {
+                    try {
+                        install(Storm) {
+                            this.dataSource = dataSource
+                        }
+                        throw AssertionError("Expected schema validation to fail startup")
+                    } catch (expected: st.orm.PersistenceException) {
+                        // Schema validation ran in fail mode, as configured.
+                    }
+                }
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `plugin option overrides schema validation mode from config`() {
+        // No schema initialized: "fail" from the config would throw, but the
+        // explicit plugin option takes precedence and disables validation.
+        val dataSource = createTestDataSource()
+        try {
+            testApplication {
+                environment {
+                    config = MapApplicationConfig("storm.validation.schemaMode" to "fail")
+                }
+                application {
+                    install(Storm) {
+                        this.dataSource = dataSource
+                        schemaValidation = "none"
                     }
                     orm shouldNotBe null
                 }

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/model/Pet.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/model/Pet.kt
@@ -4,7 +4,6 @@ import st.orm.Entity
 import st.orm.FK
 import st.orm.PK
 
-@JvmRecord
 data class Pet(
     @PK val id: Int = 0,
     val name: String,

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetType.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetType.kt
@@ -4,7 +4,6 @@ import st.orm.Entity
 import st.orm.GenerationStrategy
 import st.orm.PK
 
-@JvmRecord
 data class PetType(
     @PK(generation = GenerationStrategy.NONE) val id: Int = 0,
     val name: String,

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetView.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetView.kt
@@ -4,7 +4,6 @@ import st.orm.DbTable
 import st.orm.PK
 import st.orm.Projection
 
-@JvmRecord
 @DbTable("pet")
 data class PetView(
     @PK val id: Int = 0,

--- a/storm-ktor/src/test/resources/META-INF/storm/st.orm.repository.Repository.idx
+++ b/storm-ktor/src/test/resources/META-INF/storm/st.orm.repository.Repository.idx
@@ -1,1 +1,0 @@
-st.orm.ktor.model.PetRepository

--- a/storm-ktor/src/test/resources/schema.sql
+++ b/storm-ktor/src/test/resources/schema.sql
@@ -1,8 +1,8 @@
 drop table if exists pet CASCADE;
 drop table if exists pet_type CASCADE;
 
-create table pet_type (id integer, name varchar(255), primary key (id));
-create table pet (id integer auto_increment, name varchar(255), type_id integer, primary key (id));
+create table pet_type (id integer, name varchar(255) not null, primary key (id));
+create table pet (id integer auto_increment, name varchar(255) not null, type_id integer not null, primary key (id));
 alter table pet add constraint pet_pet_type_fk foreign key (type_id) references pet_type (id);
 
 INSERT INTO pet_type (id, name) VALUES (1, 'Cat');

--- a/storm-spring-boot-starter/src/main/java/st/orm/spring/boot/autoconfigure/StormAutoConfiguration.java
+++ b/storm-spring-boot-starter/src/main/java/st/orm/spring/boot/autoconfigure/StormAutoConfiguration.java
@@ -46,6 +46,8 @@ import st.orm.template.ORMTemplate;
 @EnableConfigurationProperties(StormProperties.class)
 public class StormAutoConfiguration {
 
+    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StormAutoConfiguration.class);
+
     /**
      * Creates an {@link ORMTemplate} bean using the provided {@link DataSource} and {@link StormProperties}.
      *
@@ -68,20 +70,29 @@ public class StormAutoConfiguration {
 
     /**
      * Runs schema validation after all singleton beans have been fully initialized. This guarantees that migration
-     * tools like Flyway and Liquibase have completed their work before validation occurs.
+     * tools like Flyway and Liquibase (or any bean-based migration mechanism) have completed their work before
+     * validation occurs.
+     *
+     * <p>Validation defaults to {@code fail}: every entity and projection is validated against the live database
+     * schema and mismatches abort startup. Set {@code storm.validation.schema_mode} to {@code warn} or {@code none}
+     * to relax or opt out.</p>
      */
     @Bean
     SmartInitializingSingleton stormSchemaValidator(DataSource dataSource, StormProperties properties) {
         return () -> {
-            String schemaMode = properties.getValidation().getSchemaMode();
-            if (schemaMode == null || schemaMode.isBlank() || "none".equalsIgnoreCase(schemaMode.trim())) {
+            String configured = properties.getValidation().getSchemaMode();
+            String schemaMode = configured == null || configured.isBlank() ? "fail" : configured.trim();
+            if ("none".equalsIgnoreCase(schemaMode)) {
                 return;
             }
             SchemaValidator validator = SchemaValidator.of(dataSource);
-            if ("fail".equalsIgnoreCase(schemaMode.trim())) {
+            if ("fail".equalsIgnoreCase(schemaMode)) {
                 validator.validateOrThrow();
-            } else if ("warn".equalsIgnoreCase(schemaMode.trim())) {
+                logger.info("Storm schema validation passed (mode=fail).");
+            } else if ("warn".equalsIgnoreCase(schemaMode)) {
                 validator.validateOrWarn();
+            } else {
+                logger.warn("Unknown schema validation mode: '{}'. Expected 'none', 'warn', or 'fail'.", schemaMode);
             }
         };
     }

--- a/storm-spring-boot-starter/src/main/java/st/orm/spring/boot/autoconfigure/StormProperties.java
+++ b/storm-spring-boot-starter/src/main/java/st/orm/spring/boot/autoconfigure/StormProperties.java
@@ -166,15 +166,21 @@ public class StormProperties {
          * <p>When set to {@code "fail"}, validation errors cause startup to fail with a {@code PersistenceException}.
          * When set to {@code "warn"}, errors are logged as warnings; startup continues.
          * When set to {@code "none"}, record validation is skipped entirely.</p>
+         *
+         * <p>Defaults to {@code "fail"} when not set. Validation runs after all singleton beans are initialized,
+         * so migrations executed by beans such as Flyway or Liquibase complete first.</p>
          */
         private String recordMode;
 
         /**
-         * Schema validation mode: {@code "none"} (default), {@code "warn"}, or {@code "fail"}.
+         * Schema validation mode: {@code "none"}, {@code "warn"}, or {@code "fail"} (default).
          *
          * <p>When set to {@code "fail"}, schema validation runs at startup and blocks if mismatches are found.
          * When set to {@code "warn"}, mismatches are logged at WARN level but startup continues.
          * When set to {@code "none"}, schema validation is skipped entirely.</p>
+         *
+         * <p>Defaults to {@code "fail"} when not set. Validation runs after all singleton beans are initialized,
+         * so migrations executed by beans such as Flyway or Liquibase complete first.</p>
          */
         private String schemaMode;
 

--- a/storm-spring-boot-starter/src/test/java/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.java
+++ b/storm-spring-boot-starter/src/test/java/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.java
@@ -19,15 +19,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import st.orm.EntityCallback;
 import st.orm.spring.RepositoryBeanFactoryPostProcessor;
 import st.orm.template.ORMTemplate;
 
+@ExtendWith(OutputCaptureExtension.class)
 class StormAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
@@ -173,6 +177,22 @@ class StormAutoConfigurationTest {
     }
 
     @Test
+    void schemaValidationDefaultsToFailMode(CapturedOutput output) {
+        // No schema-mode property: validation must run in fail mode by default.
+        // With no entities on the test classpath there is nothing to reject, so
+        // the success log proves the default dispatched into the fail branch.
+        contextRunner
+                .withPropertyValues(
+                        "spring.datasource.url=jdbc:h2:mem:schemaDefaultTest;DB_CLOSE_DELAY=-1",
+                        "spring.datasource.driver-class-name=org.h2.Driver"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(ORMTemplate.class);
+                    assertThat(output).contains("Storm schema validation passed (mode=fail).");
+                });
+    }
+
+    @Test
     void schemaValidationWarnModeShouldNotPreventContextStartup() {
         contextRunner
                 .withPropertyValues(
@@ -256,7 +276,8 @@ class StormAutoConfigurationTest {
     }
 
     @Test
-    void schemaValidationEmptyModeShouldNotRunValidation() {
+    void schemaValidationEmptyModeFallsBackToFailDefault(CapturedOutput output) {
+        // An empty schema-mode is treated as unset and falls back to the fail default.
         contextRunner
                 .withPropertyValues(
                         "spring.datasource.url=jdbc:h2:mem:schemaEmptyTest;DB_CLOSE_DELAY=-1",
@@ -265,6 +286,7 @@ class StormAutoConfigurationTest {
                 )
                 .run(context -> {
                     assertThat(context).hasSingleBean(ORMTemplate.class);
+                    assertThat(output).contains("Storm schema validation passed (mode=fail).");
                 });
     }
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -18,7 +18,7 @@
 > GitHub: https://github.com/storm-orm/storm-framework
 > License: Apache 2.0
 
-# Generated: 2026-07-04T08:28:47Z
+# Generated: 2026-07-04T11:53:49Z
 
 ========================================
 ## Source: index.md
@@ -1189,7 +1189,7 @@ data class User(
 
 [Java]
 
-In Java, record components are nullable by default. Use `@Nonnull` to mark fields that must always have a value. Primitive types (`int`, `long`, etc.) are inherently non-nullable. As with Kotlin, nullability determines JOIN behavior: a non-nullable `@FK` field produces an `INNER JOIN`, while a `@Nullable` one produces a `LEFT JOIN`.
+In Java, record components are nullable by default. Use `@Nonnull` to mark fields that must always have a value — Storm recognizes `jakarta.annotation.Nonnull`, `javax.annotation.Nonnull`, and JSpecify's `org.jspecify.annotations.NonNull` on the component; other null-marker annotations (Lombok, JetBrains, Spring) are not recognized, and JSpecify `@NullMarked` scope defaults are not applied. `@PK` fields and primitive types (`int`, `long`, etc.) are inherently non-nullable. As with Kotlin, nullability determines JOIN behavior: a non-nullable `@FK` field produces an `INNER JOIN`, while a nullable one — including a bare `@FK` field without `@Nonnull` — produces a `LEFT JOIN`. If the FK column is `NOT NULL` in the database, annotate the field with `@Nonnull`, or joins silently degrade to `LEFT JOIN`.
 
 ```java
 record User(@PK Integer id,
@@ -12370,7 +12370,7 @@ The `\{expression}` syntax is Java's string template interpolation. The `RAW` pr
 
 Java String Templates are a **preview feature** that is still evolving in the JDK. Storm is a forward-looking framework, and String Templates are the best way to write SQL in Java that is both readable and injection-safe by design.
 
-Rather than wait for the feature to stabilize, Storm ships with String Template support today. The Java API is production-ready from a quality perspective, but its API surface will adapt as String Templates move toward a stable release.
+Rather than wait for the feature to stabilize, Storm ships with String Template support today. The Java API is production-ready from a quality perspective, but its API surface will adapt as String Templates move toward a stable release. Once the redesigned string templates land in the JDK as a stable feature, the Java API moves front and center alongside Kotlin — same first-class status, no preview flags, no version pin.
 
 Only `storm-java21` depends on this preview feature. The core framework and the Kotlin API are unaffected.
 
@@ -14866,13 +14866,15 @@ Controls whether record (structural) validation runs when Storm first encounters
 
 ### storm.validation.schema_mode {#schema-validation}
 
-Controls whether schema validation runs at startup (Spring Boot only; for programmatic use, see [Validation](validation.md#programmatic-api)).
+Controls whether schema validation runs at startup (Spring Boot and Ktor; for programmatic use, see [Validation](validation.md#programmatic-api)).
 
 | Value | Behavior |
 |-------|----------|
-| `none` | Schema validation is skipped (default). |
+| `none` | Schema validation is skipped. |
 | `warn` | Mismatches are logged at WARN level; startup continues. |
-| `fail` | Mismatches cause startup to fail with a `PersistenceException`. |
+| `fail` | Mismatches cause startup to fail with a `PersistenceException` (default). |
+
+Validation runs after all singleton beans are initialized, so migrations executed by beans such as Flyway or Liquibase complete first. The Ktor plugin behaves the same way; run migrations in its `migration { }` hook.
 
 ### storm.validation.strict
 

--- a/website/static/skills/storm-demo.md
+++ b/website/static/skills/storm-demo.md
@@ -43,12 +43,10 @@ Set up the project structure quickly and without much commentary:
 - Docker Compose for the database (see below)
 - The `storm-test` dependency for verification (`st.orm:storm-test` as test scope)
 
-**Ktor repository registration (required):** After `install(Storm)`, register all repository interfaces using `stormRepositories { }`. This must be called before `routing { }`. Without it, `call.repository<T>()` throws at runtime. Use package-based registration to auto-discover all repositories:
+**Ktor repositories (automatic since 1.12):** `install(Storm)` auto-registers every repository interface from the compile-time index, created eagerly so a broken definition fails at startup. No `stormRepositories { }` block is needed; `repository<T>()` (also bare in route handlers via the `RoutingContext` extension) resolves anywhere. Run migrations in the plugin's `migration { }` hook so the default fail-mode schema validation sees the migrated schema:
 ```kotlin
-install(Storm) { this.dataSource = dataSource }
-
-stormRepositories {
-    register()  // auto-discovers all repositories from the compile-time index
+install(Storm) {
+    migration { dataSource -> Flyway.configure().dataSource(dataSource).load().migrate() }
 }
 
 routing { ... }

--- a/website/static/skills/storm-repository-kotlin.md
+++ b/website/static/skills/storm-repository-kotlin.md
@@ -62,11 +62,11 @@ class CityService(private val cities: EntityRepository<City, Int>) {
 
 ### Ktor
 
-Access repositories via `call.repository<T>()` after registering them with `stormRepositories { }`:
+Repositories from the compile-time index are registered automatically when the `Storm` plugin is installed (since 1.12); access them with a bare `repository<T>()` in route handlers:
 
 ```kotlin
 get("/users/{email}") {
-    val users = call.repository<UserRepository>()
+    val users = repository<UserRepository>()
     call.respond(users.findByEmail(call.parameters.getOrFail("email")))
 }
 ```
@@ -461,17 +461,13 @@ class UserService(private val userRepository: UserRepository) {
 ```
 
 ### Ktor
-Register repositories via `stormRepositories { }`, then access them in routes:
+Repositories auto-register at `install(Storm)` from the compile-time index (narrow with `repositories("com.myapp")` in the plugin config, or disable with `autoRegisterRepositories = false`); access them in routes with a bare `repository<T>()`:
 ```kotlin
 fun Application.module() {
     install(Storm)
-    stormRepositories {
-        register(UserRepository::class)       // register individually
-        // or: register("com.myapp.repository") // register all in package
-    }
     routing {
         get("/users/{email}") {
-            val users = call.repository<UserRepository>()
+            val users = repository<UserRepository>()
             call.respond(users.findByEmail(call.parameters.getOrFail("email")))
         }
     }
@@ -530,7 +526,7 @@ Declarative `@Transactional` on service methods also works (standard Spring) for
 
 ```kotlin
 get("/users") {
-    val users = call.repository<UserRepository>()
+    val users = repository<UserRepository>()
     transaction {
         // All operations within the block share the same transaction.
         call.respond(users.findAll())

--- a/website/static/skills/storm-setup.md
+++ b/website/static/skills/storm-setup.md
@@ -65,8 +65,8 @@ Match the compiler plugin suffix to the project's Kotlin version: 2.0.x uses `st
 - Kotlin: `st.orm:storm-ktor`
 - Optionally: `st.orm:storm-ktor-test` (test scope, for `testStormApplication` DSL)
 - Add `com.zaxxer:HikariCP` when using the built-in HOCON-configured DataSource (`storm.datasource.jdbcUrl` etc. in application.conf) — not needed when passing your own DataSource to `install(Storm)`
-- Install with `install(Storm)`, access ORM via `call.orm` in routes
-- Register repositories via `stormRepositories { register(UserRepository::class) }`
+- Install with `install(Storm)`; repositories from the compile-time index auto-register (since 1.12), accessed via a bare `repository<T>()` in routes; `orm`, `entity<T>()`, and `projection<T>()` extensions are available too
+- Run migrations in the plugin's `migration { }` hook so the default fail-mode schema validation sees the migrated schema
 
 ## Getting ORMTemplate
 
@@ -122,7 +122,7 @@ Database dialects (add as runtime dependency):
 - `st.orm:storm-sqlite`
 - `st.orm:storm-h2` (also usable as a runtime dialect, not just for tests)
 
-**Validation on startup:** Storm automatically validates the *structure* of all discovered entity types (PK/FK/inline consistency, cyclic references) when the `ORMTemplate` is created, logging "Successfully validated N Data types for correctness". This does NOT check the database schema. Schema validation is a separate, opt-in step: call `validateSchema()`/`validateSchemaOrThrow()` (e.g. at startup or in a `@StormTest`), or in Ktor set `storm.validation.schemaMode` in the plugin config to run it automatically at startup.
+**Validation on startup:** Storm automatically validates the *structure* of all discovered entity types (PK/FK/inline consistency, cyclic references) when the `ORMTemplate` is created, logging "Successfully validated N Data types for correctness". Schema validation (against the live database) is also on by default in the Spring Boot starters and the Ktor plugin since 1.12: it runs after migrations (after all singletons in Spring; after the `migration { }` hook in Ktor), fails startup on mismatches, and logs "Successfully validated N Data types against the database schema". Set `storm.validation.schema_mode` (Spring) / `storm.validation.schemaMode` (Ktor) to `warn` or `none` to relax or opt out. Programmatic use: `validateSchema()`/`validateSchemaOrThrow()` (e.g. in a `@StormTest`).
 
 After configuring dependencies, remind the user to rebuild so the metamodel classes are generated.
 


### PR DESCRIPTION
## Summary

Schema validation against the live database now runs **by default** (`fail` mode) in both Spring Boot starters and the Ktor plugin. Record (structural) validation was already on by default; this closes the gap so a Storm application refuses to start when its model and its schema disagree.

Migration remains the application's responsibility (Flyway is not mandated), but the integrations now guarantee it can run in the right order:

- **Spring starters**: validation runs via `SmartInitializingSingleton`, after every bean-based migration mechanism (Flyway, Liquibase, or custom beans) has completed and before the application serves traffic.
- **Ktor plugin**: new `migration { dataSource -> ... }` hook runs after the DataSource is available (including the zero-config HOCON pool) and before the template is created and the schema validated.

## Behavior changes

- `storm.validation.schema_mode` (Spring) / `storm.validation.schemaMode` (Ktor) now defaults to `fail`; blank values are treated as unset. Set `none` to opt out or `warn` to relax.
- The Ktor plugin reads its validation mode from the application config when not set in the plugin DSL, matching the starter property.
- On success, `SchemaValidator.validateOrThrow()` logs `Successfully validated N Data types against the database schema.` and the integrations confirm the mode, so a default-on feature is visible in the log.
- Unknown modes now log a warning in the starters (parity with Ktor).

## Test changes

- storm-ktor test compilation now runs the metamodel annotation processor via a `test-kapt` execution, generating the compile-time type index (`META-INF/storm/*.idx`) instead of hand-authored fixtures. This made the schema-validation tests real: they exposed nullability mismatches in the test schema (fixed with `NOT NULL`) and `@JvmRecord` on the test models (removed; kapt cannot stub it and plain data classes are the canonical style).
- New tests: migration hook runs before validation; the fail default aborts startup on a missing schema; the plugin option overrides the config; starters dispatch into fail mode by default (asserted via captured output).
- Suites: storm-core 2244, storm-ktor 38, starters 20 + 16 — all green.

## Docs

`configuration.md` and `ktor-integration.md` updated for the new defaults and the migration hook; AI skills (`storm-demo`, `storm-repository-kotlin`, `storm-setup`) updated for repository auto-registration and the validation defaults; `llms-full.txt` regenerated.

The three example projects have been simplified accordingly (config entries removed, Flyway via the Ktor hook) and verified live.