### PR TITLE
docs: add quickstart + comparison pages, Jimmer, and adoption polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ website/node_modules/
 website/build/
 website/.docusaurus/
 website/static/api/
+
+# Working analysis doc — not for check-in
+ADOPTION_ANALYSIS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,145 @@
+# Changelog
+
+All notable changes to Storm are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/), and Storm follows
+[Semantic Versioning](https://semver.org/).
+
+Releases are tag-driven and published to
+[Maven Central](https://central.sonatype.com/namespace/st.orm) (`st.orm`) and,
+for the CLI, to [npm](https://www.npmjs.com/package/@storm-orm/cli)
+(`@storm-orm/cli`). Full release notes for every version are on the
+[GitHub Releases](https://github.com/storm-orm/storm-framework/releases) page.
+
+## [1.11.6] - 2026-07-01
+- Kotlin 2.4 support: added the `storm-compiler-plugin-2.4` variant built against the Kotlin 2.4.0 compiler API.
+- Fixed `@Convert` on an embedded (`@Inline`) component field failing on save.
+
+## [1.11.5] - 2026-06-27
+- Documentation and tooling release.
+- Corrected the quick-start install command to `npx @storm-orm/cli` (the previously documented `@storm/cli` package does not exist on npm).
+
+## [1.11.4] - 2026-06-27
+- Improved handling of `NULL` for optional results in `Query` and `QueryBuilder` (Java and Kotlin) so optional single-result lookups behave consistently.
+- Optimized object mapping for value types, reducing per-row mapping overhead.
+
+## [1.11.3] - 2026-05-30
+- Added `validateSchema(Predicate<...>)` / `validateSchemaOrThrow(...)` overloads on `ORMTemplate`.
+- Added `validateAndReport(Predicate, strict)` / `validateReportAndThrow(...)` on `SchemaValidator` for filter-based validation.
+
+## [1.11.2] - 2026-04-09
+- Added the `storm db` command group for managing a global database connection library.
+- Added multi-database MCP support (`storm mcp add/list/remove`).
+- Added optional read-only data access via the `select_data` MCP tool.
+
+## [1.11.1] - 2026-04-01
+- Added `Slice<R>` as the common base for `Window` (cursor-based scrolling) and `Page` (offset pagination).
+- Added `findAllRef()` on `EntityRepository` / `ProjectionRepository`.
+- Added `select(predicate)` / `selectRef(predicate)` convenience methods.
+
+## [1.11.0] - 2026-03-27
+- Added the cursor-based scroll API (`Scrollable`, `Window`, `MappedWindow`).
+- Added opaque cursor serialization (`CursorCodec`, `CursorFactory` SPI).
+- Added the SQLite dialect module (`storm-sqlite`).
+
+## [1.10.0] - 2026-03-14
+- Added the Kotlin compiler plugin (`storm-compiler-plugin`) for the SQL Template DSL, replacing the `storm-kotlin-validator` lint rules with compile-time wrapping.
+- Added multi-dollar string support in SQL templates.
+- Added built-in offset-based pagination (`Page`, `Pageable`).
+
+## [1.9.1] - 2026-03-07
+- Fixed the repository scanner registering non-`Repository` interfaces in scanned packages.
+
+## [1.9.0] - 2026-03-05
+- Added the `storm-bom` module for centralized dependency version management.
+- Added the `storm-test` module with the `@StormTest` JUnit 5 extension and `StatementCapture`.
+- Added Spring Boot starter auto-configuration.
+
+## [1.8.2] - 2026-02-13
+- Added transaction-scoped, cache-first lookups; `Ref.fetch()` now checks the cache before querying.
+- Raw update queries now invalidate the cache for the affected entity type.
+
+## [1.8.1] - 2026-01-29
+- Entity cache enabled in read-only transactions and disabled for `READ_UNCOMMITTED`.
+- Primary-key-based cache lookups instead of full entity equality checks.
+
+## [1.8.0] - 2026-01-28
+- Added SQL template caching and template-generation metric logging.
+- Separated SQL template compilation and binding stages.
+
+## [1.7.2] - 2026-01-09
+- Clean entity cache after nested transaction rollback.
+- Cleaned up the extension-functions API.
+
+## [1.7.1] - 2025-12-30
+- Support for custom field types and kotlinx.serialization (Jackson or kotlinx).
+- Serializability for entities and projections; entity-level dirty checks for updates.
+
+## [1.6.2] - 2025-11-02
+- Allow a primary key to be a `Ref`.
+
+## [1.6.1] - 2025-10-04
+- Fixed `WhereProcessor` for PK/FK combinations; improved join inclusion and JDBC time-type handling.
+
+## [1.6.0] - 2025-09-13
+- Added sequence-based ID generation strategy and entity-to-ref conversion.
+
+## [1.5.0] - 2025-08-19
+- Added Kotlin coroutine support, programmatic transactions, and `Flow` support.
+
+## [1.4.0] - 2025-08-11
+- Made Kotlin a first-class citizen; set the Kotlin baseline to 2.0.21.
+- Clients now explicitly include the `storm-core` module.
+
+## [1.3.8] - 2025-07-06
+- Reflection performance improvements; scope-limited alias resolution.
+
+## [1.3.7] - 2025-06-29
+- Added parameter inlining for `SqlTemplate` and a `SqlTemplate` customizer.
+
+## [1.3.6] - 2025-05-31
+- Added Kotlin extension functions for convenient repository access.
+
+## [1.3.5] - 2025-05-26
+- Eliminated annotations from the metamodel; added a nullable reference method.
+
+## [1.3.4] - 2025-05-18
+- Full support for compound primary keys; improved nullability checks and ordering.
+
+## [1.3.3] - 2025-05-05
+- Refactored `SqlInterceptor` to use `ScopedValue`.
+
+## [1.3.2] - 2025-05-03
+- Aligned entity and projection repositories with existing persistence APIs; auto-register Jackson modules.
+
+---
+
+For releases prior to 1.3.2, see the
+[GitHub Releases](https://github.com/storm-orm/storm-framework/releases) page.
+
+[1.11.6]: https://github.com/storm-orm/storm-framework/releases/tag/v1.11.6
+[1.11.5]: https://github.com/storm-orm/storm-framework/releases/tag/v1.11.5
+[1.11.4]: https://github.com/storm-orm/storm-framework/releases/tag/v1.11.4
+[1.11.3]: https://github.com/storm-orm/storm-framework/releases/tag/v1.11.3
+[1.11.2]: https://github.com/storm-orm/storm-framework/releases/tag/v1.11.2
+[1.11.1]: https://github.com/storm-orm/storm-framework/releases/tag/v1.11.1
+[1.11.0]: https://github.com/storm-orm/storm-framework/releases/tag/v1.11.0
+[1.10.0]: https://github.com/storm-orm/storm-framework/releases/tag/v1.10.0
+[1.9.1]: https://github.com/storm-orm/storm-framework/releases/tag/v1.9.1
+[1.9.0]: https://github.com/storm-orm/storm-framework/releases/tag/v1.9.0
+[1.8.2]: https://github.com/storm-orm/storm-framework/releases/tag/v1.8.2
+[1.8.1]: https://github.com/storm-orm/storm-framework/releases/tag/v1.8.1
+[1.8.0]: https://github.com/storm-orm/storm-framework/releases/tag/v1.8.0
+[1.7.2]: https://github.com/storm-orm/storm-framework/releases/tag/v1.7.2
+[1.7.1]: https://github.com/storm-orm/storm-framework/releases/tag/v1.7.1
+[1.6.2]: https://github.com/storm-orm/storm-framework/releases/tag/v1.6.2
+[1.6.1]: https://github.com/storm-orm/storm-framework/releases/tag/v1.6.1
+[1.6.0]: https://github.com/storm-orm/storm-framework/releases/tag/v1.6.0
+[1.5.0]: https://github.com/storm-orm/storm-framework/releases/tag/v1.5.0
+[1.4.0]: https://github.com/storm-orm/storm-framework/releases/tag/v1.4.0
+[1.3.8]: https://github.com/storm-orm/storm-framework/releases/tag/v1.3.8
+[1.3.7]: https://github.com/storm-orm/storm-framework/releases/tag/v1.3.7
+[1.3.6]: https://github.com/storm-orm/storm-framework/releases/tag/v1.3.6
+[1.3.5]: https://github.com/storm-orm/storm-framework/releases/tag/v1.3.5
+[1.3.4]: https://github.com/storm-orm/storm-framework/releases/tag/v1.3.4
+[1.3.3]: https://github.com/storm-orm/storm-framework/releases/tag/v1.3.3
+[1.3.2]: https://github.com/storm-orm/storm-framework/releases/tag/v1.3.2

--- a/README.md
+++ b/README.md
@@ -129,6 +129,24 @@ List<User> users = orm.query(RAW."""
 
 ## Quick Start
 
+New to Storm? The fastest path is the **5-minute [Quickstart](https://orm.st/quickstart)**: install, define an entity, run a type-safe query.
+
+### Which modules do I need?
+
+Storm is modular; you add only what your stack uses. Versions come from the BOM (below), so you never specify them per module.
+
+| Your stack              | Add |
+|-------------------------|-----|
+| **Kotlin** (any)        | `storm-kotlin` + `storm-core` (runtime) + `storm-metamodel-ksp` (ksp) + `storm-compiler-plugin-2.x` |
+| **Kotlin + Spring Boot** | `storm-kotlin-spring-boot-starter` |
+| **Kotlin + Ktor**       | `storm-kotlin` + `storm-ktor` |
+| **Java 21**             | `storm-java21` + `storm-core` (runtime) + `storm-metamodel-processor` |
+| **Java + Spring Boot**  | `storm-spring-boot-starter` |
+| **+ your database**     | one dialect (runtime): `storm-postgresql`, `storm-mysql`, `storm-mariadb`, `storm-oracle`, `storm-mssqlserver`, `storm-sqlite`, `storm-h2` |
+| **+ JSON columns**      | `storm-jackson2`, `storm-jackson3`, or `storm-kotlinx-serialization` |
+
+The `storm-compiler-plugin-2.x` suffix matches your Kotlin major.minor version (e.g. `storm-compiler-plugin-2.0` for Kotlin 2.0.x). See [Installation](https://orm.st/docs/installation) for the full module overview.
+
 ### Dependency Management (BOM)
 
 Storm provides a Bill of Materials (BOM) for centralized version management. Import the BOM once and omit version numbers from individual Storm dependencies.
@@ -195,6 +213,16 @@ storm init
 ```
 
 See [AI-Assisted Development](docs/ai.md) for the full workflow.
+
+## Examples
+
+Three complete, runnable **Storm Movies** applications, each importing the public IMDB dataset and rendered inline at [orm.st/examples](https://orm.st/examples):
+
+| Example | Stack | Repository |
+|---------|-------|------------|
+| [Kotlin + Ktor](https://orm.st/examples/kotlin-ktor) | Kotlin, Ktor 3, Koin, PostgreSQL | [storm-example-kotlin-ktor](https://github.com/storm-orm/storm-example-kotlin-ktor) |
+| [Kotlin + Spring Boot](https://orm.st/examples/kotlin-spring-boot) | Kotlin, Spring Boot 4, PostgreSQL | [storm-example-kotlin-spring-boot-4](https://github.com/storm-orm/storm-example-kotlin-spring-boot-4) |
+| [Java + Spring Boot](https://orm.st/examples/java-spring-boot) | Java 21, Spring Boot 4, PostgreSQL | [storm-example-java-spring-boot-4](https://github.com/storm-orm/storm-example-java-spring-boot-4) |
 
 ## Documentation
 
@@ -273,6 +301,16 @@ Storm targets Kotlin 2.0+ and Java 21+ as minimum supported versions. These base
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+## Community
+
+Have a question, an idea, or something you built with Storm? Join the conversation in [GitHub Discussions](https://github.com/storm-orm/storm-framework/discussions):
+
+- [Ask a question](https://github.com/storm-orm/storm-framework/discussions/categories/q-a) if you are getting started or stuck.
+- [Share an idea](https://github.com/storm-orm/storm-framework/discussions/categories/ideas) for a future release.
+- [Show what you built](https://github.com/storm-orm/storm-framework/discussions/categories/show-and-tell).
+
+If Storm is useful to you, a [star](https://github.com/storm-orm/storm-framework) helps other developers find it.
+
 ## License
 
-Storm is released under the [Apache 2.0 License](LICENSE).
+Storm is released under the [Apache 2.0 License](LICENSE.txt).

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,14 +11,14 @@ The following tables provide a side-by-side comparison of concrete features acro
 
 ### Entity & Data Modeling
 
-| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Exposed | Ktorm |
-|---------|-------|-----|-------------|---------|------|------|---------|-------|
-| Lines per entity | ~5 | ~30<sup>1</sup> | ~30<sup>1</sup> | ~20+ | Generated | ~15 | ~12 | ~15 |
-| Immutable entities | Yes | No | No | Yes | Yes | Yes | DSL only | No |
-| Polymorphism | Yes<sup>2</sup> | Yes | Via JPA | No | No | No | No | No |
-| Automatic relationships | Yes | Yes<sup>3</sup> | Via JPA | No | No | No | DAO only | No |
-| Cascade persist | No | Yes | Yes | No | No | No | No | No |
-| Lifecycle callbacks | Yes | Yes | Via JPA | No | Yes | No | DAO only | No |
+| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Exposed | Ktorm | Jimmer |
+|---------|-------|-----|-------------|---------|------|------|---------|-------|--------|
+| Lines per entity | ~5 | ~30<sup>1</sup> | ~30<sup>1</sup> | ~20+ | Generated | ~15 | ~12 | ~15 | ~10 |
+| Immutable entities | Yes | No | No | Yes | Yes | Yes | DSL only | No | Yes |
+| Polymorphism | Yes<sup>2</sup> | Yes | Via JPA | No | No | No | No | No | No<sup>8</sup> |
+| Automatic relationships | Yes | Yes<sup>3</sup> | Via JPA | No | No | No | DAO only | No | Yes |
+| Cascade persist | No | Yes | Yes | No | No | No | No | No | Yes |
+| Lifecycle callbacks | Yes | Yes | Via JPA | No | Yes | No | DAO only | No | Yes |
 
 <sup>1</sup> JPA/Spring Data lines without Lombok; ~10 lines with Lombok.
 
@@ -26,32 +26,36 @@ The following tables provide a side-by-side comparison of concrete features acro
 
 <sup>3</sup> JPA relationships are runtime-managed via proxies.
 
+<sup>8</sup> Jimmer supports `@MappedSuperclass` for sharing fields across entities, but not JPA-style single-table, joined, or table-per-class inheritance strategies.
+
 ### Querying & Data Access
 
-| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Exposed | Ktorm |
-|---------|-------|-----|-------------|---------|------|------|---------|-------|
-| Type-safe queries | Yes | Criteria | No | No | Yes | No | Yes | Yes |
-| SQL Templates | Yes | No | No | XML/Ann | Yes | Yes | No | No |
-| N+1 prevention | Yes | No | No | No | Manual | Manual | No | No |
-| Lazy loading | Refs | Yes | Yes | No | No | No | Yes | Yes |
-| Scrolling | Yes | No | Yes | No | Yes | No | No | No |
-| JSON columns | Yes | Yes<sup>4</sup> | Via JPA | Manual | Yes | Module | Yes | Module |
-| JSON aggregation | Yes | No | No | No | Yes | No | No | No |
+| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Exposed | Ktorm | Jimmer |
+|---------|-------|-----|-------------|---------|------|------|---------|-------|--------|
+| Type-safe queries | Yes | Criteria | No | No | Yes | No | Yes | Yes | Yes |
+| SQL Templates | Yes | No | No | XML/Ann | Yes | Yes | No | No | Native<sup>9</sup> |
+| N+1 prevention | Yes | No | No | No | Manual | Manual | No | No | Yes |
+| Lazy loading | Refs | Yes | Yes | No | No | No | Yes | Yes | Fetchers |
+| Scrolling | Yes | No | Yes | No | Yes | No | No | No | No |
+| JSON columns | Yes | Yes<sup>4</sup> | Via JPA | Manual | Yes | Module | Yes | Module | Yes |
+| JSON aggregation | Yes | No | No | No | Yes | No | No | No | No |
 
 <sup>4</sup> JPA requires Hibernate 6.2+ for built-in JSON support; older versions need a third-party library or custom `AttributeConverter`.
 
+<sup>9</sup> Jimmer has no SQL template engine, but native SQL fragments can be embedded in its type-safe DSL via `sql(...)`.
+
 ### Runtime & Ecosystem
 
-| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Exposed | Ktorm |
-|---------|-------|-----|-------------|---------|------|------|---------|-------|
-| Transactions | Both | Both | Declarative | Both | Programmatic | Both | Both<sup>6</sup> | Required |
-| Schema validation | Yes | Yes | Via JPA | No | N/A<sup>5</sup> | No | Yes | No |
-| Java support | Yes | Yes | Yes | Yes | Yes | Yes | No | No |
-| Kotlin support | First-class | Good | Good | Good | Good | Good | Native | Native |
-| Coroutines | Yes | No | No | No | No | No | Yes | Limited |
-| Spring integration | Yes | Yes | Native | Yes | Yes | Yes | Yes | Yes |
-| Runtime mechanism | Codegen<sup>7</sup> | Bytecode | Bytecode | Reflection | Codegen | Reflection | Reflection | Reflection |
-| Community | New | Huge | Huge | Large | Medium | Medium | Medium | Small |
+| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Exposed | Ktorm | Jimmer |
+|---------|-------|-----|-------------|---------|------|------|---------|-------|--------|
+| Transactions | Both | Both | Declarative | Both | Programmatic | Both | Both<sup>6</sup> | Required | Both |
+| Schema validation | Yes | Yes | Via JPA | No | N/A<sup>5</sup> | No | Yes | No | No |
+| Java support | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes |
+| Kotlin support | First-class | Good | Good | Good | Good | Good | Native | Native | First-class |
+| Coroutines | Yes | No | No | No | No | No | Yes | Limited | No |
+| Spring integration | Yes | Yes | Native | Yes | Yes | Yes | Yes | Yes | Yes |
+| Runtime mechanism | Codegen<sup>7</sup> | Bytecode | Bytecode | Reflection | Codegen | Reflection | Reflection | Reflection | Codegen |
+| Community | New | Huge | Huge | Large | Medium | Medium | Medium | Small | Small |
 
 <sup>5</sup> jOOQ generates code from the database schema, so schema validation is inherent in its code generation step.
 
@@ -214,6 +218,80 @@ JDBI is a lightweight SQL convenience library that sits just above JDBC. It hand
 - You want full SQL control
 - You prefer minimal abstraction
 - You have mostly complex queries that don't fit ORM patterns
+
+## Storm vs Jimmer
+
+Jimmer is a modern Kotlin and Java ORM that, like Storm, is built on immutable entities and a stateless model with no persistence context, and it eliminates the N+1 problem by design. The two frameworks share a great deal of philosophy. Where they differ is conciseness and concept count. Jimmer trades some concision for GraphQL-style dynamic object fetching: entities are interfaces you interact with through generated drafts, reading a foreign-key id without loading the association requires an extra `@IdView` property, and every query ends in an explicit `select` with an object fetcher. That fetcher, together with Jimmer's dedicated DTO language, is a genuine strength for shape-controlled API responses. Storm keeps the model a plain data class and the query a single line, and treats any data class as a result type.
+
+Defining an entity:
+
+```kotlin
+// Jimmer
+@Entity
+interface Book {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long
+    val name: String
+    val price: BigDecimal
+
+    @ManyToOne
+    val store: BookStore?
+
+    @IdView("store")           // extra property to read the FK id without loading
+    val storeId: Long?
+}
+
+// Storm — book.store.id is already available, so no extra property is needed
+data class Book(
+    @PK val id: Long = 0,
+    val name: String,
+    val price: BigDecimal,
+    @FK val store: BookStore?
+) : Entity<Long>
+```
+
+Loading a book together with its store:
+
+```kotlin
+// Jimmer — explicit query and object fetcher
+val books = sqlClient.createQuery(Book::class) {
+    where(table.store.name eq "Manning")
+    select(table.fetchBy {
+        allScalarFields()
+        store { allScalarFields() }
+    })
+}.execute()
+
+// Storm — the store is loaded in the same query
+val books = books.findAll(Book_.store.name eq "Manning")
+```
+
+| Aspect | Storm | Jimmer |
+|--------|-------|--------|
+| **Entities** | Immutable data classes, constructed directly | Immutable interfaces, constructed and copied via generated drafts |
+| **Foreign-key id** | `book.store.id`, always available | Declare an extra `@IdView` property per association |
+| **Simple query** | `findAll(Book_.store.name eq "...")` | `createQuery { where(...); select(table.fetchBy { ... }) }.execute()` |
+| **Result shaping** | Any data class is a result type | Object fetchers and a dedicated `.dto` language |
+| **N+1 Problem** | Prevented via single joined query | Prevented via batched separate queries (DataLoader-style) |
+| **State** | Stateless; no persistence context | Stateless; no persistence context |
+| **Caching** | Transaction-scoped identity cache | Multi-level cache with automatic invalidation |
+| **Languages** | Kotlin + Java | Kotlin + Java |
+| **License** | Apache 2.0 | Apache 2.0 |
+
+### When to Choose Storm
+
+- You want the smallest possible entity model and one-line queries
+- Your reads mostly map to entities and projections
+- You prefer plain data classes over interfaces and generated drafts
+- You want relationships loaded in a single query
+
+### When to Choose Jimmer
+
+- You want GraphQL-style dynamic object fetching with precise shape control
+- Its DTO language for typed, reusable projections fits your API contracts
+- You rely on its multi-level caching with automatic invalidation
+- You want to save arbitrary object graphs with its save command
 
 ---
 
@@ -389,3 +467,4 @@ Ready to try it? See the [Getting Started](getting-started.md) guide.
 - [JDBI](https://jdbi.org/)
 - [Exposed](https://github.com/JetBrains/Exposed)
 - [Ktorm](https://www.ktorm.org/)
+- [Jimmer](https://github.com/babyfish-ct/jimmer)

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -21,6 +21,14 @@ const config: Config = {
 
   onBrokenLinks: 'warn',
 
+  // Exposed to client-side page components (e.g. the hand-built /quickstart
+  // page) so install snippets can render the resolved release version. The
+  // static-version-replace plugin only rewrites static files, not src/pages
+  // output, so pages read the version from here instead of @@STORM_VERSION@@.
+  customFields: {
+    stormVersion,
+  },
+
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],
@@ -46,7 +54,10 @@ const config: Config = {
           // because `/` is the landing page.
           if (existingPath.startsWith('/docs/')) {
             const rest = existingPath.slice('/docs/'.length);
-            if (rest) return ['/' + rest];
+            // Do not shadow real top-level pages that live under src/pages
+            // (e.g. /comparison, /quickstart) with a /docs redirect.
+            const reserved = new Set(['comparison', 'quickstart']);
+            if (rest && !reserved.has(rest)) return ['/' + rest];
           }
           return undefined;
         },
@@ -162,6 +173,11 @@ const config: Config = {
           position: 'left',
         },
         {
+          to: '/comparison',
+          label: 'Comparison',
+          position: 'left',
+        },
+        {
           to: '/blog/',
           label: 'Blog',
           position: 'left',
@@ -185,7 +201,7 @@ const config: Config = {
         {
           title: 'Docs',
           items: [
-            {label: 'Get Started', to: '/docs/getting-started'},
+            {label: 'Get Started', to: '/quickstart'},
             {label: 'Entities', to: '/docs/entities'},
             {label: 'Queries', to: '/docs/queries'},
           ],
@@ -197,6 +213,7 @@ const config: Config = {
             {label: 'Example Projects', to: '/examples/'},
             {label: 'Blog', to: '/blog/'},
             {label: 'GitHub', href: 'https://github.com/storm-orm/storm-framework'},
+            {label: 'Discussions', href: 'https://github.com/storm-orm/storm-framework/discussions'},
             {label: 'Maven Central', href: 'https://central.sonatype.com/namespace/st.orm'},
           ],
         },

--- a/website/src/components/tutorial/tutorialTheme.js
+++ b/website/src/components/tutorial/tutorialTheme.js
@@ -134,21 +134,22 @@ export function TutorialPage({title, description, slug, body}) {
 
 export const navHtml = (active) => `
 <nav><div class="wrap nav">
-  <div class="brand"><a class="bhome" href="/"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span></a><span class="tech-tag">Kotlin 2.0–2.4 · Java 21+ · Apache 2.0</span></div>
+  <div class="brand"><a class="bhome" href="/"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span></a><span class="tech-tag">Kotlin 2.0–2.4 · Apache 2.0</span></div>
   <div class="nav-links">
     <a href="/tutorials/"${active === 'tutorials' ? ' class="on"' : ''}>Tutorials</a>
     <a href="/examples/"${active === 'examples' ? ' class="on"' : ''}>Examples</a>
+    <a href="/comparison"${active === 'comparison' ? ' class="on"' : ''}>Comparison</a>
     <a href="/blog/"${active === 'blog' ? ' class="on"' : ''}>Blog</a>
     <a href="/docs/"${active === 'docs' ? ' class="on"' : ''}>Docs</a>
     <a class="gh" href="https://github.com/orgs/storm-orm/repositories">GitHub</a>
-    <a href="/docs/getting-started" class="btn primary" style="height:36px">Get started</a>
+    <a href="/quickstart" class="btn primary" style="height:36px">Get started</a>
   </div>
 </div></nav>`;
 
 export const FOOT_HTML = `
 <footer><div class="wrap foot">
   <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /></div>
-  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/blog/">Blog</a><a href="https://github.com/storm-orm/storm-framework">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
+  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/comparison">Comparison</a><a href="/blog/">Blog</a><a href="https://github.com/storm-orm/storm-framework">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
 </div></footer>`;
 
 export const TUT_CSS = `
@@ -250,12 +251,24 @@ export const TUT_CSS = `
   .storm-tut .note a{color:var(--accent)}
   .storm-tut .note a:hover{text-decoration:underline}
 
-  /* comparison table */
-  .storm-tut table.cmp{width:100%;border-collapse:collapse;margin:26px 0 0;font-size:14px}
-  .storm-tut .cmp th{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint);
-    text-align:left;padding:10px 14px;border-bottom:1px solid var(--border)}
-  .storm-tut .cmp td{padding:13px 14px;border-bottom:1px solid var(--border-soft);color:var(--body);line-height:1.6;vertical-align:top}
-  .storm-tut .cmp td:first-child{color:var(--text);font-weight:550}
+  /* comparison table — framed card, horizontal rules only (no boxy grid),
+     the outer border closes the bottom so the last row never looks unfinished.
+     Explicitly zeroes cell borders so Infima's default grid does not bleed
+     through. Column 2 is the Storm column in every comparison, so it is tinted. */
+  .storm-tut table.cmp{width:100%;border-collapse:separate;border-spacing:0;margin:26px 0 0;font-size:14px;
+    background:var(--panel-2);border:1px solid var(--border);border-radius:12px;overflow:hidden}
+  .storm-tut .cmp th,.storm-tut .cmp td{border:0;text-align:left;padding:13px 16px;vertical-align:top;line-height:1.55}
+  .storm-tut .cmp thead th{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;
+    color:var(--muted);background:rgba(255,255,255,.022);border-bottom:1px solid var(--border);white-space:nowrap}
+  .storm-tut .cmp tbody td{border-top:1px solid var(--border-soft);color:var(--body)}
+  .storm-tut .cmp tbody tr:first-child td{border-top:0}
+  .storm-tut .cmp tbody tr:nth-child(even) td{background:rgba(255,255,255,.014)}
+  .storm-tut .cmp td:first-child{color:var(--text);font-weight:600}
+  .storm-tut .cmp thead th:nth-child(2){color:var(--accent-2)}
+  .storm-tut .cmp tbody tr td:nth-child(2){background:rgba(129,140,248,.07);color:var(--text)}
+  /* let long inline code wrap inside cells instead of forcing the table wider
+     than its container (which the rounded overflow:hidden would then clip) */
+  .storm-tut .cmp th code,.storm-tut .cmp td code{white-space:normal;word-break:break-word}
 
   /* cta + doc refs */
   .storm-tut .cta{display:flex;gap:14px;margin-top:36px;flex-wrap:wrap}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -18,3 +18,28 @@
   --ifm-color-primary-lighter: #c5cae9;
   --ifm-color-primary-lightest: #e8eaf6;
 }
+
+/* Cleaner tables in docs and blog. Infima draws a full cell grid (vertical +
+   horizontal borders), which reads as a heavy spreadsheet. Drop the vertical
+   rules so it becomes clean horizontal rows, give the header a subtle fill, and
+   keep the header/last-row lines so the table reads as framed top and bottom.
+   Uses Infima variables, so it works in both light and dark themes. Left as a
+   normal `display:table` (no forced overflow) so wide docs tables still reflow
+   and scroll as before. */
+.markdown table {
+  width: 100%;
+}
+.markdown table th,
+.markdown table td {
+  border-left: 0;
+  border-right: 0;
+}
+.markdown table thead th {
+  background: var(--ifm-table-stripe-background);
+  border-top: 0;
+  border-bottom-width: 2px;
+  font-size: 0.82rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-700);
+}

--- a/website/src/pages/comparison.js
+++ b/website/src/pages/comparison.js
@@ -1,0 +1,141 @@
+import React, {useEffect} from 'react';
+import Head from '@docusaurus/Head';
+import {TUT_CSS, navHtml, FOOT_HTML, wireSqlToggles} from '../components/tutorial/tutorialTheme';
+
+// The comparison page at /comparison, in the landing/tutorial style. A
+// scannable, code-light companion to the in-depth docs/comparison.md: a
+// decision matrix plus a compact card per framework, each linking to the full
+// docs pairing. Jimmer is treated exactly like the other frameworks (a matrix
+// column and a card), with its detailed pairing living in the docs alongside
+// the rest. Kept fair per the project's competitor-copy rule: only differences
+// that are real and that the rival does not already cover are called out.
+
+const TITLE = 'Comparison · Storm vs JPA, jOOQ, Exposed, Jimmer';
+const DESC =
+  'How Storm compares to Hibernate/JPA, Spring Data, jOOQ, Exposed, Ktorm, ' +
+  'MyBatis, and Jimmer. A decision matrix plus a short, fair take on each, with ' +
+  'links to the full comparison.';
+
+// One card per framework, in the same order and format for all of them.
+const FRAMEWORKS = [
+  {
+    name: 'JPA / Hibernate',
+    slug: 'storm-vs-jpahibernate',
+    desc: 'The default for Java persistence. Storm trades managed entities, proxies, and lazy loading for immutable records and explicit, single-query loading.',
+    chips: ['Java + Kotlin', 'Mutable, managed'],
+  },
+  {
+    name: 'Spring Data JPA',
+    slug: 'storm-vs-spring-data-jpa',
+    desc: 'Repositories over JPA, with queries derived from method names. Storm keeps the repository convenience but writes explicit query bodies over stateless entities.',
+    chips: ['Java + Kotlin', 'Derived queries'],
+  },
+  {
+    name: 'jOOQ',
+    slug: 'storm-vs-jooq',
+    desc: 'A type-safe SQL DSL generated from your schema. jOOQ excels at complex SQL; Storm is more concise for entity work, deriving joins from @FK. Storm is fully open source.',
+    chips: ['Java + Kotlin', 'SQL-shaped DSL'],
+  },
+  {
+    name: 'Jimmer',
+    slug: 'storm-vs-jimmer',
+    desc: 'The closest peer: a modern, immutable, stateless Kotlin and Java ORM that also prevents N+1. The difference is conciseness. Storm keeps a plain data class and one-line queries; Jimmer uses interface entities, @IdView, and explicit fetchers for GraphQL-style shaping.',
+    chips: ['Java + Kotlin', 'Immutable'],
+  },
+  {
+    name: 'MyBatis',
+    slug: 'storm-vs-mybatis',
+    desc: 'A SQL mapper: you write every statement, Storm infers the common ones from entities and lets you drop to SQL templates for the rest.',
+    chips: ['Java + Kotlin', 'Hand-written SQL'],
+  },
+  {
+    name: 'Exposed',
+    slug: 'storm-vs-exposed',
+    desc: 'JetBrains’ Kotlin framework, defining tables as DSL objects. Storm declares the model once as annotated data classes and supports all seven transaction propagation modes without Spring.',
+    chips: ['Kotlin only', 'DSL tables'],
+  },
+  {
+    name: 'Ktorm',
+    slug: 'storm-vs-ktorm',
+    desc: 'A lightweight Kotlin ORM built on mutable entity interfaces and DSL tables. Storm uses immutable data classes and loads relationships in a single query.',
+    chips: ['Kotlin only', 'Mutable interfaces'],
+  },
+];
+
+function buildBody() {
+  const matrix = `
+<table class="cmp">
+  <thead><tr>
+    <th>Feature</th><th>Storm</th><th>JPA / Hibernate</th><th>jOOQ</th><th>Exposed</th><th>Jimmer</th>
+  </tr></thead>
+  <tbody>
+    <tr><td>Entity model</td><td>Immutable data class (~5 lines)</td><td>Mutable class (~30, ~10 with Lombok)</td><td>Generated from schema</td><td>DSL table object (+ optional DAO)</td><td>Immutable interface (KSP-generated)</td></tr>
+    <tr><td>Immutable entities</td><td>Yes</td><td>No</td><td>Yes</td><td>DSL only</td><td>Yes</td></tr>
+    <tr><td>Type-safe queries</td><td>Yes</td><td>Criteria API</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+    <tr><td>N+1 handling</td><td>Single-query entity graph</td><td>Common pitfall</td><td>Manual</td><td>Manual</td><td>Batched queries</td></tr>
+    <tr><td>Full SQL escape hatch</td><td>SQL templates</td><td>Native queries</td><td>It is SQL</td><td>Raw exec()</td><td>SQL expressions</td></tr>
+    <tr><td>Languages</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin only</td><td>Kotlin + Java</td></tr>
+    <tr><td>License</td><td>Apache 2.0</td><td>LGPL 2.1</td><td>Commercial for some DBs</td><td>Apache 2.0</td><td>Apache 2.0</td></tr>
+  </tbody>
+</table>`;
+
+  return `
+${navHtml('comparison')}
+
+<div class="art">
+  <div class="crumbs"><a href="/">Home</a><span class="sep">/</span>Comparison</div>
+  <h1>How Storm<br><span class="grad">compares.</span></h1>
+  <p class="dek">There is no universally best data framework. Storm is built for teams who want explicit, predictable database access with concise, immutable models. Here is where it sits next to the alternatives, and where each of them is the better call.</p>
+
+  <h2>At a glance</h2>
+  <p>Decision-relevant differences across the most common choices. The full, footnoted matrix and every pairing live in the <a class="tlink" href="/docs/comparison">docs comparison</a>.</p>
+  ${matrix}
+
+  <h2>Framework by framework</h2>
+  <p>A short, fair take on each. Every card links to the full pairing in the docs, with feature tables and code.</p>
+  <div class="cards">
+    ${FRAMEWORKS.map((f) => `
+    <a class="tcard" href="/docs/comparison#${f.slug}">
+      <div class="tt">Storm vs ${f.name}<span class="arrow">→</span></div>
+      <div class="td">${f.desc}</div>
+      <div class="tm">${f.chips.map((c) => `<span>${c}</span>`).join('')}</div>
+    </a>`).join('')}
+  </div>
+
+  <div class="cta">
+    <a href="/quickstart" class="btn primary">Try Storm →</a>
+    <a href="/docs/comparison" class="btn">Full comparison</a>
+  </div>
+</div>
+
+${FOOT_HTML}
+`;
+}
+
+export default function Comparison() {
+  useEffect(() => wireSqlToggles(), []);
+  const url = 'https://orm.st/comparison';
+  return (
+    <>
+      <Head>
+        <html lang="en" />
+        <title>{TITLE}</title>
+        <meta name="description" content={DESC} />
+        <link rel="canonical" href={url} />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={TITLE} />
+        <meta property="og:description" content={DESC} />
+        <meta name="twitter:title" content={TITLE} />
+        <meta name="twitter:description" content={DESC} />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <style dangerouslySetInnerHTML={{__html: TUT_CSS}} />
+      <div className="storm-tut" dangerouslySetInnerHTML={{__html: buildBody()}} />
+    </>
+  );
+}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -144,26 +144,27 @@ const CSS = `
 
 const BODY = `
 <nav><div class="wrap nav">
-  <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span><span class="tech-tag">Kotlin 2.0–2.4 · Java 21+ · Apache 2.0</span></div>
+  <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span><span class="tech-tag">Kotlin 2.0–2.4 · Apache 2.0</span></div>
   <div class="nav-links">
     <a href="/tutorials/">Tutorials</a>
     <a href="/examples/">Examples</a>
+    <a href="/comparison">Comparison</a>
     <a href="/blog/">Blog</a>
     <a href="/docs/">Docs</a>
     <a class="gh" href="https://github.com/orgs/storm-orm/repositories">GitHub</a>
-    <a href="/docs/getting-started" class="btn primary" style="height:36px">Get started</a>
+    <a href="/quickstart" class="btn primary" style="height:36px">Get started</a>
   </div>
 </div></nav>
 
 <header><div class="wrap">
   <h1>Radically Simple.<br><span class="hero-rot" id="valuesRotator">
-    <span class="grad in">Predictability over magic.</span>
+    <span class="grad in">Kotlin&nbsp;ORM.</span>
+    <span class="grad">Predictability over magic.</span>
     <span class="grad">Stateless over sessions.</span>
     <span class="grad">Immutable over managed.</span>
     <span class="grad">Explicit over surprises.</span>
-    <span class="grad">Intent over ceremony.</span>
   </span></h1>
-  <p class="sub" style="max-width:940px">Storm is a type-safe ORM for Kotlin and Java. A clear mapping between your entities and the database keeps them reusable and repositories easy to extend. Your persistence layer remains small, expressive, and fully capable as your application grows.</p>
+  <p class="sub" style="max-width:940px">Storm is a type-safe, SQL-first ORM for Kotlin. Concise data-class entities map cleanly to your database, and one-line queries keep your persistence layer small and expressive as your application grows. No proxies, no N+1, no persistence context.</p>
 
   <div class="stage">
     <div class="editor">
@@ -230,7 +231,7 @@ const BODY = `
   <h2>Write code worth reading.</h2>
   <p class="sub" style="margin:0 auto 30px;text-align:center;max-width:940px">Concise entities and one-line queries keep you productive. Immutable records simplify your architecture by letting the same types flow through your application layers. Storm is built for engineers who care about beautiful code.</p>
   <div class="cta" style="justify-content:center;margin-top:56px">
-    <a href="/docs/getting-started" class="btn primary">Get started →</a>
+    <a href="/quickstart" class="btn primary">Get started →</a>
     <a href="/examples/" class="btn">Example apps</a>
     <a href="https://github.com/storm-orm/storm-framework" class="btn">Star on GitHub</a>
   </div>
@@ -238,7 +239,7 @@ const BODY = `
 
 <footer><div class="wrap foot">
   <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /></div>
-  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/blog/">Blog</a><a href="https://github.com/storm-orm/storm-framework">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
+  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/comparison">Comparison</a><a href="/blog/">Blog</a><a href="https://github.com/storm-orm/storm-framework">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
 </div></footer>
 `;
 
@@ -333,8 +334,8 @@ export default function Home() {
           { t:"Stateless", d:"No session, flush, or transaction-bound proxies." },
           { t:"Portable", d:"Database specifics offered in a portable way, across all major databases." },
           { t:"Flexible", d:"From a simple DSL to full SQL templates when you need them." },
-          { t:"Fast", d:"Optimized for performance and memory, e.g. generated code instead of reflection." },
-          { t:"Efficient", d:"No heavyweight runtime, no external dependencies." },
+          { t:"Fast", d:"Optimized for performance, e.g. generated code instead of reflection." },
+          { t:"Efficient", d:"Low memory footprint, no heavyweight runtime, no external dependencies." },
         ] },
     ];
 
@@ -518,19 +519,24 @@ export default function Home() {
     let valuesTimer = null;
     if (valuesRotator) {
       const valueItems = valuesRotator.querySelectorAll('span');
+      const baseDwell = 4000;
+      // The Kotlin ORM line (index 0) stays twice as long as the principles.
+      const dwellFor = (i) => (i === 0 ? baseDwell * 2 : baseDwell);
       let valueIndex = 0;
-      valuesTimer = setInterval(() => {
+      const advance = () => {
         valueItems[valueIndex].classList.remove('in');
         valueIndex = (valueIndex + 1) % valueItems.length;
         valueItems[valueIndex].classList.add('in');
-      }, 4500);
+        valuesTimer = setTimeout(advance, dwellFor(valueIndex));
+      };
+      valuesTimer = setTimeout(advance, dwellFor(valueIndex));
     }
 
     // Stop the loop and undo DOM mutations when the page unmounts.
     return () => {
       gen++;
       clearTimeout(timer);
-      clearInterval(valuesTimer);
+      clearTimeout(valuesTimer);
       if(scenesEl) scenesEl.innerHTML='';
       if(sqlBtn) sqlBtn.removeEventListener('click',onSqlClick);
     };
@@ -540,10 +546,14 @@ export default function Home() {
     <>
       <Head>
         <html lang="en" />
-        <title>Storm — Type-safe ORM for Kotlin & Java 21+</title>
+        <title>Storm · The type-safe Kotlin ORM</title>
         <meta
           name="description"
-          content="Type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Concise entities, one-line queries, immutable records — every query explicit, no proxies, no N+1."
+          content="Storm is a type-safe, SQL-first Kotlin ORM. Concise data-class entities, one-line queries, immutable records. Every query explicit: no proxies, no N+1, no persistence context."
+        />
+        <meta
+          name="keywords"
+          content="Kotlin ORM, type-safe ORM, SQL-first ORM, Kotlin database library, Hibernate alternative, JPA alternative, Exposed alternative, Storm ORM"
         />
         {/* Open Graph / Twitter: default og:title is just the site name
             ("Storm Framework") and og:description is absent, so set the
@@ -551,19 +561,19 @@ export default function Home() {
         <meta property="og:type" content="website" />
         <meta
           property="og:title"
-          content={'Storm — Type-safe ORM for Kotlin & Java 21+'}
+          content={'Storm · The type-safe Kotlin ORM'}
         />
         <meta
           property="og:description"
-          content="Type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Concise entities, one-line queries, immutable records — every query explicit, no proxies, no N+1."
+          content="Storm is a type-safe, SQL-first Kotlin ORM. Concise data-class entities, one-line queries, immutable records. Every query explicit: no proxies, no N+1, no persistence context."
         />
         <meta
           name="twitter:title"
-          content={'Storm — Type-safe ORM for Kotlin & Java 21+'}
+          content={'Storm · The type-safe Kotlin ORM'}
         />
         <meta
           name="twitter:description"
-          content="Type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Concise entities, one-line queries, immutable records — every query explicit, no proxies, no N+1."
+          content="Storm is a type-safe, SQL-first Kotlin ORM. Concise data-class entities, one-line queries, immutable records. Every query explicit: no proxies, no N+1, no persistence context."
         />
         {/* Structured data so search engines can identify Storm as a
             developer tool for Kotlin/Java and consolidate it with its GitHub
@@ -573,11 +583,11 @@ export default function Home() {
             '@context': 'https://schema.org',
             '@type': 'SoftwareApplication',
             name: 'Storm',
-            alternateName: 'Storm ORM',
+            alternateName: ['Storm ORM', 'Storm Kotlin ORM'],
             applicationCategory: 'DeveloperApplication',
             operatingSystem: 'JVM (Kotlin, Java)',
             description:
-              'Storm is a type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+. Define concise, immutable entities and write one-line queries — nested predicates and entity graphs compile to a single efficient query, eliminating accidental hidden N+1 queries. Drop to full SQL templates whenever you want; never locked in.',
+              'Storm is a type-safe, SQL-first Kotlin ORM. Define concise, immutable data-class entities and write one-line queries. Nested predicates and entity graphs compile to a single efficient query, eliminating accidental hidden N+1 queries. Drop to full SQL templates whenever you want; never locked in.',
             featureList: [
               'Direct database control — every query explicit, no hidden N+1',
               'Stateless, immutable records — no proxies, no flush, no hidden state',

--- a/website/src/pages/quickstart.js
+++ b/website/src/pages/quickstart.js
@@ -1,0 +1,170 @@
+import React, {useEffect} from 'react';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {
+  TUT_CSS,
+  navHtml,
+  FOOT_HTML,
+  editor,
+  wireSqlToggles,
+  K, T, S, C, F, N, A, P, QK, QQ, QC,
+} from '../components/tutorial/tutorialTheme';
+
+// The 5-minute quickstart. Built in the landing/tutorial style (see
+// tutorialTheme.js) rather than as a docs page so it deploys live immediately
+// and is the target of every "Get started" button on the site. Kotlin-first;
+// leads with the Storm CLI one-liner (AI-assisted setup), with the manual build
+// right below. The install snippet renders the resolved release version, read
+// from siteConfig.customFields.stormVersion (docusaurus.config.ts).
+
+const TITLE = 'Quickstart · Your first Storm query in five minutes';
+const DESC =
+  'Set up Storm, define an entity as a plain Kotlin data class, and run a ' +
+  'type-safe query. The whole path from empty project to first query, with the ' +
+  'SQL it generates.';
+
+function buildBody(version) {
+  const cli = P('npx @storm-orm/cli init');
+
+  const install =
+    C('// build.gradle.kts\n') +
+    F('plugins') + P(' {\n') +
+    P('    ') + F('kotlin') + P('(') + S('"jvm"') + P(') version ') + S('"2.0.21"') + P('\n') +
+    P('    ') + F('id') + P('(') + S('"com.google.devtools.ksp"') + P(') version ') + S('"2.0.21-1.0.28"') + P('\n') +
+    P('}\n\n') +
+    F('dependencies') + P(' {\n') +
+    P('    ') + F('implementation') + P('(') + F('platform') + P('(') + S(`"st.orm:storm-bom:${version}"`) + P('))\n') +
+    P('    ') + F('implementation') + P('(') + S('"st.orm:storm-kotlin"') + P(')\n') +
+    P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-core"') + P(')\n') +
+    P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-h2"') + P(')          ') + C('// zero-setup in-memory database\n') +
+    P('    ') + F('runtimeOnly') + P('(') + S('"com.h2database:h2:2.2.224"') + P(')\n') +
+    P('    ') + F('ksp') + P('(') + S('"st.orm:storm-metamodel-ksp"') + P(')\n') +
+    P('    ') + F('kotlinCompilerPluginClasspath') + P('(') + S('"st.orm:storm-compiler-plugin-2.0"') + P(')\n') +
+    P('}');
+
+  const entity =
+    C('// Movie.kt — a plain data class. This is the whole entity.\n') +
+    K('data class ') + T('Movie') + P('(\n') +
+    P('    ') + A('@PK') + P(' ') + K('val ') + P('id: ') + T('Int') + P(' = ') + N('0') + P(',\n') +
+    P('    ') + K('val ') + P('title: ') + T('String') + P(',\n') +
+    P('    ') + K('val ') + P('year: ') + T('Int') + P(',\n') +
+    P('    ') + K('val ') + P('rating: ') + T('Double') + P(',\n') +
+    P(') : ') + T('Entity') + P('<') + T('Int') + P('>');
+
+  const schema =
+    C('-- create the table with your migration tool, or run this once\n') +
+    K('CREATE TABLE ') + P('movie (\n') +
+    P('    id      ') + T('INT') + P(' ') + K('PRIMARY KEY AUTO_INCREMENT') + P(',\n') +
+    P('    title   ') + T('VARCHAR') + P('(') + N('200') + P('),\n') +
+    P('    year    ') + T('INT') + P(',\n') +
+    P('    rating  ') + T('DOUBLE') + P('\n') +
+    P(');');
+
+  const query =
+    C('// Open an ORM on any JDBC DataSource. Thread-safe; create it once.\n') +
+    K('val ') + P('orm = dataSource.orm\n\n') +
+    C('// A repository for Movie: every CRUD method included, nothing to implement.\n') +
+    K('val ') + P('movies = orm.') + F('entity') + P('<') + T('Movie') + P('>()\n\n') +
+    C('// Insert returns a copy with the generated id.\n') +
+    K('val ') + P('saved = orm ') + K('insert ') + T('Movie') + P('(title = ') + S('"Dune: Part Two"') + P(', year = ') + N('2024') + P(', rating = ') + N('8.5') + P(')\n\n') +
+    C('// One type-safe line. Movie_ is generated at compile time, so a typo fails to compile.\n') +
+    K('val ') + P('recent = movies.') + F('findAll') + P('(Movie_.year ') + K('eq') + P(' ') + N('2024') + P(')');
+
+  const querySql =
+    QC('-- orm insert Movie(...)\n') +
+    QK('INSERT INTO') + ' movie (title, year, rating) ' + QK('VALUES') + ' (' + QQ('?') + ', ' + QQ('?') + ', ' + QQ('?') + ')\n\n' +
+    QC('-- movies.findAll(Movie_.year eq 2024)\n') +
+    QK('SELECT') + ' m.id, m.title, m.year, m.rating\n' +
+    QK('FROM') + ' movie m\n' +
+    QK('WHERE') + ' m.year = ' + QQ('?');
+
+  return `
+${navHtml('')}
+
+<div class="art">
+  <div class="crumbs"><a href="/">Home</a><span class="sep">/</span>Quickstart</div>
+  <h1>Your first query.<br><span class="grad">Five minutes.</span></h1>
+  <p class="dek">Install Storm, define an entity as a plain Kotlin data class, and run a type-safe query. No persistence context, no proxies, no XML. Here is the whole path.</p>
+  <div class="meta"><span>Kotlin</span><span>~5 min</span><span>JDK 21+</span></div>
+
+  <h2><span class="hno">1</span>Set up</h2>
+  <p>The fastest way in is the Storm CLI. It installs Storm-aware rules and skills for your AI coding assistant (Claude, Cursor, Copilot, Windsurf, Codex) and sets up a schema-aware MCP server, so the entities and queries it generates match your real schema.</p>
+  ${editor({file: 'terminal', tag: 'shell', code: cli})}
+  <p>Prefer to wire the build by hand? Add the Storm modules yourself. This is the full Kotlin set for a runnable project on an in-memory H2 database; the BOM keeps the versions aligned.</p>
+  ${editor({file: 'build.gradle.kts', tag: 'Gradle · Kotlin DSL', code: install})}
+  <p>The <code>ksp</code> dependency generates the type-safe metamodel (<code>Movie_</code>), and the compiler plugin makes SQL templates injection-safe by default. On a real database, swap <code>storm-h2</code> for your dialect and add its JDBC driver. See the <a class="tlink" href="/docs/installation">installation guide</a> for all options.</p>
+
+  <h2><span class="hno">2</span>Define an entity</h2>
+  <p>Entities are plain immutable data classes that implement <code>Entity&lt;ID&gt;</code>. Field names map to columns automatically (camelCase to snake_case). There is no base class to extend and no generated draft type to route through: the class you write is the object you get back.</p>
+  ${editor({file: 'Movie.kt', tag: 'Kotlin', code: entity})}
+  <p>Storm maps to an existing schema rather than creating one, so define the table with your migration tool (Flyway, Liquibase) or a one-off DDL script. Storm can verify at startup that your entities match it with <code>validateSchema()</code>.</p>
+  ${editor({file: 'schema.sql', tag: 'SQL', code: schema})}
+
+  <h2><span class="hno">3</span>Run a query</h2>
+  <p>Open an <code>ORMTemplate</code> on your <code>DataSource</code>, ask for a repository, and query it. Toggle <b>Show SQL</b> to see exactly what Storm runs: one statement, fully parameterized, no surprises.</p>
+  ${editor({file: 'Main.kt', tag: 'Kotlin', code: query, sql: querySql})}
+  <p>That is the core loop. Insert, <code>findById</code>, <code>update</code>, and <code>remove</code> all come for free on the repository; add your own one-line queries whenever you need them.</p>
+
+  <h2><span class="hno">4</span>Where to next</h2>
+  <p>You have the whole shape of Storm in three steps. From here:</p>
+  <div class="refs">
+    <a href="/tutorials/build-a-rest-api">Build a REST API from scratch</a>
+    <a href="/docs/first-query">First Query</a>
+    <a href="/docs/entities">Entities</a>
+    <a href="/examples/">Example apps</a>
+    <a href="/comparison">How Storm compares</a>
+  </div>
+
+  <div class="cta">
+    <a href="/tutorials/build-a-rest-api" class="btn primary">Build a real app →</a>
+    <a href="/docs/" class="btn">Read the docs</a>
+  </div>
+</div>
+
+${FOOT_HTML}
+`;
+}
+
+export default function Quickstart() {
+  const {siteConfig} = useDocusaurusContext();
+  const version = siteConfig.customFields?.stormVersion || '0.0.0';
+  useEffect(() => wireSqlToggles(), []);
+  const url = 'https://orm.st/quickstart';
+  return (
+    <>
+      <Head>
+        <html lang="en" />
+        <title>{TITLE}</title>
+        <meta name="description" content={DESC} />
+        <link rel="canonical" href={url} />
+        <meta property="og:type" content="article" />
+        <meta property="og:title" content={TITLE} />
+        <meta property="og:description" content={DESC} />
+        <meta name="twitter:title" content={TITLE} />
+        <meta name="twitter:description" content={DESC} />
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'HowTo',
+            name: 'Get started with Storm: your first query in five minutes',
+            description: DESC,
+            url,
+            step: [
+              {'@type': 'HowToStep', name: 'Set up', text: 'Use the Storm CLI, or add the Storm BOM and Kotlin modules to your build.'},
+              {'@type': 'HowToStep', name: 'Define an entity', text: 'Write a plain Kotlin data class that implements Entity<ID>.'},
+              {'@type': 'HowToStep', name: 'Run a query', text: 'Open an ORMTemplate on a DataSource and run a type-safe query.'},
+            ],
+          })}
+        </script>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <style dangerouslySetInnerHTML={{__html: TUT_CSS}} />
+      <div className="storm-tut" dangerouslySetInnerHTML={{__html: buildBody(version)}} />
+    </>
+  );
+}

--- a/website/src/pages/tutorials/build-a-rest-api.js
+++ b/website/src/pages/tutorials/build-a-rest-api.js
@@ -1,0 +1,255 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {
+  TutorialPage,
+  navHtml,
+  FOOT_HTML,
+  editor,
+  K, T, S, C, F, N, A, P, QK, QC,
+} from '../../components/tutorial/tutorialTheme';
+
+// End-to-end tutorial: build a small but complete REST API from an empty
+// project to running endpoints and a test. Kotlin + Ktor (the lightest way to
+// show the whole loop). Lives as a website tutorial page so it deploys live
+// immediately and the /quickstart "Build a real app" button can link to it.
+// The install snippet renders the resolved release version from customFields.
+
+const TITLE = 'Build a REST API from scratch';
+const DESC =
+  'From an empty project to a running, tested REST API with Storm and Ktor: ' +
+  'model two entities, load their relationship in a single query, expose CRUD ' +
+  'routes, and assert the SQL with a test.';
+
+function buildBody(version) {
+  const gradle =
+    C('// build.gradle.kts\n') +
+    F('plugins') + P(' {\n') +
+    P('    ') + F('kotlin') + P('(') + S('"jvm"') + P(') version ') + S('"2.0.21"') + P('\n') +
+    P('    ') + F('id') + P('(') + S('"io.ktor.plugin"') + P(') version ') + S('"3.0.3"') + P('\n') +
+    P('    ') + F('id') + P('(') + S('"com.google.devtools.ksp"') + P(') version ') + S('"2.0.21-1.0.28"') + P('\n') +
+    P('}\n\n') +
+    F('dependencies') + P(' {\n') +
+    P('    ') + F('implementation') + P('(') + F('platform') + P('(') + S(`"st.orm:storm-bom:${version}"`) + P('))\n') +
+    P('    ') + F('implementation') + P('(') + S('"st.orm:storm-kotlin"') + P(')\n') +
+    P('    ') + F('implementation') + P('(') + S('"st.orm:storm-ktor"') + P(')\n') +
+    P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-core"') + P(')\n') +
+    P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-h2"') + P(')\n') +
+    P('    ') + F('runtimeOnly') + P('(') + S('"com.h2database:h2:2.2.224"') + P(')\n') +
+    P('    ') + F('ksp') + P('(') + S('"st.orm:storm-metamodel-ksp"') + P(')\n') +
+    P('    ') + F('kotlinCompilerPluginClasspath') + P('(') + S('"st.orm:storm-compiler-plugin-2.0"') + P(')\n\n') +
+    P('    ') + F('implementation') + P('(') + S('"io.ktor:ktor-server-netty"') + P(')\n') +
+    P('    ') + F('implementation') + P('(') + S('"io.ktor:ktor-server-content-negotiation"') + P(')\n') +
+    P('    ') + F('implementation') + P('(') + S('"io.ktor:ktor-serialization-jackson"') + P(')\n') +
+    P('    ') + F('implementation') + P('(') + S('"st.orm:storm-jackson2"') + P(')\n\n') +
+    P('    ') + F('testImplementation') + P('(') + S('"st.orm:storm-ktor-test"') + P(')\n') +
+    P('    ') + F('testImplementation') + P('(') + S('"com.h2database:h2"') + P(')\n') +
+    P('}');
+
+  const schema =
+    C('-- src/main/resources/schema.sql\n') +
+    K('CREATE TABLE ') + P('folder (\n') +
+    P('    id    ') + T('INT') + P(' ') + K('PRIMARY KEY AUTO_INCREMENT') + P(',\n') +
+    P('    name  ') + T('VARCHAR') + P('(') + N('100') + P(') ') + K('NOT NULL') + P('\n') +
+    P(');\n') +
+    K('CREATE TABLE ') + P('bookmark (\n') +
+    P('    id         ') + T('INT') + P(' ') + K('PRIMARY KEY AUTO_INCREMENT') + P(',\n') +
+    P('    url        ') + T('VARCHAR') + P('(') + N('2000') + P(') ') + K('NOT NULL') + P(',\n') +
+    P('    title      ') + T('VARCHAR') + P('(') + N('200') + P(') ') + K('NOT NULL') + P(',\n') +
+    P('    folder_id  ') + T('INT') + P(' ') + K('NOT NULL REFERENCES') + P(' folder(id)\n') +
+    P(');\n') +
+    C('-- one folder to start with\n') +
+    K('INSERT INTO ') + P('folder (name) ') + K('VALUES') + P(' (') + S("'Reading'") + P(');');
+
+  const entities =
+    C('// Folder.kt\n') +
+    K('data class ') + T('Folder') + P('(\n') +
+    P('    ') + A('@PK') + P(' ') + K('val ') + P('id: ') + T('Int') + P(' = ') + N('0') + P(',\n') +
+    P('    ') + K('val ') + P('name: ') + T('String') + P(',\n') +
+    P(') : ') + T('Entity') + P('<') + T('Int') + P('>\n\n') +
+    C('// Bookmark.kt — @FK means the folder is loaded in the same query\n') +
+    K('data class ') + T('Bookmark') + P('(\n') +
+    P('    ') + A('@PK') + P(' ') + K('val ') + P('id: ') + T('Int') + P(' = ') + N('0') + P(',\n') +
+    P('    ') + K('val ') + P('url: ') + T('String') + P(',\n') +
+    P('    ') + K('val ') + P('title: ') + T('String') + P(',\n') +
+    P('    ') + A('@FK') + P(' ') + K('val ') + P('folder: ') + T('Folder') + P(',\n') +
+    P(') : ') + T('Entity') + P('<') + T('Int') + P('>');
+
+  const conf =
+    C('# src/main/resources/application.conf\n') +
+    P('storm {\n') +
+    P('    datasource {\n') +
+    P('        jdbcUrl = ') + S("\"jdbc:h2:mem:bookmarks;DB_CLOSE_DELAY=-1;INIT=RUNSCRIPT FROM 'classpath:schema.sql'\"") + P('\n') +
+    P('        username = ') + S('"sa"') + P('\n') +
+    P('        password = ') + S('""') + P('\n') +
+    P('    }\n') +
+    P('    validation { schemaMode = ') + S('"warn"') + P(' }') + P('   ') + C('# log any entity/schema mismatch\n') +
+    P('}');
+
+  const repo =
+    C('// BookmarkRepository.kt — CRUD is inherited; add only your own queries\n') +
+    K('interface ') + T('BookmarkRepository') + P(' : ') + T('EntityRepository') + P('<') + T('Bookmark') + P(', ') + T('Int') + P('> {\n') +
+    P('    ') + K('fun ') + F('findByFolderName') + P('(name: ') + T('String') + P('): ') + T('List') + P('<') + T('Bookmark') + P('> =\n') +
+    P('        ') + F('findAll') + P('(Bookmark_.folder.name ') + K('eq') + P(' name)\n') +
+    P('}');
+
+  const app =
+    C('// Application.kt\n') +
+    K('fun ') + F('main') + P('() {\n') +
+    P('    ') + F('embeddedServer') + P('(') + T('Netty') + P(', port = ') + N('8080') + P(') { ') + F('module') + P('() }.') + F('start') + P('(wait = ') + K('true') + P(')\n') +
+    P('}\n\n') +
+    K('fun ') + T('Application') + P('.') + F('module') + P('() {\n') +
+    P('    ') + F('install') + P('(') + T('Storm') + P(')') + P('                     ') + C('// reads storm.datasource; auto-registers repositories\n') +
+    P('    ') + F('install') + P('(') + T('ContentNegotiation') + P(') {\n') +
+    P('        ') + F('jackson') + P(' { ') + F('registerModule') + P('(') + T('StormModule') + P('()) }\n') +
+    P('    }\n') +
+    P('    ') + F('routing') + P(' { ') + F('bookmarkRoutes') + P('() }\n') +
+    P('}');
+
+  const routes =
+    C('// Routes.kt\n') +
+    A('@JsonIgnoreProperties') + P('(ignoreUnknown = ') + K('true') + P(')\n') +
+    K('data class ') + T('NewBookmark') + P('(') + K('val ') + P('url: ') + T('String') + P(', ') + K('val ') + P('title: ') + T('String') + P(', ') + K('val ') + P('folderId: ') + T('Int') + P(')\n\n') +
+    K('fun ') + T('Route') + P('.') + F('bookmarkRoutes') + P('() {\n') +
+    P('    ') + F('get') + P('(') + S('"/bookmarks"') + P(') {\n') +
+    P('        call.') + F('respond') + P('(') + F('repository') + P('<') + T('BookmarkRepository') + P('>().') + F('findAll') + P('())\n') +
+    P('    }\n\n') +
+    P('    ') + F('get') + P('(') + S('"/bookmarks/{id}"') + P(') {\n') +
+    P('        ') + K('val ') + P('id = call.parameters.') + F('getOrFail') + P('(') + S('"id"') + P(').') + F('toInt') + P('()\n') +
+    P('        ') + K('val ') + P('bookmark = call.orm.') + F('entity') + P('<') + T('Bookmark') + P('>().') + F('findById') + P('(id)\n') +
+    P('        call.') + F('respond') + P('(bookmark ?: ') + T('HttpStatusCode') + P('.NotFound)\n') +
+    P('    }\n\n') +
+    P('    ') + F('post') + P('(') + S('"/bookmarks"') + P(') {\n') +
+    P('        ') + K('val ') + P('body = call.') + F('receive') + P('<') + T('NewBookmark') + P('>()\n') +
+    P('        ') + K('val ') + P('folder = call.orm.') + F('entity') + P('<') + T('Folder') + P('>().') + F('findById') + P('(body.folderId)\n') +
+    P('        ') + K('if ') + P('(folder == ') + K('null') + P(') { call.') + F('respond') + P('(') + T('HttpStatusCode') + P('.BadRequest, ') + S('"unknown folder"') + P('); ') + K('return@post') + P(' }\n') +
+    P('        ') + K('val ') + P('created = ') + F('transaction') + P(' {\n') +
+    P('            call.orm ') + K('insert ') + T('Bookmark') + P('(url = body.url, title = body.title, folder = folder)\n') +
+    P('        }\n') +
+    P('        call.') + F('respond') + P('(') + T('HttpStatusCode') + P('.Created, created)\n') +
+    P('    }\n\n') +
+    P('    ') + F('delete') + P('(') + S('"/bookmarks/{id}"') + P(') {\n') +
+    P('        ') + K('val ') + P('id = call.parameters.') + F('getOrFail') + P('(') + S('"id"') + P(').') + F('toInt') + P('()\n') +
+    P('        ') + F('transaction') + P(' { call.orm.') + F('entity') + P('<') + T('Bookmark') + P('>().') + F('removeById') + P('(id) }\n') +
+    P('        call.') + F('respond') + P('(') + T('HttpStatusCode') + P('.NoContent)\n') +
+    P('    }\n') +
+    P('}');
+
+  const listCode =
+    C('// GET /bookmarks returns every bookmark, each with its folder\n') +
+    F('repository') + P('<') + T('BookmarkRepository') + P('>().') + F('findAll') + P('()');
+  const listSql =
+    QC('-- one query, no N+1: the folder is joined in\n') +
+    QK('SELECT') + ' b.id, b.url, b.title, f.id, f.name\n' +
+    QK('FROM') + ' bookmark b\n' +
+    QK('INNER JOIN') + ' folder f ' + QK('ON') + ' b.folder_id = f.id';
+
+  const run =
+    C('# start the app\n') +
+    P('./gradlew run\n\n') +
+    C('# create a bookmark in folder 1\n') +
+    P('curl -s -X POST localhost:8080/bookmarks \\\n') +
+    P("  -H 'content-type: application/json' \\\n") +
+    P('  -d ') + S('\'{"url":"https://orm.st","title":"Storm","folderId":1}\'') + P('\n\n') +
+    C('# list them back — each bookmark includes its folder object\n') +
+    P('curl -s localhost:8080/bookmarks');
+
+  const test =
+    C('// BookmarkRoutesTest.kt\n') +
+    A('@Test') + P('\n') +
+    K('fun ') + P('`POST creates a bookmark with a single insert`() = ') + F('testStormApplication') + P('(\n') +
+    P('    scripts = ') + F('listOf') + P('(') + S('"/schema.sql"') + P('),\n') +
+    P(') { scope ->\n') +
+    P('    ') + F('application') + P(' {\n') +
+    P('        ') + F('install') + P('(') + T('Storm') + P(') { dataSource = scope.stormDataSource }\n') +
+    P('        ') + F('install') + P('(') + T('ContentNegotiation') + P(') { ') + F('jackson') + P(' { ') + F('registerModule') + P('(') + T('StormModule') + P('()) } }\n') +
+    P('        ') + F('routing') + P(' { ') + F('bookmarkRoutes') + P('() }\n') +
+    P('    }\n\n') +
+    P('    scope.stormSqlCapture.') + F('run') + P(' {\n') +
+    P('        client.') + F('post') + P('(') + S('"/bookmarks"') + P(') {\n') +
+    P('            ') + F('contentType') + P('(') + T('ContentType') + P('.Application.Json)\n') +
+    P('            ') + F('setBody') + P('(') + S('"""{"url":"https://orm.st","title":"Storm","folderId":1}"""') + P(')\n') +
+    P('        }\n') +
+    P('    }\n') +
+    P('    ') + F('assertEquals') + P('(') + N('1') + P(', scope.stormSqlCapture.') + F('count') + P('(') + T('Operation') + P('.INSERT))\n') +
+    P('}');
+
+  return `
+${navHtml('tutorials')}
+
+<div class="art">
+  <div class="crumbs"><a href="/">Home</a><span class="sep">/</span><a href="/tutorials/">Tutorials</a><span class="sep">/</span>Build a REST API</div>
+  <h1>Build a REST API<br><span class="grad">from scratch.</span></h1>
+  <p class="dek">Start with an empty project and finish with a running, tested REST API: two entities, their relationship loaded in a single query, CRUD routes over Ktor, and a test that asserts the exact SQL. About twenty minutes end to end.</p>
+  <div class="meta"><span>Kotlin</span><span>Ktor 3</span><span>~20 min</span></div>
+
+  <div class="note">New to Storm? The <a href="/quickstart">five-minute quickstart</a> covers just install, entity, and query. This tutorial builds the whole app around them.</div>
+
+  <h2><span class="hno">1</span>Create the project</h2>
+  <p>Start a plain Kotlin/Gradle project and add Ktor and Storm. The Ktor plugin manages the Ktor artifact versions, and the Storm BOM manages Storm's, so most dependencies need no version. We use H2 so there is nothing to install.</p>
+  ${editor({file: 'build.gradle.kts', tag: 'Gradle · Kotlin DSL', code: gradle})}
+
+  <h2><span class="hno">2</span>Create the schema</h2>
+  <p>Storm maps to an existing schema rather than generating one, which keeps migrations under your control. For this tutorial a small script is enough; H2 runs it on startup, so there is no migration tool to set up yet.</p>
+  ${editor({file: 'schema.sql', tag: 'SQL', code: schema})}
+
+  <h2><span class="hno">3</span>Model the domain</h2>
+  <p>Two immutable data classes. A <code>Bookmark</code> belongs to a <code>Folder</code>; marking that reference <code>@FK</code> is the whole relationship. Field names map to columns automatically, so <code>folder</code> becomes the <code>folder_id</code> column.</p>
+  ${editor({file: 'model.kt', tag: 'Kotlin', code: entities})}
+
+  <h2><span class="hno">4</span>Point Storm at the database</h2>
+  <p>The Storm Ktor plugin reads its DataSource from <code>application.conf</code>. No wiring code: <code>install(Storm)</code> builds a connection pool and, because the metamodel processor already indexed them, registers your repositories.</p>
+  ${editor({file: 'application.conf', tag: 'HOCON', code: conf})}
+
+  <h2><span class="hno">5</span>Add a repository</h2>
+  <p>Extend <code>EntityRepository</code> and every CRUD method comes for free. Add your own one-line queries on top; <code>Bookmark_</code> is the compile-time metamodel, so a typo in a field name fails to compile.</p>
+  ${editor({file: 'BookmarkRepository.kt', tag: 'Kotlin', code: repo})}
+
+  <h2><span class="hno">6</span>Wire up the application</h2>
+  <p>A standard Ktor <code>main</code> and module. Install Storm, register Storm's Jackson module so entities serialize cleanly, and mount the routes.</p>
+  ${editor({file: 'Application.kt', tag: 'Kotlin', code: app})}
+
+  <h2><span class="hno">7</span>Write the routes</h2>
+  <p>Read straight from the ORM, write inside <code>transaction { }</code>. Because Ktor and Storm are both coroutine-based, the transaction rides the request's coroutine with no proxies or annotations. <code>call.orm</code> and <code>repository&lt;T&gt;()</code> are extensions available right in the handler.</p>
+  ${editor({file: 'Routes.kt', tag: 'Kotlin', code: routes})}
+  <p>The list endpoint is where Storm earns its keep. One call, one query: the folder for every bookmark is joined in, so there is no N+1 to discover later. Toggle <b>Show SQL</b> to see exactly what runs.</p>
+  ${editor({file: 'BookmarkRepository.kt', tag: 'Kotlin', code: listCode, sql: listSql})}
+
+  <h2><span class="hno">8</span>Run it</h2>
+  <p>Start the server and exercise it with curl. The created bookmark comes back with its full folder object, loaded in the same query that fetched the bookmark.</p>
+  ${editor({file: 'terminal', tag: 'shell', code: run})}
+
+  <h2><span class="hno">9</span>Test it</h2>
+  <p><code>storm-ktor-test</code> spins up an in-memory database from your schema script and captures the SQL. Here we assert the create path is a single INSERT, so an accidental N+1 or extra round-trip fails the build rather than slipping into production.</p>
+  ${editor({file: 'BookmarkRoutesTest.kt', tag: 'Kotlin · test', code: test})}
+
+  <h2><span class="hno">✓</span>You built it</h2>
+  <p>An empty folder to a running, tested API: two entities, a joined relationship, four routes, and a repository, with no persistence context, no proxies, and no N+1. From here:</p>
+  <div class="refs">
+    <a href="/docs/relationships">Relationships</a>
+    <a href="/docs/repositories">Repositories</a>
+    <a href="/docs/ktor-integration">Ktor integration</a>
+    <a href="/docs/testing">Testing</a>
+    <a href="/examples/kotlin-ktor">The full Ktor example app</a>
+  </div>
+
+  <div class="cta">
+    <a href="/docs/" class="btn primary">Read the docs</a>
+    <a href="/examples/" class="btn">See full example apps</a>
+  </div>
+</div>
+
+${FOOT_HTML}`;
+}
+
+export default function BuildARestApi() {
+  const {siteConfig} = useDocusaurusContext();
+  const version = siteConfig.customFields?.stormVersion || '0.0.0';
+  return (
+    <TutorialPage
+      title={TITLE}
+      description={DESC}
+      slug="build-a-rest-api"
+      body={buildBody(version)}
+    />
+  );
+}

--- a/website/src/pages/tutorials/index.js
+++ b/website/src/pages/tutorials/index.js
@@ -20,10 +20,20 @@ ${navHtml('tutorials')}
   <h1>A fresh wind<br><span class="grad">for your data layer.</span></h1>
   <p class="sub">Task-focused tutorials for engineers coming from JPA, Hibernate, or Exposed, plus how-to recipes for Storm itself. Each comparison takes a persistence task you already know, shows both approaches side by side, and lets you inspect the SQL they produce.</p>
   <div class="catnav">
+    <a href="#start-here">Start here<b>1</b></a>
     <a href="#from-jpa">From JPA<b>9</b></a>
     <a href="#from-exposed">From Exposed<b>7</b></a>
     <a href="#storm-way">The Storm way<b>6</b></a>
   </div>
+</div>
+
+<div class="shead" id="start-here"><span class="mark">//</span>Start here<span class="sdesc">New to Storm? Build a complete REST API from an empty project, then use the task recipes below as you go.</span></div>
+<div class="cards">
+  <a class="tcard" href="/tutorials/build-a-rest-api" style="grid-column:1 / -1">
+    <div class="tt">Build a REST API from scratch<span class="arrow">→</span></div>
+    <div class="td">Empty project to a running, tested API: two entities, their relationship loaded in a single query, CRUD routes on Ktor, and a test that asserts the SQL. The whole end-to-end path in about twenty minutes.</div>
+    <div class="tm"><span>Kotlin</span><span>Ktor 3</span><span>~20 min</span></div>
+  </a>
 </div>
 
 <div class="shead" id="from-jpa"><span class="mark">//</span>From JPA<span class="sdesc">You know Spring Data JPA and Hibernate. Each tutorial shows a task the JPA way and the Storm way, side by side.</span></div>

--- a/website/versioned_docs/version-1.11.0/index.md
+++ b/website/versioned_docs/version-1.11.0/index.md
@@ -230,7 +230,7 @@ If you are a tech lead or architect evaluating Storm for a production system, th
 
 Storm is focused on being a great ORM and SQL template engine. It intentionally does not include:
 
-- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](/ai), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
+- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](ai.md), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
 - **Second-level cache.** Storm's entity cache is transaction-scoped and cleared on commit. For cross-transaction caching, use Spring's `@Cacheable` or a dedicated cache layer like Caffeine or Redis.
 - **Lazy loading proxies.** Entities are plain records with no proxies. Related entities are loaded eagerly in a single query via JOINs. For deferred loading, use [Refs](refs.md) to explicitly control when related data is fetched.
 

--- a/website/versioned_docs/version-1.11.1/index.md
+++ b/website/versioned_docs/version-1.11.1/index.md
@@ -244,7 +244,7 @@ If you are a tech lead or architect evaluating Storm for a production system, th
 
 Storm is focused on being a great ORM and SQL template engine. It intentionally does not include:
 
-- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](/ai), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
+- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](ai.md), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
 - **Second-level cache.** Storm's entity cache is transaction-scoped and cleared on commit. For cross-transaction caching, use Spring's `@Cacheable` or a dedicated cache layer like Caffeine or Redis.
 - **Lazy loading proxies.** Entities are plain records with no proxies. Related entities are loaded eagerly in a single query via JOINs. For deferred loading, use [Refs](refs.md) to explicitly control when related data is fetched.
 

--- a/website/versioned_docs/version-1.11.2/index.md
+++ b/website/versioned_docs/version-1.11.2/index.md
@@ -244,7 +244,7 @@ If you are a tech lead or architect evaluating Storm for a production system, th
 
 Storm is focused on being a great ORM and SQL template engine. It intentionally does not include:
 
-- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](/ai), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
+- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](ai.md), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
 - **Second-level cache.** Storm's entity cache is transaction-scoped and cleared on commit. For cross-transaction caching, use Spring's `@Cacheable` or a dedicated cache layer like Caffeine or Redis.
 - **Lazy loading proxies.** Entities are plain records with no proxies. Related entities are loaded eagerly in a single query via JOINs. For deferred loading, use [Refs](refs.md) to explicitly control when related data is fetched.
 

--- a/website/versioned_docs/version-1.11.3/index.md
+++ b/website/versioned_docs/version-1.11.3/index.md
@@ -244,7 +244,7 @@ If you are a tech lead or architect evaluating Storm for a production system, th
 
 Storm is focused on being a great ORM and SQL template engine. It intentionally does not include:
 
-- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](/ai), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
+- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](ai.md), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
 - **Second-level cache.** Storm's entity cache is transaction-scoped and cleared on commit. For cross-transaction caching, use Spring's `@Cacheable` or a dedicated cache layer like Caffeine or Redis.
 - **Lazy loading proxies.** Entities are plain records with no proxies. Related entities are loaded eagerly in a single query via JOINs. For deferred loading, use [Refs](refs.md) to explicitly control when related data is fetched.
 

--- a/website/versioned_docs/version-1.11.4/index.md
+++ b/website/versioned_docs/version-1.11.4/index.md
@@ -244,7 +244,7 @@ If you are a tech lead or architect evaluating Storm for a production system, th
 
 Storm is focused on being a great ORM and SQL template engine. It intentionally does not include:
 
-- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](/ai), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
+- **Schema migration or DDL generation.** Storm does not automatically create, alter, or drop tables at runtime. With Storm's [AI integration](ai.md), your coding assistant can read your database schema and generate Flyway or Liquibase migration scripts on demand. For schema versioning, use [Flyway](https://flywaydb.org/) or [Liquibase](https://www.liquibase.com/).
 - **Second-level cache.** Storm's entity cache is transaction-scoped and cleared on commit. For cross-transaction caching, use Spring's `@Cacheable` or a dedicated cache layer like Caffeine or Redis.
 - **Lazy loading proxies.** Entities are plain records with no proxies. Related entities are loaded eagerly in a single query via JOINs. For deferred loading, use [Refs](refs.md) to explicitly control when related data is fetched.
 


### PR DESCRIPTION
## Summary

Adoption-focused improvements across the website, docs, and repo, from a review of orm.st, the README, GitHub setup, docs, tutorials and examples.

### Website
- **New `/quickstart`** — a live 5-minute Kotlin path (set up → entity → query, with the generated SQL). Leads with `npx @storm-orm/cli init`, manual Gradle setup below. Every "Get started" button now points here.
- **New `/comparison`** — added to the nav bar. Decision matrix plus one card per framework, including Jimmer as a peer (no special treatment).
- **New end-to-end tutorial** — "Build a REST API from scratch" (Kotlin + Ktor), featured as "Start here" on the tutorials hub.
- **Table styling** — reworked the comparison and doc tables (framed, horizontal rules, proper bottom border, tinted Storm column) so content fits and the bottom line reads.
- Moved "memory" from the Fast card to the Efficient card.
- Reserved `/comparison` and `/quickstart` from the docs redirect so the real pages are not shadowed.

### Docs
- Added **Jimmer** as the last column of the three comparison matrices (researched, verified values; two new footnotes) and a dedicated "Storm vs Jimmer" section focused on conciseness.
- Fixed broken `/ai` links in the `1.11.0`–`1.11.4` snapshots (relative `ai.md`, matching the current docs).

### Repo
- **README** — added an Examples section, a "which modules do I need?" map, and fixed the LICENSE link (`LICENSE` → `LICENSE.txt`).
- Added **CHANGELOG.md**.

## Notes
- Docs-matrix Jimmer columns show at `/docs/next/comparison`; the live `/docs/comparison` picks them up at the next release snapshot. The website `/comparison` matrix is live immediately.
- `npm run build` passes. The remaining broken-link warnings are the pre-existing `../api/*` javadoc links, which CI builds into `website/static/api/`.
