### PR TITLE
docs(website): render example READMEs inline at /examples/<slug>

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -5,6 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 const stormVersion = require('./plugins/read-storm-version');
 const remarkStormVersion = require('./plugins/remark-storm-version');
 const staticVersionReplace = require('./plugins/static-version-replace');
+const exampleReadmes = require('./plugins/example-readmes');
 
 const config: Config = {
   title: 'Storm Framework',
@@ -26,6 +27,9 @@ const config: Config = {
 
   plugins: [
     [staticVersionReplace, { version: stormVersion }],
+    // Renders the example-project READMEs inline at /examples/<slug>,
+    // fetched from GitHub at build time (see plugins/example-readmes.js).
+    exampleReadmes,
     // Redirect the old root-level doc URLs (which used to serve at `/`) to their
     // new `/docs/...` homes, so existing links, bookmarks, and SEO keep working
     // now that the landing page owns `/`.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,8 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.7.0",
-        "@docusaurus/plugin-client-redirects": "3.9.2",
+        "@docusaurus/plugin-client-redirects": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
+        "marked": "^18.0.5",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -10601,6 +10602,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,7 @@
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/plugin-client-redirects": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
+    "marked": "^18.0.5",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/website/plugins/example-readmes.js
+++ b/website/plugins/example-readmes.js
@@ -1,0 +1,113 @@
+const {marked} = require('marked');
+
+// Build-time fetch of the example-project READMEs, rendered inline at
+// /examples/<slug> so visitors stay in the orm.st funnel (tutorials ->
+// examples -> getting started) and the content is indexable on our domain.
+// The READMEs stay canonical in their repos; the site rebuilds on every docs
+// push and release, which keeps the rendered copies fresh without any manual
+// syncing. Each page shows the clone command and a GitHub link up front.
+
+const GITHUB_ORG = 'storm-orm';
+
+const EXAMPLES = [
+  {
+    slug: 'kotlin-ktor',
+    repo: 'storm-example-kotlin-ktor',
+    title: 'Storm Movies · Kotlin + Ktor',
+    description:
+      'A server-rendered movie browser on Ktor 3 with the Storm plugin: ' +
+      'automatic repository registration, Koin wiring via stormModule(), ' +
+      'coroutine-native transactions, kotlinx.serialization for the JSON ' +
+      'APIs, and Playwright-driven interface tests.',
+    chips: ['Kotlin', 'Ktor 3', 'Koin', 'PostgreSQL'],
+  },
+  {
+    slug: 'kotlin-spring-boot',
+    repo: 'storm-example-kotlin-spring-boot-4',
+    title: 'Storm Movies · Kotlin + Spring Boot 4',
+    description:
+      'The same movie browser on Spring Boot 4 with immutable data-class ' +
+      'entities, metamodel-based queries, coroutine-native transactions, and ' +
+      'schema validation. PostgreSQL with Flyway migrations; repository tests ' +
+      'on H2 with storm-test.',
+    chips: ['Kotlin', 'Spring Boot 4', 'PostgreSQL'],
+  },
+  {
+    slug: 'java-spring-boot',
+    repo: 'storm-example-java-spring-boot-4',
+    title: 'Storm Movies · Java + Spring Boot 4',
+    description:
+      'The Java flavor on Java 21: immutable record entities, ' +
+      'metamodel-based queries, Spring-managed transactions, and schema ' +
+      'validation. No JPA, no proxies, no persistence context.',
+    chips: ['Java 21', 'Spring Boot 4', 'PostgreSQL'],
+  },
+];
+
+async function fetchReadme(repo) {
+  const url = `https://raw.githubusercontent.com/${GITHUB_ORG}/${repo}/main/README.md`;
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} for ${url}`);
+      }
+      return await response.text();
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+    }
+  }
+  throw new Error(
+    `example-readmes: failed to fetch ${url} after 3 attempts: ${lastError}`
+  );
+}
+
+function renderReadme(markdown, repo) {
+  let html = marked.parse(markdown, {gfm: true});
+  // The page hero owns the title; drop the README's own <h1>.
+  html = html.replace(/<h1[^>]*>[\s\S]*?<\/h1>\s*/, '');
+  // Repo-relative links and images only resolve on GitHub; point them there.
+  html = html.replace(
+    /(href|src)="(?!https?:\/\/|#|mailto:)([^"]+)"/g,
+    (match, attr, target) => {
+      const path = target.replace(/^\.?\//, '');
+      return attr === 'src'
+        ? `src="https://raw.githubusercontent.com/${GITHUB_ORG}/${repo}/main/${path}"`
+        : `href="https://github.com/${GITHUB_ORG}/${repo}/blob/main/${path}"`;
+    }
+  );
+  return html;
+}
+
+module.exports = function exampleReadmesPlugin() {
+  return {
+    name: 'example-readmes',
+
+    async loadContent() {
+      const readmes = await Promise.all(
+        EXAMPLES.map((example) => fetchReadme(example.repo))
+      );
+      return EXAMPLES.map((example, index) => ({
+        ...example,
+        html: renderReadme(readmes[index], example.repo),
+      }));
+    },
+
+    async contentLoaded({content, actions}) {
+      for (const example of content) {
+        const dataPath = await actions.createData(
+          `example-${example.slug}.json`,
+          JSON.stringify(example)
+        );
+        actions.addRoute({
+          path: `/examples/${example.slug}`,
+          component: '@site/src/components/examples/ExampleReadmePage.js',
+          modules: {example: dataPath},
+          exact: true,
+        });
+      }
+    },
+  };
+};

--- a/website/src/components/examples/ExampleReadmePage.js
+++ b/website/src/components/examples/ExampleReadmePage.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import {TUT_CSS, navHtml, FOOT_HTML} from '../tutorial/tutorialTheme';
+
+// Route component for the /examples/<slug> pages added by the
+// example-readmes plugin. Receives the example (title, description, chips,
+// repo, rendered README html) as a JSON module prop and renders it in the
+// landing-page style: hero with the clone command and GitHub link, then the
+// README content.
+
+const README_CSS = `
+  .storm-tut .readme{max-width:860px;margin:0 auto;padding:0 24px 48px}
+  .storm-tut .readme h2{font-size:24px;letter-spacing:-.02em;font-weight:700;margin:56px 0 0}
+  .storm-tut .readme h2::before{content:"// ";font-family:var(--mono);font-size:15px;font-weight:500;color:var(--accent)}
+  .storm-tut .readme h3{font-size:18px;letter-spacing:-.01em;font-weight:650;margin:36px 0 0;color:var(--text)}
+  .storm-tut .readme a{color:var(--accent)}
+  .storm-tut .readme a:hover{text-decoration:underline}
+  .storm-tut .readme a code{color:var(--accent)}
+  .storm-tut .readme pre{background:var(--panel);border:1px solid var(--border);border-radius:12px;
+    padding:16px 20px;margin:18px 0 0;overflow-x:auto;
+    box-shadow:0 30px 70px -50px rgba(0,0,0,.8)}
+  .storm-tut .readme pre code{font-family:var(--mono);font-size:13px;line-height:1.7;color:var(--plain);
+    background:none;border:0;padding:0;white-space:pre}
+  .storm-tut .readme table{border-collapse:collapse;margin:18px 0 0;font-size:14.5px;line-height:1.6}
+  .storm-tut .readme th,.storm-tut .readme td{border:1px solid var(--border);padding:9px 14px;text-align:left;color:var(--body)}
+  .storm-tut .readme th{color:var(--text);font-weight:600;background:var(--panel)}
+  .storm-tut .readme blockquote{margin:18px 0 0;padding:2px 20px;border-left:3px solid var(--accent);
+    background:var(--panel);border-radius:0 10px 10px 0}
+
+  .storm-tut .exhero{max-width:860px;margin:0 auto;padding:54px 24px 10px}
+  .storm-tut .exhero .crumbs{font-family:var(--mono);font-size:12px;color:var(--faint);letter-spacing:.04em}
+  .storm-tut .exhero .crumbs a:hover{color:var(--muted)}
+  .storm-tut .exhero .crumbs .sep{margin:0 9px;color:#2c2c36}
+  .storm-tut .exhero h1{font-size:clamp(30px,4.5vw,44px);line-height:1.08;letter-spacing:-.03em;font-weight:800;margin:18px 0 0}
+  .storm-tut .exhero .dek{color:var(--muted);font-size:16.5px;line-height:1.66;margin:18px 0 0;max-width:700px}
+  .storm-tut .exhero .meta{display:flex;gap:8px;margin-top:22px;flex-wrap:wrap}
+  .storm-tut .exhero .meta span{font-family:var(--mono);font-size:11.5px;color:var(--faint);border:1px solid var(--border-soft);border-radius:999px;padding:5px 13px}
+  .storm-tut .getit{display:flex;gap:12px;margin-top:26px;flex-wrap:wrap;align-items:stretch}
+  .storm-tut .clonebar{display:flex;align-items:center;gap:10px;font-family:var(--mono);font-size:13px;color:var(--plain);
+    background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:0 18px;min-height:44px;overflow-x:auto;white-space:nowrap}
+  .storm-tut .clonebar .dollar{color:var(--green);user-select:none}
+`;
+
+export default function ExampleReadmePage({example}) {
+  const {slug, repo, title, description, chips, html} = example;
+  const url = `https://orm.st/examples/${slug}/`;
+  const githubUrl = `https://github.com/storm-orm/${repo}`;
+  const pageTitle = `${title} · Storm Example Projects`;
+
+  const body = `
+${navHtml('examples')}
+
+<div class="exhero">
+  <div class="crumbs"><a href="/examples/">Examples</a><span class="sep">/</span>${title}</div>
+  <h1>${title}</h1>
+  <p class="dek">${description}</p>
+  <div class="meta">${chips.map((chip) => `<span>${chip}</span>`).join('')}</div>
+  <div class="getit">
+    <div class="clonebar"><span class="dollar">$</span>git clone ${githubUrl}.git</div>
+    <a class="btn" href="${githubUrl}">View on GitHub →</a>
+  </div>
+</div>
+
+<div class="readme">${html}</div>
+
+${FOOT_HTML}
+`;
+
+  return (
+    <>
+      <Head>
+        <html lang="en" />
+        <title>{pageTitle}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={url} />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={description} />
+        <meta name="twitter:title" content={pageTitle} />
+        <meta name="twitter:description" content={description} />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <style dangerouslySetInnerHTML={{__html: TUT_CSS + README_CSS}} />
+      <div className="storm-tut" dangerouslySetInnerHTML={{__html: body}} />
+    </>
+  );
+}

--- a/website/src/pages/examples/index.js
+++ b/website/src/pages/examples/index.js
@@ -5,7 +5,8 @@ import {TUT_CSS, navHtml, FOOT_HTML} from '../../components/tutorial/tutorialThe
 // The example-projects hub at /examples, rendered in the landing-page style
 // (see tutorialTheme.js). Three complete movie-browser applications built on
 // the public IMDB dataset: the same app on Ktor and Spring Boot, in Kotlin
-// and Java. Each card links to its GitHub repository.
+// and Java. Each card links to its detail page (README rendered inline by
+// the example-readmes plugin, with the clone command and GitHub link).
 
 const TITLE = 'Storm Example Projects · Complete applications built with Storm';
 const DESC =
@@ -23,20 +24,20 @@ ${navHtml('examples')}
 
 <div class="shead" id="projects"><span class="mark">//</span>Example projects<span class="sdesc">Server-rendered movie browsers: entities, repositories, projections, pagination, transactions, and tests in a working application.</span></div>
 <div class="cards">
-  <a class="tcard" href="https://github.com/storm-orm/storm-example-kotlin-ktor">
+  <a class="tcard" href="/examples/kotlin-ktor/">
     <div class="tt">Storm Movies · Kotlin + Ktor<span class="arrow">→</span></div>
-    <div class="td">A server-rendered movie browser on Ktor 3 with the Storm plugin: automatic repository registration, coroutine-native transactions, kotlinx.serialization for the JSON APIs, and Playwright-driven interface tests.</div>
-    <div class="tm"><span>GitHub</span><span>Kotlin</span><span>Ktor</span></div>
+    <div class="td">A server-rendered movie browser on Ktor 3 with the Storm plugin: automatic repository registration, Koin wiring via stormModule(), coroutine-native transactions, kotlinx.serialization for the JSON APIs, and Playwright-driven interface tests.</div>
+    <div class="tm"><span>Kotlin</span><span>Ktor 3</span><span>Koin</span></div>
   </a>
-  <a class="tcard" href="https://github.com/storm-orm/storm-example-kotlin-spring-boot-4">
+  <a class="tcard" href="/examples/kotlin-spring-boot/">
     <div class="tt">Storm Movies · Kotlin + Spring Boot 4<span class="arrow">→</span></div>
     <div class="td">The same movie browser on Spring Boot 4 with immutable data-class entities, metamodel-based queries, coroutine-native transactions, and schema validation. PostgreSQL with Flyway migrations; repository tests on H2 with storm-test.</div>
-    <div class="tm"><span>GitHub</span><span>Kotlin</span><span>Spring Boot 4</span></div>
+    <div class="tm"><span>Kotlin</span><span>Spring Boot 4</span></div>
   </a>
-  <a class="tcard" href="https://github.com/storm-orm/storm-example-java-spring-boot-4">
+  <a class="tcard" href="/examples/java-spring-boot/">
     <div class="tt">Storm Movies · Java + Spring Boot 4<span class="arrow">→</span></div>
     <div class="td">The Java flavor on Java 21: immutable record entities, metamodel-based queries, Spring-managed transactions, and schema validation. No JPA, no proxies, no persistence context.</div>
-    <div class="tm"><span>GitHub</span><span>Java 21</span><span>Spring Boot 4</span></div>
+    <div class="tm"><span>Java 21</span><span>Spring Boot 4</span></div>
   </a>
 </div>
 


### PR DESCRIPTION
## Summary

The `/examples/` hub cards used to forward straight to GitHub. They now link to detail pages that render each example project's README inline, keeping visitors in the orm.st funnel and making the content indexable on our domain:

- `/examples/kotlin-ktor/`
- `/examples/kotlin-spring-boot/`
- `/examples/java-spring-boot/`

Each page opens with the title, description, and stack chips, a prominent `git clone` command, and a "View on GitHub" button, followed by the README content styled to match the tutorial pages.

## How it works

- A new `example-readmes` Docusaurus plugin fetches the three READMEs from `raw.githubusercontent.com` at build time (3 retries, fails the build loudly if GitHub is unreachable), so the rendered copies refresh on every site build with no manual syncing.
- Markdown is rendered with `marked` (new dependency). The README's own `<h1>` is stripped (the page hero owns the title) and repo-relative links/images are rewritten to absolute GitHub URLs.
- Routes are added via `addRoute`, so the pages land in the sitemap automatically.

The example repos' READMEs were reworded since they now double as site copy.

## Verification

Built the site and verified all three pages render with the clone command, README content, and sitemap entries; served locally and smoke-tested all routes.