### PR TITLE
fix(website): SEO/AI hygiene, canonical consolidation, and homepage claim tuning

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -101,7 +101,7 @@ AI works better when framework behavior is explicit and visible in source code.
 
 Traditional ORMs rely on mechanisms that are powerful but implicit: proxy objects that intercept field access, lazy loading that triggers queries at unpredictable moments, persistence contexts that track entity state across transaction boundaries, and cascading rules that propagate changes through the object graph. These features serve real purposes, but they make AI-assisted development harder. The AI has to account for behavior that does not appear in the code. Code that compiles and looks correct can still break at runtime because of invisible framework state.
 
-Storm eliminates all of that. Entities are plain Kotlin data classes or Java records. There are no proxies, no managed state, no persistence context, and no lazy loading. Queries are explicit, and what you see in the source code is exactly what happens at runtime. This makes Storm's behavior predictable for AI tools: the code is the complete picture.
+Storm eliminates all of that. Entities are plain Kotlin data classes or Java records. There are no proxies, no managed state, no persistence context, and no transparent lazy loading: deferred loading is explicit, through `Ref<T>`. Queries are explicit, and what you see in the source code is exactly what happens at runtime. This makes Storm's behavior predictable for AI tools: the code is the complete picture.
 
 The design choices that matter most:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ slug: /
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# ST/ORM
+# Storm
 
 **Storm** is a modern, high-performance ORM for Kotlin 2.0+ and Java 21+, built around a powerful SQL template engine. It focuses on simplicity, type safety, and predictable performance through immutable models and compile-time metadata.
 

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -3,7 +3,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Automatic relationship loading is a core part of Storm's design. Your data model is fully captured by immutable entity classes. When you define a foreign key, Storm automatically joins the related entity and returns complete, fully populated records in a single query.
+Automatic relationship loading is a core part of Storm's design. The database owns your data model, and your entities capture it as immutable classes. When you define a foreign key, Storm automatically joins the related entity and returns complete, fully populated records in a single query.
 
 This design enables:
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,6 +6,7 @@ const stormVersion = require('./plugins/read-storm-version');
 const remarkStormVersion = require('./plugins/remark-storm-version');
 const staticVersionReplace = require('./plugins/static-version-replace');
 const exampleReadmes = require('./plugins/example-readmes');
