### PR TITLE
fix(website): resolve versions and canonical docs links in llms.txt / llms-full.txt

### DIFF
--- a/website/plugins/static-version-replace.js
+++ b/website/plugins/static-version-replace.js
@@ -1,6 +1,10 @@
 /**
- * Docusaurus plugin that replaces @@STORM_VERSION@@ in static files
- * (e.g., website/static/skills/*.md) after they are copied to the build output.
+ * Docusaurus plugin that replaces @@STORM_VERSION@@ in static files after they
+ * are copied to the build output: the per-tool skill files (static/skills/*.md)
+ * and the AI-facing docs indexes (static/llms.txt and static/llms-full.txt).
+ * These files are copied verbatim and never pass through the remark version
+ * plugin, so this postBuild pass is what keeps their install snippets on the
+ * current version.
  */
 
 const fs = require('fs');
@@ -11,16 +15,25 @@ module.exports = function staticVersionReplace(context, options) {
   return {
     name: 'static-version-replace',
     async postBuild({ outDir }) {
-      const skillsDir = path.join(outDir, 'skills');
-      if (!fs.existsSync(skillsDir)) return;
-      for (const name of fs.readdirSync(skillsDir)) {
-        if (!name.endsWith('.md')) continue;
-        const file = path.join(skillsDir, name);
+      const replaceInFile = (file) => {
+        if (!fs.existsSync(file)) return;
         const content = fs.readFileSync(file, 'utf-8');
         if (content.includes('@@STORM_VERSION@@')) {
           fs.writeFileSync(file, content.replaceAll('@@STORM_VERSION@@', version));
         }
+      };
+
+      // Per-tool skill files copied from static/skills/.
+      const skillsDir = path.join(outDir, 'skills');
+      if (fs.existsSync(skillsDir)) {
+        for (const name of fs.readdirSync(skillsDir)) {
+          if (name.endsWith('.md')) replaceInFile(path.join(skillsDir, name));
+        }
       }
+
+      // AI-facing docs indexes copied from static/.
+      replaceInFile(path.join(outDir, 'llms.txt'));
+      replaceInFile(path.join(outDir, 'llms-full.txt'));
     },
   };
 };

--- a/website/scripts/generate-llms-full.sh
+++ b/website/scripts/generate-llms-full.sh
@@ -110,7 +110,7 @@ cat > "$OUTPUT" <<'HEADER'
 > only schema metadata (table definitions, column types, constraints) while
 > shielding your database credentials and data from the LLM. Built-in
 > verification (validateSchema(), SqlCapture) lets the AI validate its own work
-> correct before anything is committed.
+> before anything is committed.
 >
 > Get started: `npx @storm-orm/cli`
 > Website: https://orm.st

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11,7 +11,7 @@
 > only schema metadata (table definitions, column types, constraints) while
 > shielding your database credentials and data from the LLM. Built-in
 > verification (validateSchema(), SqlCapture) lets the AI validate its own work
-> correct before anything is committed.
+> before anything is committed.
 >
 > Get started: `npx @storm-orm/cli`
 > Website: https://orm.st

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -25,40 +25,40 @@ License: Apache 2.0
 
 ## Documentation
 
-- [Introduction](https://orm.st/)
-- [Getting Started](https://orm.st/getting-started)
-- [Entities](https://orm.st/entities)
-- [Projections](https://orm.st/projections)
-- [Relationships](https://orm.st/relationships)
-- [Repositories](https://orm.st/repositories)
-- [Queries](https://orm.st/queries)
-- [Metamodel](https://orm.st/metamodel)
-- [Refs](https://orm.st/refs)
-- [Transactions](https://orm.st/transactions)
-- [Spring Integration](https://orm.st/spring-integration)
-- [Ktor Integration](https://orm.st/ktor-integration)
-- [Database Dialects](https://orm.st/dialects)
-- [Testing](https://orm.st/testing)
-- [Converters](https://orm.st/converters)
-- [JSON Columns](https://orm.st/json)
-- [Polymorphism](https://orm.st/polymorphism)
-- [Entity Lifecycle](https://orm.st/entity-lifecycle)
-- [Serialization](https://orm.st/serialization)
-- [Validation](https://orm.st/validation)
-- [Batch Processing and Streaming](https://orm.st/batch-streaming)
-- [Upserts](https://orm.st/upserts)
-- [SQL Templates](https://orm.st/sql-templates)
-- [Hydration](https://orm.st/hydration)
-- [Dirty Checking](https://orm.st/dirty-checking)
-- [Entity Cache](https://orm.st/entity-cache)
-- [Configuration](https://orm.st/configuration)
-- [SQL Logging](https://orm.st/sql-logging)
-- [Metrics](https://orm.st/metrics)
-- [Storm vs Other Frameworks](https://orm.st/comparison)
-- [FAQ](https://orm.st/faq)
-- [Migration from JPA](https://orm.st/migration-from-jpa)
-- [API Reference: Kotlin](https://orm.st/api-kotlin)
-- [API Reference: Java](https://orm.st/api-java)
+- [Introduction](https://orm.st/docs/)
+- [Getting Started](https://orm.st/docs/getting-started)
+- [Entities](https://orm.st/docs/entities)
+- [Projections](https://orm.st/docs/projections)
+- [Relationships](https://orm.st/docs/relationships)
+- [Repositories](https://orm.st/docs/repositories)
+- [Queries](https://orm.st/docs/queries)
+- [Metamodel](https://orm.st/docs/metamodel)
+- [Refs](https://orm.st/docs/refs)
+- [Transactions](https://orm.st/docs/transactions)
+- [Spring Integration](https://orm.st/docs/spring-integration)
+- [Ktor Integration](https://orm.st/docs/ktor-integration)
+- [Database Dialects](https://orm.st/docs/dialects)
+- [Testing](https://orm.st/docs/testing)
+- [Converters](https://orm.st/docs/converters)
+- [JSON Columns](https://orm.st/docs/json)
+- [Polymorphism](https://orm.st/docs/polymorphism)
+- [Entity Lifecycle](https://orm.st/docs/entity-lifecycle)
+- [Serialization](https://orm.st/docs/serialization)
+- [Validation](https://orm.st/docs/validation)
+- [Batch Processing and Streaming](https://orm.st/docs/batch-streaming)
+- [Upserts](https://orm.st/docs/upserts)
+- [SQL Templates](https://orm.st/docs/sql-templates)
+- [Hydration](https://orm.st/docs/hydration)
+- [Dirty Checking](https://orm.st/docs/dirty-checking)
+- [Entity Cache](https://orm.st/docs/entity-cache)
+- [Configuration](https://orm.st/docs/configuration)
+- [SQL Logging](https://orm.st/docs/sql-logging)
+- [Metrics](https://orm.st/docs/metrics)
+- [Storm vs Other Frameworks](https://orm.st/docs/comparison)
+- [FAQ](https://orm.st/docs/faq)
+- [Migration from JPA](https://orm.st/docs/migration-from-jpa)
+- [API Reference: Kotlin](https://orm.st/docs/api-kotlin)
+- [API Reference: Java](https://orm.st/docs/api-java)
 
 ## Full Documentation
 
@@ -243,7 +243,7 @@ val cityName = user.city.fetch().name  // Fetches when needed
 Kotlin (Gradle):
 ```kotlin
 dependencies {
-    implementation(platform("st.orm:storm-bom:1.10.0"))
+    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
     implementation("st.orm:storm-kotlin")
     runtimeOnly("st.orm:storm-core")
     kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
@@ -257,7 +257,7 @@ Java (Maven):
         <dependency>
             <groupId>st.orm</groupId>
             <artifactId>storm-bom</artifactId>
-            <version>1.10.0</version>
+            <version>@@STORM_VERSION@@</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -281,7 +281,7 @@ Java (Maven):
 Kotlin (Gradle):
 ```kotlin
 dependencies {
-    implementation(platform("st.orm:storm-bom:1.10.0"))
+    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
     implementation("st.orm:storm-kotlin-spring-boot-starter")
     runtimeOnly("st.orm:storm-core")
     kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
@@ -301,7 +301,7 @@ Java (Maven):
 Kotlin (Gradle):
 ```kotlin
 dependencies {
-    implementation(platform("st.orm:storm-bom:1.11.0"))
+    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
     implementation("st.orm:storm-kotlin")
     implementation("st.orm:storm-ktor")
     runtimeOnly("st.orm:storm-core")


### PR DESCRIPTION
## Problem

The AI-facing docs indexes drifted out of sync with the released version, so tools that follow `llms.txt` could ingest stale versions and old docs routes.

Root cause: neither file is wired into the version pipeline the docs pages use.

- **`llms.txt`** is a hand-maintained static file. It hardcoded `storm-bom:1.10.0`/`1.11.0` and linked to **bare** doc paths (`https://orm.st/entities`, …) which resolve to an *older* docs version, while `/docs/entities` is the current one. Docusaurus copies `static/` verbatim, so nothing ever refreshed it.
- **`llms-full.txt`** is generated by `scripts/generate-llms-full.sh`, but that script only concatenates + strips docs — it never substitutes `@@STORM_VERSION@@`. Those placeholders (normally resolved only at page-render time by the remark plugin) flowed straight into the file.
- The one plugin that *does* resolve `@@STORM_VERSION@@` in `postBuild` (`static-version-replace.js`) was hard-scoped to `build/skills/*.md`, so it never touched either file.

## Fix

- **Extend `static-version-replace.js`** to also resolve `@@STORM_VERSION@@` in the built `llms.txt` and `llms-full.txt`, using the same `stormVersion` source the docs already use. Now both are correct on every build.
- **`llms.txt`:** replace the hardcoded BOM versions with `@@STORM_VERSION@@`, and rewrite the bare doc links to canonical `/docs/...` URLs (including `Introduction` → `/docs/`).
- **Typo:** "lets the AI validate its own work **correct** before anything is committed" → "…validate its own work before…", fixed in both `llms-full.txt` and the generator's header so future regenerations stay correct.

## Verification

`npm run build`, then against the build output:

- `build/llms.txt` and `build/llms-full.txt`: **0** unresolved `@@STORM_VERSION@@`; BOM snippets now read `storm-bom:1.11.6`.
- All `orm.st` doc links in `build/llms.txt` are `/docs/...` (no bare paths, no accidental `/docs/docs/`).
- `/docs/` (the `Introduction` target) resolves — `build/docs/index.html` exists.
- Typo no longer present in `build/llms-full.txt`.

## Not included

`llms-full.txt` document *content* was not regenerated (only the header typo + build-time version resolution). Running `bash website/scripts/generate-llms-full.sh` will refresh the body from current docs when desired; that's a separate, larger change.
