### PR TITLE
docs(website): design blog series, hub filtering, and site polish

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,32 +1,41 @@
-# Getting Started
+# Get Started
 
 Storm is a modern SQL Template and ORM framework for Kotlin 2.0+ and Java 21+. It uses immutable data classes and records instead of proxied entities, giving you predictable behavior, type-safe queries, and high performance.
 
-## Design Philosophy
-
-Storm is built around a simple idea: your data model should be a plain value, not a framework-managed object. In Storm, entities are Kotlin data classes or Java records. They carry no hidden state, no change-tracking proxies, and no lazy-loading hooks. You can create them, pass them across layers, serialize them, compare them by value, and store them in collections without worrying about session scope, detachment, or side effects. What you see in the source code is exactly what exists at runtime.
-
-This stateless design is a deliberate trade-off. Traditional ORMs like JPA/Hibernate give you transparent lazy loading and proxy-based dirty checking, but at the cost of complexity: you must reason about managed vs. detached state, proxy initialization, persistence context boundaries, and cascading rules that interact in subtle ways. Storm avoids all of this. It still performs dirty checking, but by comparing entity state within a transaction rather than through proxies or bytecode manipulation. When you query a relationship, you get the result in the same query. There are no surprises.
-
-Storm is also SQL-first. Rather than abstracting SQL away behind a query language (like JPQL) or a verbose criteria builder, Storm embraces SQL directly. Its SQL Template API lets you write real SQL with type-safe parameter interpolation and automatic result mapping. For common CRUD patterns, the type-safe DSL and repository interfaces provide concise, compiler-checked alternatives, but the full power of SQL is always available when you need it.
-
-The framework is organized around three core abstractions:
-
-- **Entity** is your data model. A Kotlin data class or Java record with a few annotations (`@PK`, `@FK`) that describe its mapping to the database. Storm derives table and column names automatically, so annotations are only needed for primary keys, foreign keys, and cases where the naming convention does not match.
-- **Repository** provides CRUD operations and type-safe queries for a specific entity. You define an interface, write query methods with explicit bodies using the DSL, and Storm handles the rest. No magic method-name parsing, no hidden query generation.
-- **SQL Template** gives you direct access to SQL with type-safe parameter binding and result mapping. You write real SQL, embed parameters and entity types directly in the query string, and get back typed results. This is the escape hatch when the DSL is not enough, and it is a first-class citizen in Storm, not an afterthought.
-
-These abstractions share a common principle: explicit behavior over implicit magic. Every query is visible in the source code. Every relationship is loaded when you ask for it. Every transaction boundary is declared, not inferred. This makes Storm applications straightforward to debug, profile, and reason about.
-
 ## Choose Your Path
 
-Storm supports two ways to get started. Pick the one that fits your workflow.
+Two ways to get started, and both reach the same working setup: follow the guides by hand, or let your AI coding tool do it. Pick whichever fits your workflow.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
-<TabItem value="ai" label="AI-Assisted" default>
+<TabItem value="manual" label="Manual" default>
+
+### Manual Setup
+
+Follow these three steps in order for the fastest path from zero to a working application.
+
+**1. Installation**
+
+Set up your project with the right dependencies, build flags, and optional modules.
+
+**[Go to Installation](installation.md)**
+
+**2. First Entity**
+
+Define your first entity, create an ORM template, and perform insert, read, update, and remove operations.
+
+**[Go to First Entity](first-entity.md)**
+
+**3. First Query**
+
+Write custom queries, build repositories, stream results, and use the type-safe metamodel.
+
+**[Go to First Query](first-query.md)**
+
+</TabItem>
+<TabItem value="ai" label="AI-Assisted">
 
 ### AI-Assisted Setup
 
@@ -57,38 +66,13 @@ Storm's AI workflow includes built-in verification. The AI can run `ORMTemplate.
 See [AI-Assisted Development](ai.md) for the full setup guide, available skills, and MCP server configuration.
 
 </TabItem>
-<TabItem value="manual" label="Manual">
-
-### Manual Setup
-
-Follow these three steps in order for the fastest path from zero to a working application.
-
-**1. Installation**
-
-Set up your project with the right dependencies, build flags, and optional modules.
-
-**[Go to Installation](installation.md)**
-
-**2. First Entity**
-
-Define your first entity, create an ORM template, and perform insert, read, update, and remove operations.
-
-**[Go to First Entity](first-entity.md)**
-
-**3. First Query**
-
-Write custom queries, build repositories, stream results, and use the type-safe metamodel.
-
-**[Go to First Query](first-query.md)**
-
-</TabItem>
 </Tabs>
 
 ---
 
 ## What's Next
 