+const versionedDocsCanonical = require('./plugins/versioned-docs-canonical');
 
 const config: Config = {
   title: 'Storm Framework',
@@ -27,6 +28,9 @@ const config: Config = {
 
   plugins: [
     [staticVersionReplace, { version: stormVersion }],
+    // Point versioned and `next` docs canonicals at the current /docs/ page so
+    // old snapshots do not compete with the live docs (see the plugin).
+    versionedDocsCanonical,
     // Renders the example-project READMEs inline at /examples/<slug>,
     // fetched from GitHub at build time (see plugins/example-readmes.js).
     exampleReadmes,
@@ -110,11 +114,18 @@ const config: Config = {
           createSitemapItems: async (params) => {
             const {defaultCreateSitemapItems, ...rest} = params;
             const items = await defaultCreateSitemapItems(rest);
-            return items.filter(
+            const filtered = items.filter(
               (item) =>
                 !item.url.includes('/docs/next') &&
                 !/\/docs\/\d+\.\d+\.\d+(\/|$)/.test(item.url),
             );
+            // The AI-facing docs indexes are static files, so they are not in
+            // the route table the sitemap is built from; add them explicitly.
+            filtered.push(
+              {url: 'https://orm.st/llms.txt', changefreq: 'weekly', priority: 0.5},
+              {url: 'https://orm.st/llms-full.txt', changefreq: 'weekly', priority: 0.5},
+            );
+            return filtered;
           },
         },
         blog: false,

--- a/website/plugins/versioned-docs-canonical.js
+++ b/website/plugins/versioned-docs-canonical.js
@@ -1,0 +1,64 @@
+/**
+ * Docusaurus plugin that rewrites the <link rel="canonical"> on versioned and
+ * `next` docs pages to point at the current (unversioned) /docs/<path>. Old
+ * numbered snapshots and the unreleased dev docs otherwise self-canonicalize
+ * and compete with the live docs for ranking. The sitemap already excludes
+ * these pages; this consolidates the remaining crawl/canonical signal onto the
+ * current version. Only rewrites when the current page actually exists in the
+ * build, so pages with no current equivalent keep their self-canonical.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SITE = 'https://orm.st';
+
+module.exports = function versionedDocsCanonical() {
+  return {
+    name: 'versioned-docs-canonical',
+    async postBuild({ outDir }) {
+      const docsDir = path.join(outDir, 'docs');
+      if (!fs.existsSync(docsDir)) return;
+
+      // Fold numbered snapshots (1.2.3) and the dev docs (`next`) onto current.
+      const segments = fs.readdirSync(docsDir).filter((name) => {
+        const full = path.join(docsDir, name);
+        return (
+          fs.statSync(full).isDirectory() &&
+          (name === 'next' || /^\d+\.\d+\.\d+$/.test(name))
+        );
+      });
+
+      const walk = (dir, seg) => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            walk(full, seg);
+            continue;
+          }
+          if (entry.name !== 'index.html') continue;
+
+          const rel = path
+            .relative(path.join(docsDir, seg), path.dirname(full))
+            .split(path.sep)
+            .filter(Boolean)
+            .join('/');
+
+          // Only fold onto a page that exists in the current (unversioned) docs.
+          const currentPage = path.join(docsDir, rel, 'index.html');
+          if (!fs.existsSync(currentPage)) continue;
+
+          const target = rel ? `${SITE}/docs/${rel}` : `${SITE}/docs/`;
+          const html = fs.readFileSync(full, 'utf-8');
+          const next = html.replace(
+            /(<link\b[^>]*\brel="canonical"\s+href=")[^"]*(")/,
+            `$1${target}$2`,
+          );
+          if (next !== html) fs.writeFileSync(full, next);
+        }
+      };
+
+      for (const seg of segments) walk(path.join(docsDir, seg), seg);
+    },
+  };
+};

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -163,7 +163,7 @@ const BODY = `
     <span class="grad">Explicit over surprises.</span>
     <span class="grad">Intent over ceremony.</span>
   </span></h1>
-  <p class="sub" style="max-width:940px">A clear mapping between your data model and database keeps entities reusable and repositories easy to extend. Your persistence layer remains small, expressive, and fully capable as your application grows.</p>
+  <p class="sub" style="max-width:940px">Storm is a type-safe ORM for Kotlin and Java. A clear mapping between your entities and the database keeps them reusable and repositories easy to extend. Your persistence layer remains small, expressive, and fully capable as your application grows.</p>
 
   <div class="stage">
     <div class="editor">
@@ -194,7 +194,7 @@ const BODY = `
     <div class="card">
       <div class="ic"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12h18M3 6h18M3 18h18"/></svg></div>
       <h3>Direct database control</h3>
-      <p>Every query is explicit and predictable. Nested predicates and entity graphs compile to a single efficient query, eliminating hidden queries and N+1.</p>
+      <p>Every query is explicit and predictable. Nested predicates and entity graphs compile to a single efficient query, eliminating accidental hidden N+1 queries.</p>
     </div>
     <div class="card">
       <div class="ic"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6 9 17l-5-5"/></svg></div>
@@ -577,7 +577,7 @@ export default function Home() {
             applicationCategory: 'DeveloperApplication',
             operatingSystem: 'JVM (Kotlin, Java)',
             description:
-              'Storm is a type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Define concise, immutable entities and write one-line queries — nested predicates and entity graphs compile to a single efficient query, eliminating hidden queries and N+1. Drop to full SQL templates whenever you want; never locked in.',
+              'Storm is a type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Define concise, immutable entities and write one-line queries — nested predicates and entity graphs compile to a single efficient query, eliminating accidental hidden N+1 queries. Drop to full SQL templates whenever you want; never locked in.',
             featureList: [
               'Direct database control — every query explicit, no hidden N+1',
               'Stateless, immutable records — no proxies, no flush, no hidden state',

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -5,7 +5,7 @@
 >
 > It uses immutable data classes and records instead of proxied entities, providing
 > type-safe queries, predictable performance, and zero hidden magic. There is no
-> persistence context, no lazy loading, no proxy generation, and no entity state
+> persistence context, no transparent lazy loading, no proxy generation, and no entity state
 > management. Entities are plain Kotlin data classes or Java records.
 >
 > Storm works perfectly as a standalone ORM, but its design and tooling make it

--- a/website/static/skills/storm-entity-kotlin.md
+++ b/website/static/skills/storm-entity-kotlin.md
@@ -177,4 +177,4 @@ Run the test. Show the user the result and explain what it proves. If validation
 
 The test can be temporary — verify and remove, or keep as a regression test. Ask the user which they prefer.
 
-Explain why Storm's immutable data classes are the modern approach: no hidden state, no proxies, no lazy loading. Freely cacheable, serializable, comparable by value, thread-safe. AI tools generate correct code because there is no invisible magic.
+Explain why Storm's immutable data classes are the modern approach: no hidden state, no proxies, no transparent lazy loading. Freely cacheable, serializable, comparable by value, thread-safe. AI tools generate correct code because there is no invisible magic.


### PR DESCRIPTION
## Summary

The remaining items from the site review, in one PR: SEO/AI-index hygiene plus a few homepage claim/positioning tweaks.

### SEO / AI plumbing
- **Versioned-docs canonical consolidation** (new `plugins/versioned-docs-canonical.js`): versioned snapshots (`/docs/1.10.0/entities`) and the dev docs (`/docs/next/entities`) previously self-canonicalized, competing with the live `/docs/entities`. A `postBuild` pass now rewrites their `<link rel="canonical">` to the current `/docs/<path>` (only when that current page exists). The sitemap already excludes these pages; this consolidates the remaining canonical/crawl signal.
- **Sitemap now lists `llms.txt` and `llms-full.txt`**. They are static files, so the route-based sitemap never included them; added explicitly in `createSitemapItems`.

_(Already in place, no change needed: `robots.txt` points to the sitemap, and bare doc paths like `/entities` already 301-redirect to `/docs/entities` with a canonical — the live site just needs a redeploy to reflect it.)_

### Homepage copy
- Subhead now leads with **"Storm is a type-safe ORM for Kotlin and Java."** — adds the ORM/Kotlin/Java keywords and establishes the product name up front. Also swaps "your data model and database" → "your entities and the database" to match the database-owns-the-model positioning.
- N+1 claim softened from "eliminating hidden queries and N+1" → **"eliminating accidental hidden N+1 queries"** (body copy and the JSON-LD description), so it reads as a guarantee against *accidental* N+1 rather than magic.

### Accuracy & positioning (docs)
- **"no lazy loading" → "no transparent lazy loading"** in `docs/ai.md`, the entity skill, and `llms.txt` — Storm *does* support deferred loading, explicitly via `Ref<T>`; the old wording overclaimed.
- `docs/relationships.md`: "Your data model is fully captured by immutable entity classes" → **"The database owns your data model, and your entities capture it as immutable classes."**
- Docs intro H1 **"ST/ORM" → "Storm"** (matches the site title and the product name; the body already said "Storm").

## Verification
`npm run build`, then against the build output:
- `build/sitemap.xml` contains `https://orm.st/llms.txt` and `https://orm.st/llms-full.txt`.
- Canonicals: `docs/1.10.0/entities`, `docs/next/ai`, `docs/next/relationships`, and the `next` intro all now point at the current `/docs/...`; current pages keep their self-canonical.
- Homepage bundle carries the new subhead and softened N+1 copy.
- `/docs/next` renders the updated intro H1, relationships positioning, and ai.md wording.

## Notes
- The `docs/` edits (ai.md, relationships.md, index.md H1) render at `/docs/next` and go live at `/docs/*` only when the next release snapshots `docs/` into `versioned_docs/`.
- `llms.txt` also appears in PR #174, but on a different line (versions/links there vs. the lazy-loading wording here), so the two auto-merge.
- **Brand:** this standardizes the docs intro and homepage lead on "Storm". The `ST/ORM` stylization is left as the wordmark/logo and in the blog (which deliberately uses it). A fuller brand sweep is a separate call if you want it.