-Once you have completed the getting-started guides, explore the features that match your needs:
+Once you have completed the steps above, explore the features that match your needs:
 
 **Core Concepts:**
 - [Entities](entities.md) -- annotations, nullability, naming conventions

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -141,12 +141,6 @@ const config: Config = {
           position: 'right',
         },
         {
-          type: 'docSidebar',
-          sidebarId: 'docs',
-          position: 'left',
-          label: 'Documentation',
-        },
-        {
           to: '/tutorials/',
           label: 'Tutorials',
           position: 'left',
@@ -155,6 +149,17 @@ const config: Config = {
           to: '/examples/',
           label: 'Examples',
           position: 'left',
+        },
+        {
+          to: '/blog/',
+          label: 'Blog',
+          position: 'left',
+        },
+        {
+          type: 'docSidebar',
+          sidebarId: 'docs',
+          position: 'left',
+          label: 'Documentation',
         },
         {
           href: 'https://github.com/orgs/storm-orm/repositories',
@@ -169,7 +174,7 @@ const config: Config = {
         {
           title: 'Docs',
           items: [
-            {label: 'Getting Started', to: '/docs/getting-started'},
+            {label: 'Get Started', to: '/docs/getting-started'},
             {label: 'Entities', to: '/docs/entities'},
             {label: 'Queries', to: '/docs/queries'},
           ],
@@ -179,6 +184,7 @@ const config: Config = {
           items: [
             {label: 'Tutorials', to: '/tutorials/'},
             {label: 'Example Projects', to: '/examples/'},
+            {label: 'Blog', to: '/blog/'},
             {label: 'GitHub', href: 'https://github.com/storm-orm/storm-framework'},
             {label: 'Maven Central', href: 'https://central.sonatype.com/namespace/st.orm'},
           ],

--- a/website/src/components/blog/blogTheme.js
+++ b/website/src/components/blog/blogTheme.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import {TUT_CSS, navHtml, FOOT_HTML} from '../tutorial/tutorialTheme';
+
+// Shared chrome for the blog articles under `/blog/*`. Reuses the tutorial /
+// landing look (see tutorialTheme.js) so the blog reads as part of the
+// marketing site rather than as docs. Each article file supplies the article
+// body (the `<div class="art">...`); this component wraps it with the nav,
+// footer, fonts, and SEO metadata (including a BlogPosting datePublished so the
+// post dates show up in search results).
+
+export function BlogPage({title, description, slug, dateISO, body}) {
+  const url = `https://orm.st/blog/${slug}`;
+  return (
+    <>
+      <Head>
+        <html lang="en" />
+        <title>{`${title} · Storm Blog`}</title>
+        <meta name="description" content={description} />
+        <link rel="canonical" href={url} />
+        <meta property="og:type" content="article" />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="article:published_time" content={dateISO} />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BlogPosting',
+            headline: title,
+            description,
+            url,
+            mainEntityOfPage: {'@type': 'WebPage', '@id': url},
+            image: 'https://orm.st/img/storm.png',
+            datePublished: dateISO,
+            dateModified: dateISO,
+            author: {'@type': 'Organization', name: 'Storm', url: 'https://github.com/storm-orm'},
+            publisher: {
+              '@type': 'Organization',
+              name: 'Storm',
+              url: 'https://orm.st',
+              logo: {'@type': 'ImageObject', url: 'https://orm.st/img/storm-dark.png'},
+            },
+          })}
+        </script>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <style dangerouslySetInnerHTML={{__html: TUT_CSS}} />
+      <div
+        className="storm-tut"
+        dangerouslySetInnerHTML={{__html: navHtml('blog') + body + FOOT_HTML}}
+      />
+    </>
+  );
+}

--- a/website/src/components/tutorial/tutorialTheme.js
+++ b/website/src/components/tutorial/tutorialTheme.js
@@ -136,9 +136,10 @@ export const navHtml = (active) => `
 <nav><div class="wrap nav">
   <div class="brand"><a class="bhome" href="/"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span></a><span class="tech-tag">Kotlin 2.0–2.4 · Java 21+ · Apache 2.0</span></div>
   <div class="nav-links">
-    <a href="/docs/"${active === 'docs' ? ' class="on"' : ''}>Docs</a>
     <a href="/tutorials/"${active === 'tutorials' ? ' class="on"' : ''}>Tutorials</a>
     <a href="/examples/"${active === 'examples' ? ' class="on"' : ''}>Examples</a>
+    <a href="/blog/"${active === 'blog' ? ' class="on"' : ''}>Blog</a>
+    <a href="/docs/"${active === 'docs' ? ' class="on"' : ''}>Docs</a>
     <a class="gh" href="https://github.com/orgs/storm-orm/repositories">GitHub</a>
     <a href="/docs/getting-started" class="btn primary" style="height:36px">Get started</a>
   </div>
@@ -147,7 +148,7 @@ export const navHtml = (active) => `
 export const FOOT_HTML = `
 <footer><div class="wrap foot">
   <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /></div>
-  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="https://github.com/storm-orm/storm-framework">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
+  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/blog/">Blog</a><a href="https://github.com/storm-orm/storm-framework">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
 </div></footer>`;
 
 export const TUT_CSS = `
@@ -266,9 +267,11 @@ export const TUT_CSS = `
   .storm-tut .tuthero{max-width:1080px;margin:0 auto;padding:64px 24px 6px}
   .storm-tut .tuthero .sub{color:var(--muted);font-size:17.5px;line-height:1.66;margin:20px 0 0;max-width:700px}
   .storm-tut .catnav{display:flex;gap:10px;margin-top:28px;flex-wrap:wrap}
-  .storm-tut .catnav a{font-family:var(--mono);font-size:12.5px;color:var(--muted);border:1px solid var(--border-soft);border-radius:999px;padding:8px 16px;transition:.16s;background:var(--panel-2)}
-  .storm-tut .catnav a:hover{color:var(--accent);border-color:rgba(129,140,248,.4)}
-  .storm-tut .catnav a b{color:var(--faint);font-weight:500;margin-left:7px}
+  .storm-tut .catnav a{font-family:var(--mono);font-size:12.5px;color:#b1b5da;border:1px solid rgba(129,140,248,.20);border-radius:999px;padding:8px 16px;transition:.16s;background:rgba(129,140,248,.07);cursor:pointer}
+  .storm-tut .catnav a:hover{color:#e9eaf7;border-color:rgba(129,140,248,.45);background:rgba(129,140,248,.13)}
+  .storm-tut .catnav a.on{color:#0a0a0f;background:var(--accent);border-color:var(--accent);font-weight:600}
+  .storm-tut .catnav a b{color:rgba(178,182,220,.55);font-weight:500;margin-left:7px}
+  .storm-tut .catnav a.on b{color:rgba(10,10,15,.55)}
   .storm-tut .shead{max-width:1080px;margin:0 auto;padding:52px 24px 0;font-family:var(--mono);font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--text);scroll-margin-top:86px}
   .storm-tut .shead .mark{color:var(--accent);margin-right:10px}
   .storm-tut .shead .sdesc{display:block;margin-top:9px;font-family:var(--sans);font-size:14.5px;letter-spacing:0;text-transform:none;color:var(--muted);line-height:1.6}

--- a/website/src/pages/blog/data-layer-first-principles.js
+++ b/website/src/pages/blog/data-layer-first-principles.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+import {editor, K, T, A, P} from '../../components/tutorial/tutorialTheme';
+
+const TITLE = 'A first-principles approach to a JVM data layer';
+const DESC =
+  'A short walk from the most concise way to work with a database table to a ' +
+  'complete data layer, adding nothing on the way. The smallest typed shape ' +
+  'turns out to be the carrier of your data, and the contract for querying the ' +
+  'relation graph.';
+const SLUG = 'data-layer-first-principles';
+const DATE = '2025-09-30';
+
+const CODE_CITY = [
+  K('data class '), T('City'), P('(\n'),
+  P('    '), A('@PK'), P(' '), K('val '), P('id: '), T('Int'), P(',\n'),
+  P('    '), K('val '), P('name: '), T('String'), P(',\n'),
+  P('    '), K('val '), P('country: '), T('String'), P('\n'),
+  P(')'),
+].join('');
+
+const CODE_USER = [
+  K('data class '), T('User'), P('(\n'),
+  P('    '), A('@PK'), P(' '), K('val '), P('id: '), T('Int'), P(',\n'),
+  P('    '), K('val '), P('name: '), T('String'), P(',\n'),
+  P('    '), A('@FK'), P(' '), K('val '), P('city: '), T('City'), P('\n'),
+  P(')'),
+].join('');
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>A first-principles approach</div>
+  <h1>A first-principles approach to <span class="grad">your data layer</span></h1>
+  <p class="dek">Take the most concise thing you can write to work with a database table, then follow where it leads. Nothing gets added along the way. That one small definition keeps turning out to be the answer to the next problem, and the next, until it adds up to a whole data layer.</p>
+  <div class="meta"><span>September 30, 2025</span><span>Design</span><span>4 min read</span></div>
+
+  <h2>The simplest thing you can write</h2>
+  <p>Start at the bottom. The database owns the data model; the application just needs a concise, typed way to work with it. So what is the least you can write to make a database row usable in application code? Only its shape: a typed, named set of fields. In a modern language that is a record or a data class, and there is a principle hiding in how little that is.</p>
+  ${editor({file: 'City.kt', tag: 'Kotlin', code: CODE_CITY})}
+  <p>The names come from convention, and Kotlin nullability says which values may be absent in application code. That is the entire application-facing shape. The first principle is to keep it exactly this small: nothing more than the data, with no hidden lifecycle, behavior, or framework state attached. Everything that follows, follows from refusing to add to it.</p>
+
+  <h2>It happens to be the perfect carrier</h2>
+  <p>Here is the first thing you get for free. That most concise form, a plain data class, happens to be the ideal way to carry the data around. Nothing is attached to it, so it moves through every layer untouched: out of the repository, into your services, through the controller, out to a serializer, across a thread boundary, and back. You did not design a carrier. You wrote the smallest useful application shape, and it turns out that a carrier is exactly what that is. What you loaded is what you pass.</p>
+
+  <h2>And it queries the whole graph</h2>
+  <p>Then the second thing falls out. A relationship can be part of that shape too. If a user always needs its city, the field is typed as <code>City</code>; if the load should be deferred, it is typed as <code>Ref&lt;City&gt;</code>.</p>
+  ${editor({file: 'User.kt', tag: 'Kotlin', code: CODE_USER})}
+  <p>So relationships live in the shape, and the same definition that carries the data also describes how to query it. ST/ORM generates a metamodel from it, and because the relationships are in the shape, you can follow them across the relation graph: <code>users.findAll(User_.city.name eq "Sunnyvale")</code> reaches from a user to its city in one line, type-checked, with the join derived from the relationship path rather than written by hand at every call site.</p>
+
+  <h2>What falls out of keeping it small</h2>
+  <p>Step back and the picture is simple. The same small shape gives application code a value to pass around, a typed contract for queries, and a path into the relation graph. Those are usually separate pieces you write, map, and keep in sync. In ST/ORM they fall out of one decision: keep the application-facing view of database data small, typed, and free of hidden state.</p>
+
+  <div class="cta">
+    <a href="/docs/getting-started" class="btn primary">Get started →</a>
+    <a href="/docs/first-query" class="btn">See the one-line queries</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/dirty-checking-without-proxies.js
+++ b/website/src/pages/blog/dirty-checking-without-proxies.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+
+const TITLE = 'Dirty checking without proxies';
+const DESC =
+  'You do not need bytecode enhancement or a session-bound proxy to know ' +
+  'what changed on an entity. You need the value before and the value after. ' +
+  'Here is how ST/ORM detects changes with neither.';
+const SLUG = 'dirty-checking-without-proxies';
+const DATE = '2026-03-17';
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>Dirty checking without proxies</div>
+  <h1>Dirty checking <span class="grad">without proxies</span></h1>
+  <p class="dek">Dirty checking is one of the genuinely nice things a traditional ORM does for you: it writes only the columns that changed. The usual objection to value-based ORMs is that you lose it. You do not.</p>
+  <div class="meta"><span>March 17, 2026</span><span>Internals</span><span>4 min read</span></div>
+
+  <h2>How the classic approach works</h2>
+  <p>Hibernate has two ways to know what changed. It can snapshot every managed entity when it loads, and at flush time diff the current state against the snapshot to build the UPDATE. Or it can enhance your bytecode so that setters record which fields were touched. Both are clever, and both are the reason the session has to own your objects: the change tracking is a property of the managed lifecycle, not of the data. That ownership is exactly what gives you detached-state bugs and <a class="tlink" href="/blog/lazyinitializationexception">proxies that outlive their session</a>.</p>
+
+  <h2>How ST/ORM does it</h2>
+  <p>ST/ORM detects changes the obvious way. Inside a transaction, it compares the entity you read with the entity you write, and it issues an UPDATE for only the columns that differ. That is the whole mechanism. No proxy, no bytecode enhancement, no snapshot held by a session, because the two values are all it needs. You read a <code>User</code>, you produce an updated copy, you save it, and ST/ORM writes the delta.</p>
+  <p>Because entities are immutable, producing an updated copy is the natural way to change one anyway, and the before and the after are two distinct values, which is precisely what a diff wants. Immutability pays off twice here. If you save the very same value you read, it is the same object, so reference identity settles the question before a single field is compared: nothing changed, and nothing is written. And when there is a change to inspect, ST/ORM reads the fields through the <a class="tlink" href="/blog/static-metamodel">generated metamodel</a> rather than by reflection, so the comparison is direct, generated access with no runtime lookup in the path.</p>
+
+  <h2>Why the difference matters</h2>
+  <p>The benefit is the same, minimal updates, but the cost structure is completely different. Change detection is now a function of two values rather than a lifecycle you have to keep an entity inside of. The entity outside a transaction is just data. Nothing is tracking it, nothing will flush it, and it cannot go stale in the way a managed object can. You get the ergonomic win of dirty checking without buying the session coupling that usually comes attached to it.</p>
+  <p>This is the pattern for the whole framework in miniature: keep the useful behavior, drop the hidden state that traditionally paid for it.</p>
+
+  <div class="cta">
+    <a href="/docs/dirty-checking" class="btn primary">How dirty checking works →</a>
+    <a href="/blog/entities-should-be-values" class="btn">Entities should be values</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/entities-should-be-values.js
+++ b/website/src/pages/blog/entities-should-be-values.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+
+const TITLE = 'Entities are just data: immutable records, not managed objects';
+const DESC =
+  'In ST/ORM an entity is a plain record: an immutable value with no session ' +
+  'and no hidden state. Here is what that buys you across your application, ' +
+  'without giving up dirty checking or lazy loading.';
+const SLUG = 'entities-should-be-values';
+const DATE = '2025-10-28';
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>Entities are just data</div>
+  <h1>Entities are just <span class="grad">data</span></h1>
+  <p class="dek">In <a class="tlink" href="/blog/why-we-built-storm">the story of how ST/ORM came to be</a>, we kept saying that an entity is a plain record. It sounds almost too simple to matter. It is the decision the rest of the design leans on.</p>
+  <div class="meta"><span>October 28, 2025</span><span>Design</span><span>4 min read</span></div>
+
+  <h2>A value, not an object</h2>
+  <p>A record, or an immutable Kotlin data class, is a value. It has no object identity beyond the fields it holds, and two of them with the same contents are equal. You can copy one, put it in a set, hand it to another thread, or pass it to a serializer, and none of that is risky, because there is nothing hidden to disturb and no lifecycle to violate. What you read in the source is what exists at runtime. An entity in ST/ORM is exactly this, and nothing more. It is the same plain shape we followed to its conclusion in <a class="tlink" href="/blog/data-layer-first-principles">a first-principles look at the data layer</a>.</p>
+
+  <h2>The words you stop needing</h2>
+  <p>A managed entity comes with a vocabulary. Attached and detached. The persistence context. Flush, merge, cascade. None of those words describe your data. They describe the machinery that tracks a mutable object across a session so the framework can work out what changed and when to write it. When the entity is a value, most of that machinery has nowhere to attach itself, and the words quietly leave your codebase. You are left reasoning about data, not about a lifecycle.</p>
+
+  <h2>What that lets you do</h2>
+  <p>Because the entity carries no session and no persistence state, you can pass it anywhere without a second thought: out of the repository, through your services, into a controller, across a coroutine boundary, and back. A service can return an entity without also returning an invisible dependency on an open session. There is no session for it to outlive, so the error that haunts a managed model, the one that fires after the session closes, cannot happen here. You can cache it, because it will not change under you. You can serialize it, because it is only its fields.</p>
+
+  <h2>What you do not give up</h2>
+  <p>Two worries usually surface here, and the answer to both is: nothing you would miss. Immutability does not cost you dirty checking. You change an entity by producing a new copy, and ST/ORM writes only the columns that differ, by comparing the value you saved against the one you read, with no proxy involved. And it does not cost you lazy loading. When deferring a load is the right call, you write the field as a Ref, and loading it is a call you make, in code a reviewer can see. Both are still here. The one thing that changes is that they are explicit instead of hidden, and that is not a price you pay for plain values. It is much of the reason to want them.</p>
+
+  <p>That is the quiet bet behind ST/ORM. The database owns the data model. The application gets plain, typed values it can pass around, copy, test, cache, and serialize without asking what session they belong to. Once an entity is just data, the framework can do less, the code can say more, and the value can be trusted everywhere it goes.</p>
+
+  <div class="cta">
+    <a href="/docs/getting-started" class="btn primary">Get started →</a>
+    <a href="/blog/" class="btn">More from the blog</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/index.js
+++ b/website/src/pages/blog/index.js
@@ -1,0 +1,217 @@
+import React, {useEffect} from 'react';
+import Head from '@docusaurus/Head';
+import {TUT_CSS, navHtml, FOOT_HTML} from '../../components/tutorial/tutorialTheme';
+
+// The blog hub at /blog, rendered in the landing-page style (see
+// tutorialTheme.js) rather than with Docusaurus's built-in blog plugin, so it
+// matches the tutorials and examples. Each article lives next to this file as
+// its own custom page; keep this list newest-first and in sync with them.
+
+const TITLE = 'Storm Blog · Design decisions and deep dives';
+const DESC =
+  'The design decisions behind ST/ORM, deep dives into how it works, and the ' +
+  'thinking that shapes the API. Plain values, explicit SQL, and no hidden ' +
+  'state, argued one decision at a time.';
+
+// Kept newest-first in this array, but rendered oldest-first on the page so the
+// hub reads top to bottom in series order, starting from the origin post.
+const POSTS = [
+  {
+    slug: 'should-you-use-an-orm',
+    date: 'June 9, 2026',
+    tag: 'Opinion',
+    title: "Why shouldn't we use an ORM?",
+    blurb:
+      'The strongest arguments against ORMs are really arguments against ORMs that hide SQL. Take the concealment away and most of the case dissolves.',
+  },
+  {
+    slug: 'why-we-didnt-choose-exposed',
+    date: 'April 14, 2026',
+    tag: 'Comparison',
+    title: "Why we didn't choose Exposed",
+    blurb:
+      'We build in Kotlin, so why not build ST/ORM on JetBrains Exposed? Exposed is excellent at modeling a database. ST/ORM draws the boundary differently: the model stays in the database, and application code gets plain, typed records.',
+  },
+  {
+    slug: 'dirty-checking-without-proxies',
+    date: 'March 17, 2026',
+    tag: 'Internals',
+    title: 'Dirty checking without proxies',
+    blurb:
+      'You do not need bytecode enhancement or a session-bound proxy to write only the columns that changed. You need the value before and the value after.',
+  },
+  {
+    slug: 'static-metamodel',
+    date: 'March 3, 2026',
+    tag: 'Internals',
+    title: 'The static metamodel',
+    blurb:
+      'Every entity gets a companion generated at compile time. It makes column and path references type-checked, and it lets queries and hydration run on generated code instead of reflection.',
+  },
+  {
+    slug: 'three-abstractions',
+    date: 'February 17, 2026',
+    tag: 'Design',
+    title: 'Three abstractions and nothing else',
+    blurb:
+      'Entity, Repository, SQL Template. A model you can hold in your head is a model that does not surprise you.',
+  },
+  {
+    slug: 'stop-hiding-my-sql',
+    date: 'January 20, 2026',
+    tag: 'SQL',
+    title: 'Stop hiding my SQL',
+    blurb:
+      'SQL is the one interface every database and every backend engineer already shares. Type it and keep it in view, do not replace it with a second query language.',
+  },
+  {
+    slug: 'n-plus-one-query-problem',
+    date: 'December 16, 2025',
+    tag: 'Hibernate',
+    title: 'The N+1 problem, and loading you can see',
+    blurb:
+      'You do not fix N+1 by remembering a fetch clause. You fix it by making loading a decision the code shows you, and one you can assert in a test.',
+  },
+  {
+    slug: 'lazyinitializationexception',
+    date: 'November 25, 2025',
+    tag: 'Hibernate',
+    title: "LazyInitializationException, and what it's telling you",
+    blurb:
+      'The most-googled Hibernate error is not a bug in your code. It is a lazy promise coming due after the session closed, and value entities cannot throw it.',
+  },
+  {
+    slug: 'entities-should-be-values',
+    date: 'October 28, 2025',
+    tag: 'Design',
+    title: 'Entities are just data',
+    blurb:
+      'An entity in ST/ORM is a plain record: a value with no session and no hidden state. Here is what that buys you across your application, without giving up dirty checking or lazy loading.',
+  },
+  {
+    slug: 'data-layer-first-principles',
+    date: 'September 30, 2025',
+    tag: 'Design',
+    title: 'A first-principles approach to your data layer',
+    blurb:
+      'The most concise way to describe a table turns out to be the ultimate carrier of your data, and the contract for querying the entire relation graph. Simplicity is the ultimate sophistication.',
+  },
+  {
+    slug: 'why-we-built-storm',
+    date: 'September 2, 2025',
+    tag: 'Origin',
+    title: 'Why we built ST/ORM',
+    blurb:
+      'We used JPA and Hibernate for years and mostly liked them. This is the quieter reason we built a different ORM anyway: 300 tables, and managed entities you cannot pass around without ceremony.',
+  },
+];
+
+const ORDERED = [...POSTS].reverse();
+
+// Distinct categories in series order (first appearance, oldest-first), each
+// with a post count, for the clickable filter bar.
+const CATEGORIES = ORDERED.reduce((acc, p) => {
+  const found = acc.find((c) => c.tag === p.tag);
+  if (found) found.count += 1;
+  else acc.push({tag: p.tag, count: 1});
+  return acc;
+}, []);
+
+const cards = ORDERED.map(
+  (p) => `
+  <a class="tcard" href="/blog/${p.slug}" data-tag="${p.tag}">
+    <div class="tt">${p.title}<span class="arrow">→</span></div>
+    <div class="td">${p.blurb}</div>
+    <div class="tm"><span>${p.date}</span><span>${p.tag}</span></div>
+  </a>`,
+).join('');
+
+// One chip per category. No chip is active by default, so every card shows;
+// wireBlogFilters() applies the selected category and toggles it back off.
+const filterBar = `
+<div class="bfilters">
+  ${CATEGORIES.map(
+    (c) => `<button type="button" class="bchip" data-filter="${c.tag}">${c.tag}<b>${c.count}</b></button>`,
+  ).join('')}
+</div>`;
+
+const BLOG_FILTER_CSS = `
+  .storm-tut .bfilters{display:flex;gap:12px;flex-wrap:wrap;margin-top:28px}
+  .storm-tut .bchip{font-family:var(--mono);font-size:12.5px;color:#b1b5da;border:1px solid rgba(129,140,248,.20);border-radius:999px;padding:8px 16px;background:rgba(129,140,248,.07);cursor:pointer;transition:.16s;line-height:1}
+  .storm-tut .bchip:hover{color:#e9eaf7;border-color:rgba(129,140,248,.45);background:rgba(129,140,248,.13)}
+  .storm-tut .bchip.on{color:#0a0a0f;background:var(--accent);border-color:var(--accent);font-weight:600}
+  .storm-tut .bchip b{color:rgba(178,182,220,.55);font-weight:500;margin-left:7px}
+  .storm-tut .bchip.on b{color:rgba(10,10,15,.55)}
+`;
+
+// Wires the filter chips: clicking one highlights it and shows only the cards
+// whose data-tag matches (an empty filter shows all). Mirrors wireSqlToggles().
+function wireBlogFilters() {
+  const root = document.querySelector('.storm-tut');
+  if (!root) return () => {};
+  const chips = Array.from(root.querySelectorAll('.bchip'));
+  const cardEls = Array.from(root.querySelectorAll('.cards .tcard'));
+  const handlers = [];
+  // No active chip means show everything; an active chip filters to its
+  // category; clicking the active chip again deselects it and shows all.
+  const apply = (filter) => {
+    chips.forEach((c) => c.classList.toggle('on', !!filter && c.getAttribute('data-filter') === filter));
+    cardEls.forEach((card) => {
+      const show = !filter || card.getAttribute('data-tag') === filter;
+      card.style.display = show ? '' : 'none';
+    });
+  };
+  chips.forEach((chip) => {
+    const onClick = () => {
+      const next = chip.classList.contains('on') ? '' : chip.getAttribute('data-filter');
+      apply(next);
+    };
+    chip.addEventListener('click', onClick);
+    handlers.push([chip, onClick]);
+  });
+  return () => handlers.forEach(([chip, fn]) => chip.removeEventListener('click', fn));
+}
+
+const BODY = `
+${navHtml('blog')}
+
+<div class="tuthero">
+  <h1>Ideas behind<br><span class="grad">the framework.</span></h1>
+  <p class="sub">Design decisions, deep dives, and the reasoning that shapes ST/ORM.</p>
+${filterBar}
+</div>
+
+<div class="shead" id="articles"><span class="mark">//</span>Articles<span class="sdesc">Why ST/ORM is built the way it is, and what that means for the code you write.</span></div>
+<div class="cards">
+${cards}
+</div>
+
+${FOOT_HTML}
+`;
+
+export default function Blog() {
+  useEffect(() => wireBlogFilters(), []);
+  return (
+    <>
+      <Head>
+        <html lang="en" />
+        <title>{TITLE}</title>
+        <meta name="description" content={DESC} />
+        <link rel="canonical" href="https://orm.st/blog/" />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={TITLE} />
+        <meta property="og:description" content={DESC} />
+        <meta name="twitter:title" content={TITLE} />
+        <meta name="twitter:description" content={DESC} />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <style dangerouslySetInnerHTML={{__html: TUT_CSS + BLOG_FILTER_CSS}} />
+      <div className="storm-tut" dangerouslySetInnerHTML={{__html: BODY}} />
+    </>
+  );
+}

--- a/website/src/pages/blog/lazyinitializationexception.js
+++ b/website/src/pages/blog/lazyinitializationexception.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+
+const TITLE =
+  "LazyInitializationException: what it means, and why value entities can't throw it";
+const DESC =
+  'LazyInitializationException is the most-googled Hibernate error. It is not ' +
+  'a bug in your code. It is a lazy promise coming due after the session ' +
+  'closed, and value-based entities cannot throw it.';
+const SLUG = 'lazyinitializationexception';
+const DATE = '2025-11-25';
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>LazyInitializationException</div>
+  <h1><span class="grad">LazyInitializationException</span>, and what it's telling you</h1>
+  <p class="dek">It is one of the most searched Hibernate errors, and everyone who uses Hibernate long enough meets it. It is worth understanding what it actually is, because it is not a mistake in your code. It is the model working exactly as designed.</p>
+  <div class="meta"><span>November 25, 2025</span><span>Hibernate</span><span>4 min read</span></div>
+
+  <h2>The error everyone meets</h2>
+  <p>You load an entity in a service method, pass it up to a controller or a template, and something touches a lazy relationship. Out comes LazyInitializationException: could not initialize proxy, no Session. The first few times, you reach for open-session-in-view, or a JOIN FETCH, or mapping to a DTO before you leave the transaction. All of them work. None of them explain what happened.</p>
+
+  <h2>It is not a mistake, it is the model</h2>
+  <p>A lazy association is not data. It is a promise to call the database later. The proxy standing in for the related object holds on to the session that made the promise, and when you touch it, the proxy tries to keep that promise. If the session that backed it has already closed, there is no one left to make the call, so it throws. Read that again, because it is the whole thing. Every workaround you have used is a way of managing the timing of that promise: keep the session open longer, force the load earlier, or copy the data out before the session ends. You are not fixing a bug. You are scheduling around a design.</p>
+
+  <h2>Data cannot throw it</h2>
+  <p>ST/ORM makes a different choice at the root, the one behind <a class="tlink" href="/blog/entities-should-be-values">treating entities as plain data</a>. An entity is a value, fully there when you receive it. A field typed as its entity was loaded in the same query, through a join. A field you want to defer is a Ref, which holds the foreign key and nothing else, and loading it is a call you write, not a trigger you spring. There is no proxy, because there is nothing to stand in for. There is no session for the value to outlive, because the value never belonged to one. You can return it, serialize it, cache it, or hand it to another thread, and none of that can produce a LazyInitializationException, because the conditions that create one are gone.</p>
+
+  <h2>The trade</h2>
+  <p>That is the trade ST/ORM makes. You give up transparent lazy loading, and in return the most reliable error in the Hibernate world stops being something you design around. It is simply not a shape your code can take.</p>
+
+  <div class="cta">
+    <a href="/docs/getting-started" class="btn primary">Get started →</a>
+    <a href="/blog/" class="btn">More from the blog</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/n-plus-one-query-problem.js
+++ b/website/src/pages/blog/n-plus-one-query-problem.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+
+const TITLE = 'The N+1 query problem in ORMs, and loading you can see';
+const DESC =
+  'You do not fix the N+1 query problem by remembering a fetch clause. You fix ' +
+  'it by making loading a decision the code shows you, visible in the type and ' +
+  'in the source.';
+const SLUG = 'n-plus-one-query-problem';
+const DATE = '2025-12-16';
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>The N+1 problem</div>
+  <h1>The N+1 problem, and <span class="grad">loading you can see</span></h1>
+  <p class="dek">The N+1 problem keeps coming back to codebases that have already fixed it more than once. That is not a discipline failure. It is what happens when the default hides queries and the fix is something you have to remember.</p>
+  <div class="meta"><span>December 16, 2025</span><span>Hibernate</span><span>4 min read</span></div>
+
+  <h2>The problem that keeps coming back</h2>
+  <p>Render fifty users with the name of each user's city. Two tables, one foreign key. The list query fetches the users, and then each read of user.city.name runs its own select. One query becomes fifty-one. Nothing in the code, the types, or the compiler warned you, because nothing is broken: the code is correct, and it does exactly what the framework's default asks, which is to load the city the moment you read it. You find out instead from the query log, or from production latency. You fix it with a JOIN FETCH or an entity graph, and those work. Then a few weeks later someone writes a new query for a new screen, forgets the fetch clause, and it is back. The team has fixed this exact problem before. They will fix it again.</p>
+
+  <h2>Why it keeps returning</h2>
+  <p>Because the fix lives in the wrong place. The mapping declares one loading behavior, individual queries override it per call site, and the compiler checks none of it. Every new query is a fresh chance to forget, and forgetting is silent. A default that hides queries, plus an override you have to remember, is a quiet machine for reintroducing the same problem.</p>
+
+  <h2>Put the loading decision in the type</h2>
+  <p>ST/ORM moves the loading decision out of the query and into the entity, as a type. It is the same move behind <a class="tlink" href="/blog/entities-should-be-values">entities being plain data</a>. For a single-valued relationship, a foreign key written as its plain entity is always loaded with the row, through a join: write <code>val city: City</code> and the city comes back with the user. There is no lazy variant of it, so there is nothing to forget, and every caller behaves the same way. When deferring the load is the right call, you say so in the type: write the field as <code>val city: Ref&lt;City&gt;</code> and ST/ORM reads only the foreign key, until you fetch the city on purpose. The choice between the two is visible to the compiler and to the reviewer. If a loop makes that fetch per row, the extra queries are right there in the source, where a reviewer can see them, instead of hidden inside a getter.</p>
+
+  <div class="cta">
+    <a href="/docs/getting-started" class="btn primary">Get started →</a>
+    <a href="/blog/" class="btn">More from the blog</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/should-you-use-an-orm.js
+++ b/website/src/pages/blog/should-you-use-an-orm.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+
+const TITLE = "Why shouldn't we use an ORM? The case for visible SQL";
+const DESC =
+  'The strongest arguments against ORMs are really arguments against ORMs ' +
+  'that hide SQL. Take the concealment away and most of the case dissolves, ' +
+  'which leaves room for a third option.';
+const SLUG = 'should-you-use-an-orm';
+const DATE = '2026-06-09';
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>Why shouldn't we use an ORM?</div>
+  <h1>Why <span class="grad">shouldn't</span> we use an ORM?</h1>
+  <p class="dek">It is a fair question, and the people asking it usually have scars to back it up. But listen closely to the complaints and they are almost never about mapping rows to types. They are usually about everything else the ORM does.</p>
+  <div class="meta"><span>June 9, 2026</span><span>Opinion</span><span>5 min read</span></div>
+
+  <h2>The strongest case against ORMs</h2>
+  <p>Let us make the argument properly, because it deserves it. ORMs hide the query, so you cannot see what runs against your database. They make performance opaque, so an <a class="tlink" href="/blog/n-plus-one-query-problem">N+1</a> or a missing index surfaces in production instead of in review. In the JPA world, they often put JPQL or a criteria API between you and the SQL you already know, and then abandon it the moment you need something it cannot express. And they couple your objects to a session lifecycle, which is where <a class="tlink" href="/blog/lazyinitializationexception">a whole genre of runtime errors</a> comes from.</p>
+  <p>There is truth in all of those complaints. If that were the whole story, the answer would be simple: drop the ORM and write SQL by hand.</p>
+
+  <h2>Notice what the complaints have in common</h2>
+  <p>None of them is about mapping. Connecting a plain record to a table, binding a parameter safely, turning a result row into a typed value: nobody writes an angry post about that part. It is useful and quiet. The common theme is concealment: the query you cannot see, the state you cannot track, the lifecycle you have to remember. The objection to ORMs is really an objection to hiding.</p>
+  <p>That matters, because hiding is not intrinsic to mapping. You can have the ergonomics of an ORM without the concealment. Those two things got bundled together historically, but they do not have to be.</p>
+
+  <h2>A third option</h2>
+  <p>ST/ORM keeps the useful half and drops the resented half. It maps rows to <a class="tlink" href="/blog/entities-should-be-values">plain values</a> and keeps the mapping concise by convention, so you are not hand-writing result mapping or annotating every column. But the SQL stays in view. There is a type-safe DSL for the boring, high-volume queries, and real SQL templates for the queries where SQL should stay SQL, with type-checked column references and parameters bound automatically. There is no JPQL to learn and no proxy to outlive.</p>
+  <p>So the answer to "why shouldn't we use an ORM?" is: avoid the kind that hides your SQL, hides your state, and asks you to reason about a lifecycle you cannot see. That is a real position, and we agree with it. It is also the kind of ORM we chose not to build.</p>
+
+  <div class="cta">
+    <a href="/docs/sql-templates" class="btn primary">See SQL templates →</a>
+    <a href="/blog/stop-hiding-my-sql" class="btn">Stop hiding my SQL</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/static-metamodel.js
+++ b/website/src/pages/blog/static-metamodel.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+
+const TITLE = 'The static metamodel behind ST/ORM: type-safe queries without reflection';
+const DESC =
+  'ST/ORM generates a static metamodel from each entity at compile time. It ' +
+  'makes column and path references type-checked, and it lets queries and ' +
+  'hydration run on generated code instead of reflection.';
+const SLUG = 'static-metamodel';
+const DATE = '2026-03-03';
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>The static metamodel</div>
+  <h1>The static <span class="grad">metamodel</span></h1>
+  <p class="dek">Every entity you write gets a generated metamodel class, produced at compile time. It is a quiet piece of the design, and it is where type safety and speed turn out to be the same decision.</p>
+  <div class="meta"><span>March 3, 2026</span><span>Internals</span><span>4 min read</span></div>
+
+  <h2>A generated metamodel class</h2>
+  <p>For an entity like <code>City</code>, ST/ORM generates a small metamodel class, <code>City_</code>, at compile time. There is nothing in it you write by hand. The metamodel does not define the data model; it exposes the database-backed shape of the entity to application code. From that shape it derives one typed handle per field, and one per relationship, standing in for the columns and the paths you can reach from that row. It is a companion to the entity, regenerated whenever the entity changes, so it never drifts from the thing it describes.</p>
+
+  <h2>Type safety you cannot forget to ask for</h2>
+  <p>Because those handles are real, typed code, the compiler checks every reference you build a query from. <code>User_.city.name eq "Sunnyvale"</code> is not a string that happens to match a column. It is a path the compiler knows, so a renamed field, a broken path, or a wrong type is a build error, not something you find in production. This is the same generated metamodel that lets <a class="tlink" href="/blog/data-layer-first-principles">a relationship become a query across the graph</a>, and the same one that keeps <a class="tlink" href="/blog/stop-hiding-my-sql">real SQL templates checked</a> against known fields and types. You do not opt in to the safety. It is the only way the references exist.</p>
+
+  <h2>Generated paths, not reflection</h2>
+  <p>The other half is what does not happen at runtime. Many ORMs discover your fields by reflection: they ask the class, while the program runs, what it has, then read and write it through that reflective handle. It works, but it is slower than plain field access, and it moves a class of errors from the compiler to the first request that reaches the path. Because ST/ORM already holds the metamodel as generated code, none of that is necessary. The paths are known ahead of time, so reading and writing a field is direct, generated access, with no per-row reflective lookup in the way.</p>
+
+  <h2>Where it pays off: hydration</h2>
+  <p>The clearest place you feel this is hydration, turning a result row into an entity. That happens for every row of every query, so it is the part that has to be fast. With a generated metamodel, hydration is code-generated too: each column is read through a known path and lands in the right constructor argument, without asking the class at runtime what to do with it. There is no per-row reflection to pay for, so the mapping runs close to the cost of the work itself.</p>
+
+  <h2>Why it matters</h2>
+  <p>The point is that type safety and performance came from one decision, not from two separate features you have to balance. Generate the model's shape once, at compile time, and the compiler can check your queries while the runtime skips reflection entirely. Everything downstream, from a query predicate to change detection, gets to stand on generated paths instead of runtime discovery. It is a small piece of generated code, but almost every part of the data layer gets to lean on it.</p>
+
+  <div class="cta">
+    <a href="/docs/metamodel" class="btn primary">The metamodel →</a>
+    <a href="/blog/" class="btn">More from the blog</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/stop-hiding-my-sql.js
+++ b/website/src/pages/blog/stop-hiding-my-sql.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+import {editor, K, T, S, C, F, P} from '../../components/tutorial/tutorialTheme';
+
+const TITLE = 'Stop hiding my SQL: why ORM queries should stay visible';
+const DESC =
+  'SQL is the one interface every relational database and every backend ' +
+  "engineer already shares. An ORM's job is to make it type-safe, not to " +
+  'replace it with a second query language.';
+const SLUG = 'stop-hiding-my-sql';
+const DATE = '2026-01-20';
+
+const CODE_SQL_TEMPLATE = [
+  C('// Only RANK() OVER is raw SQL; the columns and table are typed\n'),
+  K('data class '), T('RankedCity'), P('('), K('val '), P('name: '), T('String'), P(', '), K('val '), P('rank: '), T('Long'), P(')\n\n'),
+  K('val '), P('ranked = orm.'), F('query'), P(' { '), S('"""'), P('\n'),
+  P('    '), K('SELECT'), P(' '), T('\${City_.name}'), P(', '), K('RANK'), P('() '), K('OVER'), P(' ('), K('ORDER BY'), P(' '), T('\${City_.population}'), P(' '), K('DESC'), P(')\n'),
+  P('    '), K('FROM'), P(' '), T('\${City::class}'), P('\n'),
+  P('    '), K('WHERE'), P(' '), T('\${City_.country}'), P(' = '), T('\$country'), P('\n'),
+  S('"""'), P(' }.'), F('resultList'), P('<'), T('RankedCity'), P('>()'),
+].join('');
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>Stop hiding my SQL</div>
+  <h1><span class="grad">Stop hiding</span> my SQL</h1>
+  <p class="dek">Somewhere along the way, hiding SQL became the default definition of a good ORM. It is worth questioning that, because SQL was rarely the part that caused the pain.</p>
+  <div class="meta"><span>January 20, 2026</span><span>SQL</span><span>4 min read</span></div>
+
+  <h2>The second query language problem</h2>
+  <p>To hide SQL, an ORM gives you something to write instead: JPQL, a criteria builder, or a fluent DSL that models joins and predicates as method calls. A DSL is a good thing to have, and ST/ORM has one. The problem starts when it becomes the only safe path and SQL becomes the unsafe escape hatch, because that path always ends somewhere. You hit an aggregate, a window function, a recursive CTE, or a database-specific feature the abstraction never modeled, and you drop to a native query. At which point you are writing SQL anyway, except now it is a raw string with no type safety, because the safe path only covered the cases that did not need it.</p>
+
+  <h2>SQL was never the weak point</h2>
+  <p>SQL is declarative, portable enough for real work, and understood by almost every backend engineer who works near a relational database. It is one of the most durable interfaces in our field. The weak point in hand-written database code was never the SQL itself. It was the stuff around it: column names as bare strings that no compiler checks, parameters concatenated into the query by hand, result sets mapped to objects by index one brittle line at a time, and mappings that drift silently when the query changes.</p>
+  <p>So fix that part. Leave the SQL alone.</p>
+
+  <h2>Type the SQL, do not bury it</h2>
+  <p>ST/ORM's SQL templates, the piece that <a class="tlink" href="/blog/why-we-built-storm">started the whole project</a>, let you write real SQL with type-safe interpolation and automatic result mapping. Column references go through the generated metamodel, so a renamed field, a broken path, or a wrong type is a compile error, not a runtime surprise. Interpolated values become bind parameters, so a value is never concatenated into the SQL text. Results map to plain data classes and records. Take a window function, the kind of query a DSL will not express for you, and none of the safety goes away:</p>
+  ${editor({file: 'ReportService.kt', tag: 'Kotlin · ST/ORM', code: CODE_SQL_TEMPLATE})}
+  <p>For the boring, high-volume queries there is a concise DSL, so you are not writing SQL for a find-by-id. The DSL is there for the common queries; the template is there when SQL is the clearest language for the job. It is not a trapdoor you fall through when the abstraction fails but a first-class way to work, sitting right next to the DSL, so the full power of your database is always one line away. You get typed references, safe parameters, and automatic mapping, while the SQL stays visible.</p>
+
+  <div class="cta">
+    <a href="/docs/sql-templates" class="btn primary">SQL templates →</a>
+    <a href="/docs/metamodel" class="btn">The metamodel</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/three-abstractions.js
+++ b/website/src/pages/blog/three-abstractions.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+
+const TITLE = 'Three abstractions and nothing else: the ST/ORM model';
+const DESC =
+  'If you cannot hold your ORM’s model in your head, that is not depth, ' +
+  'it is surface area. ST/ORM has three moving parts: Entity, Repository, and ' +
+  'SQL Template.';
+const SLUG = 'three-abstractions';
+const DATE = '2026-02-17';
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>Three abstractions</div>
+  <h1><span class="grad">Three abstractions</span> and nothing else</h1>
+  <p class="dek">There is a kind of framework complexity that gets mistaken for power. If you cannot explain the model on a whiteboard, that is not richness. It is surface area you will be debugging later. ST/ORM has three user-facing concepts, and they are enough to explain the model.</p>
+  <div class="meta"><span>February 17, 2026</span><span>Design</span><span>4 min read</span></div>
+
+  <h2>Entity</h2>
+  <p>The data your application works with. A Kotlin data class or a Java record with a couple of annotations, <code>@PK</code> for the primary key and <code>@FK</code> for a foreign key. ST/ORM connects entities to tables and columns by convention, so annotations show up only where the convention does not fit. An entity carries no hidden state and no behavior. It is <a class="tlink" href="/blog/entities-should-be-values">database-backed data as a plain value</a>, and nothing else.</p>
+
+  <h2>Repository</h2>
+  <p>CRUD operations and type-safe queries for one entity. You define an interface and write the query method bodies with the DSL. There is no method-name parsing that turns <code>findByStatusAndCreatedAtAfter</code> into a hidden query, and no generated query you have to reverse-engineer from a log. If a repository runs a query, you wrote it, and you can read it.</p>
+
+  <h2>SQL Template</h2>
+  <p>Direct access to SQL with type-safe binding and result mapping, for when the DSL is not the right tool: joins, reports, database-specific features, or queries where SQL should stay SQL. It is a first-class citizen that sits beside the DSL, not a trapdoor you fall through when the abstraction runs out. Type references and metamodel columns keep it checked; parameters are bound automatically. It follows the case for <a class="tlink" href="/blog/stop-hiding-my-sql">keeping SQL in view rather than hiding it</a>.</p>
+
+  <h2>Why a small model is the point</h2>
+  <p>There is more underneath, of course: transactions, a static metamodel, change detection, generated code. It is all there to support these three, not to add a fourth concept you have to learn.</p>
+  <p>These three share one principle: visible behavior over framework decisions you have to guess later. No query fires that you did not write, and the SQL each one produces is predictable. Every relationship is loaded when you ask for it. Every transaction boundary is declared, not inferred. The payoff is not just aesthetic. It is that you can teach the whole model to a new engineer in an afternoon, and never have to reconstruct what the framework decided to do on your behalf. A model you can hold in your head is easier to teach, easier to review, and harder for the framework to surprise you with later.</p>
+
+  <div class="cta">
+    <a href="/docs/getting-started" class="btn primary">Get started →</a>
+    <a href="/docs/repositories" class="btn">Repositories</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/why-we-built-storm.js
+++ b/website/src/pages/blog/why-we-built-storm.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+
+const TITLE = 'Why we built ST/ORM';
+const DESC =
+  'We used JPA and Hibernate for years and mostly liked them. This is the ' +
+  'quieter story of why we still built ST/ORM: a backend we had to replace, an ' +
+  'entity model that pushed us toward DTOs, and an idea, sparked by Java ' +
+  'String Templates, for a model we actually wanted to program against.';
+const SLUG = 'why-we-built-storm';
+const DATE = '2025-09-02';
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>Why we built ST/ORM</div>
+  <h1>Why we built <span class="grad">ST/ORM</span></h1>
+  <p class="dek">This is not an ORM horror story. It is the story of how a team that was reasonably happy with its ORM still ended up building something different.</p>
+  <div class="meta"><span>September 2, 2025</span><span>Origin</span><span>6 min read</span></div>
+
+  <h2>We used to reach for Hibernate by default</h2>
+  <p>We still like Hibernate, actually. It served us well for a long time, and it has had a huge impact on the JVM ecosystem. It solved real problems and helped shape the way many applications are built.</p>
+  <p>We also liked where the ecosystem had gone. Modern JPA and Spring Data improved a great deal on what they inherited: a derived repository method turns a simple query into a method name, most of the old boilerplate is gone, and the day-to-day is genuinely pleasant. JPQL we never really liked, though it has its merits. Ask us at the time and we would have said the tools were good, and mostly they were.</p>
+  <p>At the same time, no tool is perfect. As our projects grew larger, Hibernate started to get in our way a bit too often. For the type of systems we were building, the trade-offs became more visible.</p>
+  <p>At some point, one of our teams even chose JdbcTemplate for a new project. That says something. When plain SQL and manual mapping start to feel like a relief, you know the abstraction is costing you more than expected. It feels refreshingly simple at first. Then the application grows, and you quickly remember why higher-level tools were invented in the first place.</p>
+  <p>But none of that was the thing we kept fighting. What wore on us was not the queries, or the boilerplate, or the SQL. It was one level down, in the way the entities themselves behaved, and it only came fully into focus the day we had to start over.</p>
+
+  <h2>The backend we had to replace</h2>
+  <p>That day arrived when we set out to replace a backend that had been with the company since we were still a startup, the kind of application that grows one requirement at a time until it simply has to be rebuilt properly.</p>
+  <p>The scale alone was daunting. Modeling more than 300 tables as entities is a large, careful job, and we had watched the previous model grow heavier over the years. The more the entities referenced one another, the harder it became to stop a simple read from fanning out into many queries or pulling in more of the graph than we wanted. Doing all of that again, from scratch, was not encouraging.</p>
+  <p>But effort was not the real question. A rebuild is the moment you get to ask whether you want to make the same decisions again, and one of them is a question every JPA codebase meets eventually: do you pass entities between your internal components, or convert everything into DTOs?</p>
+  <p>At the edges, for an external API, DTOs make sense on their own. Inside the application you often write them for a narrower reason. An entity is a managed, session-bound instance, and it is not always safe to hand around freely, so you copy it into a DTO to keep that persistence concern from leaking into the rest of your code. That is a lot of packing and unpacking, and we had done it once already. The real question was whether we wanted to do it again.</p>
+
+  <h2>Designed today, it would look different</h2>
+  <p>Underneath all of this, I had been turning over a different question for years. The ORM most of us reach for was designed more than two decades ago, and the languages have moved a long way since. So I kept coming back to the same thought experiment: if you designed it today, from a blank page, what would it look like?</p>
+  <p>Back then you more or less had to build on mutable, managed beans, because that is what the language gave you. Today the language hands you immutable value types for free: Java records and Kotlin data classes, cheap to create, equal by their contents, and safe to pass to any layer or thread without worrying what becomes of them next. With those in hand, a managed, session-bound entity looks less like the natural choice and more like an answer to a constraint the language no longer has. If I were starting today, I would build on the records.</p>
+
+  <h2>The idea, and the model I wanted</h2>
+  <p>The thought experiment turned into a plan when Java String Templates arrived as a preview feature. That was the spark. They let you write a real string, SQL in our case, with typed values embedded directly in it and checked by the compiler. Seeing that, the first piece fell into place: a SQL template engine with row mapping, where your records go into the query and the same records come back out, with nothing to hand-map on either side. String Templates were the catalyst, not a dependency: once we had the shape, we kept it, and it does not require the preview feature at all.</p>
+  <p>And once records go in and come out, a second thing follows that I wanted just as much. You can describe the whole database in its most concise form: small records that map one to one onto your tables, and nothing more. The records describe the mapping, so there is nothing to configure on the side and no second copy of the schema living in a file somewhere. A model that small is a pleasure to work with, and that was part of what we were after.</p>
+  <p>Because you are not laying an abstraction over the database, the record stays true to the actual shape of your tables. And because it was never shaped for one particular query or screen, it is not tied to a single use, so the same record serves across the application. Everything you asked for is already in it, so there is no lazy loading to reason about later.</p>
+  <p>It also carries no session and no persistence state. The database stays in the layer that talks to it, instead of leaking into the rest of your code. That leak was the thing the DTOs had been guarding against, and now there was nothing to guard.</p>
+  <p>The part that had made the rebuild feel so daunting became easier too. Getting all those tables accurate still takes real time, and a wrong type or a missed nullability tends to surface later, at runtime. But an entity is only a plain record, so there is little to get wrong, and you can validate each one against the live schema to confirm it lines up. What had been a slow, careful job became one we could trust.</p>
+  <p>That template engine and its row mapping were where it all started, not where it stopped. We already had plain records and a metamodel that described their columns, and those pieces pointed at the next step on their own. A repository layer followed: CRUD and type-safe queries, checked by the compiler through that same metamodel. It did not feel like adding a feature. It felt like following the model to where it already led.</p>
+  <p>Most of the time you are not writing SQL at all. You are calling type-safe methods over your records, and the real SQL sits underneath, backing every one of them and ready the moment you want to take full control. So the end product is not a SQL API. It is an ORM backed by SQL.</p>
+  <p>So that is how it happened. We did not set out to build another ORM. We set out to build the model we would enjoy programming against, and building the ORM was the natural consequence. We called it ST/ORM.</p>
+
+  <div class="cta">
+    <a href="/docs/getting-started" class="btn primary">Get started →</a>
+    <a href="/blog/" class="btn">More from the blog</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/blog/why-we-didnt-choose-exposed.js
+++ b/website/src/pages/blog/why-we-didnt-choose-exposed.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import {BlogPage} from '../../components/blog/blogTheme';
+
+const TITLE = "Why we didn't choose Exposed for ST/ORM";
+const DESC =
+  "We build in Kotlin, so why didn't we build ST/ORM on JetBrains Exposed? A " +
+  'respectful comparison of Exposed, schema-first design, DAO entities, and ' +
+  "ST/ORM's different boundary.";
+const SLUG = 'why-we-didnt-choose-exposed';
+const DATE = '2026-04-14';
+
+const BODY = `
+<div class="art">
+  <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>Why we didn't choose Exposed</div>
+  <h1>Why we didn't choose <span class="grad">Exposed</span></h1>
+  <p class="dek">We build in Kotlin, so there is a fair question we owe an answer to. JetBrains already makes <a class="tlink" href="https://www.jetbrains.com/help/exposed/" target="_blank" rel="noopener">JetBrains Exposed</a>, a strong and well-liked Kotlin SQL library for exactly our language. Why did we not simply build ST/ORM on that?</p>
+  <div class="meta"><span>April 14, 2026</span><span>Comparison</span><span>4 min read</span></div>
+
+  <h2>A question of boundaries</h2>
+  <p>The answer is less about missing features and more about boundaries. Exposed gives you a strong Kotlin way to model and work with a database. ST/ORM starts from the belief that the data model belongs in the database, and focuses on making that model available to application logic as plain, typed data. It is the same idea behind <a class="tlink" href="/blog/why-we-built-storm">why we built ST/ORM</a> in the first place.</p>
+
+  <h2>Exposed starts from the database</h2>
+  <p>Exposed and the thing we were building start from different first principles, and Exposed's fit the Kotlin story very well. Its center of gravity is the database itself. With its table DSL you describe a whole schema in Kotlin: the tables, the columns, the keys and constraints, and you can drive the database from that description. At modeling a database this way, Exposed is genuinely excellent. It is hard to beat. If your goal is to describe and command a database in idiomatic Kotlin, it is a superb answer.</p>
+
+  <h2>Exposed aims to be the Kotlin way to talk to SQL</h2>
+  <p>That strength comes with a wide aim. Exposed sets out to be the complete Kotlin way to talk to a database, and defining the schema is the part it optimizes for. Writing an application against that schema, day to day, is a slightly different concern, and there the fit is looser. The DSL gives you a type-safe way to write queries, but it hands the results back as rows for you to map into your own types. Across a handful of tables that is fine. Across a few hundred, it is a lot of mapping to write and keep correct by hand.</p>
+
+  <h2>The DAO API solves part of the mapping problem</h2>
+  <p>Exposed does have an answer for the mapping. Its DAO API turns each row into an entity object you work with directly, and for many projects it closes the gap well. What gave us pause was the kind of abstraction it is. A <a class="tlink" href="/blog/three-abstractions">repository</a> abstracts access: it groups the operations for reading and writing a row, and hands the row back as the same plain record it always was. The DAO abstracts representation: on top of the table it puts a second version of your data, a mutable, transaction-bound entity with lazy proxies and updates that flush on commit. That is a parallel model to keep in sync, and it carries the managed lifecycle we had just spent a rebuild moving away from. Both are useful. Only one adds another model of your data to learn.</p>
+
+  <h2>ST/ORM draws the boundary differently</h2>
+  <p>We come at this from the other side, though not in the way it might sound. Exposed is schema-first. ST/ORM is database-respecting, but application-facing. We agree with Exposed on the thing that matters most: the real data model lives in the database, not in your code. Where we part is that Exposed also gives you the tools to define that model from Kotlin, and we did not want to.</p>
+  <p>We take the schema as the database hands it to us, and put all of our effort into a narrower goal: making that model available to application code as plain, typed records, the same <a class="tlink" href="/blog/entities-should-be-values">values rather than managed objects</a> that shape the rest of ST/ORM. It follows straight from <a class="tlink" href="/blog/data-layer-first-principles">our first-principles approach to the data layer</a>. Exposed lets you model the database beautifully and then reach for the data. We leave the database to define itself, and reach only for the data, as plain records that go into <a class="tlink" href="/blog/stop-hiding-my-sql">real SQL</a> and come back unchanged.</p>
+
+  <h2>Kotlin-first, enterprise JVM second</h2>
+  <p>It is genuinely good that Exposed, after many years, is now fully embraced by JetBrains, with a 1.0 release and real investment behind it. It is their Kotlin-native data library, and it sits close to where JetBrains is heading, which is Kotlin everywhere, multiplatform included. ST/ORM is aimed at a different room. It lives in the enterprise JVM, where Kotlin is a first-class citizen rather than the only one. It became a Kotlin-first platform for a plain reason: we want the Java variant to feel natural in Java too, and the language is still catching up in a few places that matter to an API shaped like this one.</p>
+
+  <h2>A fit decision, not a verdict</h2>
+  <p>So none of this is a case against Exposed. We admire it, enough that our own transactions follow the same programmatic, coroutine-friendly shape JetBrains Exposed made popular. Our decision was a fit decision, not a verdict. Exposed is excellent when you want to model and command a database in Kotlin. ST/ORM optimizes for a different boundary. Once you have committed to that, you are no longer looking for a library to adopt. You are looking at the thing you probably have to build yourself. Both of those can be true at once.</p>
+
+  <div class="cta">
+    <a href="/docs/getting-started" class="btn primary">Get started →</a>
+    <a href="/blog/" class="btn">More from the blog</a>
+  </div>
+</div>`;
+
+export default function Page() {
+  return <BlogPage title={TITLE} description={DESC} slug={SLUG} dateISO={DATE} body={BODY} />;
+}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -146,9 +146,10 @@ const BODY = `
 <nav><div class="wrap nav">
   <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span><span class="tech-tag">Kotlin 2.0–2.4 · Java 21+ · Apache 2.0</span></div>
   <div class="nav-links">
-    <a href="/docs/">Docs</a>
     <a href="/tutorials/">Tutorials</a>
     <a href="/examples/">Examples</a>
+    <a href="/blog/">Blog</a>
+    <a href="/docs/">Docs</a>
     <a class="gh" href="https://github.com/orgs/storm-orm/repositories">GitHub</a>
     <a href="/docs/getting-started" class="btn primary" style="height:36px">Get started</a>
   </div>
@@ -237,7 +238,7 @@ const BODY = `
 
 <footer><div class="wrap foot">
   <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /></div>
-  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="https://github.com/storm-orm/storm-framework">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
+  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/blog/">Blog</a><a href="https://github.com/storm-orm/storm-framework">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
 </div></footer>
 `;
 
@@ -305,14 +306,14 @@ export default function Home() {
 
       { name:'5 · sql', file:'UserService.kt',
         caption:"full SQL when you want it — never locked in",
-        code:[ C("// Need full control of SQL? Plain SQL works — rows map to any data class.\n"),
-          K("data class "),T("RankedCity"),P("("),K("val "),P("name: "),T("String"),P(", "),K("val "),P("population: "),T("Int"),P(", "),K("val "),P("rank: "),T("Long"),P(")\n\n"),
+        code:[ C("// Full control of SQL, with typed columns and tables; rows map to any data class.\n"),
+          K("data class "),T("RankedCity"),P("("),K("val "),P("name: "),T("String"),P(", "),K("val "),P("rank: "),T("Long"),P(")\n\n"),
           K("val "),P("ranked = orm."),F("query"),P(" { "),S('"""'),P("\n"),
-          P("    "),K("SELECT "),P("name, population, RANK() "),K("OVER"),P(" ("),K("ORDER BY "),P("population "),K("DESC"),P(")\n"),
-          P("    "),K("FROM "),P("city\n"),
-          P("    "),K("WHERE "),P("country = "),T("$country"),P("   "),C("-- bind variable\n"),
+          P("    "),K("SELECT "),T("${City_.name}"),P(", RANK() "),K("OVER"),P(" ("),K("ORDER BY "),T("${City_.population}"),P(" "),K("DESC"),P(")\n"),
+          P("    "),K("FROM "),T("${City::class}"),P("\n"),
+          P("    "),K("WHERE "),T("${City_.country}"),P(" = "),T("$country"),P("   "),C("-- typed columns · bound value\n"),
           S('"""'),P(" }."),F("resultList"),P("<"),T("RankedCity"),P(">()\n\n"),
-          C("// Or use the powerful template engine behind the ORM.\n"),
+          C("// Or expand a whole entity to its columns and joins.\n"),
           K("val "),P("users = orm."),F("query"),P(" { "),S('"""'),P("\n"),
           P("    "),K("SELECT "),T("${User::class}"),P("\n"),
           P("    "),K("FROM "),T("${User::class}"),P("\n"),
@@ -373,10 +374,10 @@ export default function Home() {
       '<span class="sqlk">COMMIT</span>\n'+
       '<span class="sqlc">-- onCommit hook runs here, only after COMMIT succeeds</span>',
 
-      '<span class="sqlc">-- plain SQL passes through · $country becomes ?</span>\n'+
-      '<span class="sqlk">SELECT</span> name, population, <span class="sqlk">RANK</span>() <span class="sqlk">OVER</span> (<span class="sqlk">ORDER BY</span> population <span class="sqlk">DESC</span>)\n'+
-      '<span class="sqlk">FROM</span> city\n'+
-      '<span class="sqlk">WHERE</span> country = <span class="sqlq">?</span>\n\n'+
+      '<span class="sqlc">-- typed columns resolve to the city alias · $country becomes ?</span>\n'+
+      '<span class="sqlk">SELECT</span> c.name, <span class="sqlk">RANK</span>() <span class="sqlk">OVER</span> (<span class="sqlk">ORDER BY</span> c.population <span class="sqlk">DESC</span>)\n'+
+      '<span class="sqlk">FROM</span> city c\n'+
+      '<span class="sqlk">WHERE</span> c.country = <span class="sqlq">?</span>\n\n'+
       '<span class="sqlc">-- ${User::class} expands to columns · $city becomes ?</span>\n'+
       '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
       '<span class="sqlk">FROM</span> "user" u\n'+

--- a/website/src/pages/tutorials/exposed-n-plus-one.js
+++ b/website/src/pages/tutorials/exposed-n-plus-one.js
@@ -103,7 +103,7 @@ ${navHtml('tutorials')}
   ${editor({file: 'FeedService.kt', tag: 'Kotlin · Storm', code: CODE_STORM_MODEL, sql: SQL_STORM_MODEL})}
   <p>There is no eager-loading call to remember because there is no lazy default to escape. And when deferring the load is genuinely the right call, that decision is also made in the model, as a type:</p>
   ${editor({file: 'Entities.kt', tag: 'Kotlin · Storm', code: CODE_STORM_REF})}
-  <p>Refs that point to the same id share one instance inside a transaction, so fetching across a result list loads each distinct city once. The <a class="tlink" href="/tutorials/n-plus-one">JPA edition of this tutorial</a> covers the mechanics in more depth, and query counts are one-line assertions with <a class="tlink" href="/tutorials/testing">SqlCapture</a>, so "no N+1" can be a test rather than a review comment.</p>
+  <p>Refs that point to the same id share one instance inside a transaction, so fetching across a result list loads each distinct city once. The <a class="tlink" href="/tutorials/n-plus-one">JPA edition of this tutorial</a> covers the mechanics in more depth, and query counts are one-line assertions with <a class="tlink" href="/tutorials/testing">SqlCapture</a>.</p>
 
   <h2><span class="hno">04</span>Side by side</h2>
   <table class="cmp">

--- a/website/src/pages/tutorials/index.js
+++ b/website/src/pages/tutorials/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import Head from '@docusaurus/Head';
 import {TUT_CSS, navHtml, FOOT_HTML} from '../../components/tutorial/tutorialTheme';
 
@@ -161,7 +161,38 @@ ${navHtml('tutorials')}
 ${FOOT_HTML}
 `;
 
+// Wires the series chips in the hero: clicking one shows only that section
+// (its header and cards) and highlights the chip; clicking it again clears the
+// filter and shows all. Falls back to anchor jumps when JS is unavailable.
+function wireTutorialFilters() {
+  const root = document.querySelector('.storm-tut');
+  if (!root) return () => {};
+  const chips = Array.from(root.querySelectorAll('.catnav a'));
+  const sections = Array.from(root.querySelectorAll('.shead'));
+  const handlers = [];
+  const apply = (filter) => {
+    chips.forEach((c) => c.classList.toggle('on', !!filter && (c.getAttribute('href') || '').slice(1) === filter));
+    sections.forEach((shead) => {
+      const cards = shead.nextElementSibling;
+      const show = !filter || shead.id === filter;
+      shead.style.display = show ? '' : 'none';
+      if (cards && cards.classList.contains('cards')) cards.style.display = show ? '' : 'none';
+    });
+  };
+  chips.forEach((chip) => {
+    const onClick = (e) => {
+      e.preventDefault();
+      const id = (chip.getAttribute('href') || '').slice(1);
+      apply(chip.classList.contains('on') ? '' : id);
+    };
+    chip.addEventListener('click', onClick);
+    handlers.push([chip, onClick]);
+  });
+  return () => handlers.forEach(([chip, fn]) => chip.removeEventListener('click', fn));
+}
+
 export default function Tutorials() {
+  useEffect(() => wireTutorialFilters(), []);
   return (
     <>
       <Head>

--- a/website/src/pages/tutorials/n-plus-one.js
+++ b/website/src/pages/tutorials/n-plus-one.js
@@ -121,7 +121,7 @@ ${navHtml('tutorials')}
 <div class="art">
   <div class="crumbs"><a href="/tutorials/">Tutorials</a><span class="sep">/</span>Solving the N+1 problem</div>
   <h1>Solving the <span class="grad">N+1 problem</span></h1>
-  <p class="dek">The most common performance bug in JPA applications, and how Storm removes the conditions that create it. Side by side, with the SQL each approach actually runs.</p>
+  <p class="dek">The most common performance problem in JPA applications, and how Storm removes the conditions that create it. Side by side, with the SQL each approach actually runs.</p>
   <div class="meta"><span>Series · JPA to Storm</span><span>7 min read</span><span>Kotlin</span></div>
 
   <h2><span class="hno">01</span>The task</h2>

--- a/website/src/pages/tutorials/testing.js
+++ b/website/src/pages/tutorials/testing.js
@@ -84,7 +84,7 @@ ${navHtml('tutorials')}
   <div class="refs">
     <a href="/docs/testing">Testing</a>
     <a href="/docs/sql-logging">SQL Logging</a>
-    <a href="/docs/getting-started">Getting Started</a>
+    <a href="/docs/getting-started">Get Started</a>
   </div>
   <div class="cta">
     <a href="/docs/getting-started" class="btn primary">Get started →</a>


### PR DESCRIPTION
## Summary

Adds a custom-styled **blog** at `/blog` and polishes the surrounding site. The blog is built as bespoke React pages that match the tutorials' styling (not the Docusaurus blog plugin).

Each post has a clean H1 plus a keyword-rich meta title, a meta description, `BlogPosting` JSON-LD, and internal cluster links that only point to *earlier* posts in the series. "Stop hiding my SQL" and the data-layer post include formatted code examples via the shared editor component.

### Hub filtering

- **Blog hub:** clickable category chips (Origin, Design, Hibernate, SQL, Internals, Comparison, Opinion). Click to filter; click the active chip again to clear. All posts render server-side, so filtering is a progressive enhancement.
- **Tutorials hub:** the series chips ("From JPA", "From Exposed", "The Storm way") now filter to a single section, with a no-JS anchor-jump fallback.

### Site polish

- Top nav reordered so **Docs** sits just before **GitHub** (shared nav, landing page, and Docusaurus navbar).
- The landing-page SQL example and the "Stop hiding my SQL" post now use typed metamodel **template elements** (`${City_.name}`, `${City::class}`) instead of bare column strings; the landing SQL panel shows the correct aliased output.
- Getting Started docs restructured (design-philosophy content moved into the blog); minor tutorial copy fixes.

## Verification

- `npm run build` succeeds; all blog routes generate with no broken internal blog links.
- Internal links are backward-only within the series; no post links to a later-dated one.
- No em dashes in blog/site copy.
