### PR TITLE
docs(comparison): order Jimmer before Exposed and scroll wide tables

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,14 +11,14 @@ The following tables provide a side-by-side comparison of concrete features acro
 
 ### Entity & Data Modeling
 
-| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Exposed | Ktorm | Jimmer |
-|---------|-------|-----|-------------|---------|------|------|---------|-------|--------|
-| Lines per entity | ~5 | ~30<sup>1</sup> | ~30<sup>1</sup> | ~20+ | Generated | ~15 | ~12 | ~15 | ~10 |
-| Immutable entities | Yes | No | No | Yes | Yes | Yes | DSL only | No | Yes |
-| Polymorphism | Yes<sup>2</sup> | Yes | Via JPA | No | No | No | No | No | No<sup>8</sup> |
-| Automatic relationships | Yes | Yes<sup>3</sup> | Via JPA | No | No | No | DAO only | No | Yes |
-| Cascade persist | No | Yes | Yes | No | No | No | No | No | Yes |
-| Lifecycle callbacks | Yes | Yes | Via JPA | No | Yes | No | DAO only | No | Yes |
+| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Jimmer | Exposed | Ktorm |
+|---------|-------|-----|-------------|---------|------|------|--------|---------|-------|
+| Lines per entity | ~5 | ~30<sup>1</sup> | ~30<sup>1</sup> | ~20+ | Generated | ~15 | ~10 | ~12 | ~15 |
+| Immutable entities | Yes | No | No | Yes | Yes | Yes | Yes | DSL only | No |
+| Polymorphism | Yes<sup>2</sup> | Yes | Via JPA | No | No | No | No<sup>8</sup> | No | No |
+| Automatic relationships | Yes | Yes<sup>3</sup> | Via JPA | No | No | No | Yes | DAO only | No |
+| Cascade persist | No | Yes | Yes | No | No | No | Yes | No | No |
+| Lifecycle callbacks | Yes | Yes | Via JPA | No | Yes | No | Yes | DAO only | No |
 
 <sup>1</sup> JPA/Spring Data lines without Lombok; ~10 lines with Lombok.
 
@@ -30,14 +30,14 @@ The following tables provide a side-by-side comparison of concrete features acro
 
 ### Querying & Data Access
 
-| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Exposed | Ktorm | Jimmer |
-|---------|-------|-----|-------------|---------|------|------|---------|-------|--------|
+| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Jimmer | Exposed | Ktorm |
+|---------|-------|-----|-------------|---------|------|------|--------|---------|-------|
 | Type-safe queries | Yes | Criteria | No | No | Yes | No | Yes | Yes | Yes |
-| SQL Templates | Yes | No | No | XML/Ann | Yes | Yes | No | No | Native<sup>9</sup> |
-| N+1 prevention | Yes | No | No | No | Manual | Manual | No | No | Yes |
-| Lazy loading | Refs | Yes | Yes | No | No | No | Yes | Yes | Fetchers |
+| SQL Templates | Yes | No | No | XML/Ann | Yes | Yes | Native<sup>9</sup> | No | No |
+| N+1 prevention | Yes | No | No | No | Manual | Manual | Yes | No | No |
+| Lazy loading | Refs | Yes | Yes | No | No | No | Fetchers | Yes | Yes |
 | Scrolling | Yes | No | Yes | No | Yes | No | No | No | No |
-| JSON columns | Yes | Yes<sup>4</sup> | Via JPA | Manual | Yes | Module | Yes | Module | Yes |
+| JSON columns | Yes | Yes<sup>4</sup> | Via JPA | Manual | Yes | Module | Yes | Yes | Module |
 | JSON aggregation | Yes | No | No | No | Yes | No | No | No | No |
 
 <sup>4</sup> JPA requires Hibernate 6.2+ for built-in JSON support; older versions need a third-party library or custom `AttributeConverter`.
@@ -46,16 +46,16 @@ The following tables provide a side-by-side comparison of concrete features acro
 
 ### Runtime & Ecosystem
 
-| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Exposed | Ktorm | Jimmer |
-|---------|-------|-----|-------------|---------|------|------|---------|-------|--------|
-| Transactions | Both | Both | Declarative | Both | Programmatic | Both | Both<sup>6</sup> | Required | Both |
-| Schema validation | Yes | Yes | Via JPA | No | N/A<sup>5</sup> | No | Yes | No | No |
-| Java support | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes |
-| Kotlin support | First-class | Good | Good | Good | Good | Good | Native | Native | First-class |
-| Coroutines | Yes | No | No | No | No | No | Yes | Limited | No |
+| Feature | Storm | JPA | Spring Data | MyBatis | jOOQ | JDBI | Jimmer | Exposed | Ktorm |
+|---------|-------|-----|-------------|---------|------|------|--------|---------|-------|
+| Transactions | Both | Both | Declarative | Both | Programmatic | Both | Both | Both<sup>6</sup> | Required |
+| Schema validation | Yes | Yes | Via JPA | No | N/A<sup>5</sup> | No | No | Yes | No |
+| Java support | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No |
+| Kotlin support | First-class | Good | Good | Good | Good | Good | First-class | Native | Native |
+| Coroutines | Yes | No | No | No | No | No | No | Yes | Limited |
 | Spring integration | Yes | Yes | Native | Yes | Yes | Yes | Yes | Yes | Yes |
-| Runtime mechanism | Codegen<sup>7</sup> | Bytecode | Bytecode | Reflection | Codegen | Reflection | Reflection | Reflection | Codegen |
-| Community | New | Huge | Huge | Large | Medium | Medium | Medium | Small | Small |
+| Runtime mechanism | Codegen<sup>7</sup> | Bytecode | Bytecode | Reflection | Codegen | Reflection | Codegen | Reflection | Reflection |
+| Community | New | Huge | Huge | Large | Medium | Medium | Small | Medium | Small |
 
 <sup>5</sup> jOOQ generates code from the database schema, so schema validation is inherent in its code generation step.
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -27,7 +27,12 @@
    normal `display:table` (no forced overflow) so wide docs tables still reflow
    and scroll as before. */
 .markdown table {
-  width: 100%;
+  /* Wide comparison tables (e.g. Runtime & Ecosystem, 9 columns) exceed the
+     content column. Make the table a scroll container so it fits the screen
+     with an internal horizontal scrollbar instead of overflowing the page. */
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
 }
 .markdown table th,
 .markdown table td {

--- a/website/src/pages/comparison.js
+++ b/website/src/pages/comparison.js
@@ -66,15 +66,15 @@ function buildBody() {
   const matrix = `
 <table class="cmp">
   <thead><tr>
-    <th>Feature</th><th>Storm</th><th>JPA / Hibernate</th><th>jOOQ</th><th>Exposed</th><th>Jimmer</th>
+    <th>Feature</th><th>Storm</th><th>JPA / Hibernate</th><th>jOOQ</th><th>Jimmer</th><th>Exposed</th>
   </tr></thead>
   <tbody>
-    <tr><td>Entity model</td><td>Immutable data class (~5 lines)</td><td>Mutable class (~30, ~10 with Lombok)</td><td>Generated from schema</td><td>DSL table object (+ optional DAO)</td><td>Immutable interface (KSP-generated)</td></tr>
-    <tr><td>Immutable entities</td><td>Yes</td><td>No</td><td>Yes</td><td>DSL only</td><td>Yes</td></tr>
+    <tr><td>Entity model</td><td>Immutable data class (~5 lines)</td><td>Mutable class (~30, ~10 with Lombok)</td><td>Generated from schema</td><td>Immutable interface (KSP-generated)</td><td>DSL table object (+ optional DAO)</td></tr>
+    <tr><td>Immutable entities</td><td>Yes</td><td>No</td><td>Yes</td><td>Yes</td><td>DSL only</td></tr>
     <tr><td>Type-safe queries</td><td>Yes</td><td>Criteria API</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
-    <tr><td>N+1 handling</td><td>Single-query entity graph</td><td>Common pitfall</td><td>Manual</td><td>Manual</td><td>Batched queries</td></tr>
-    <tr><td>Full SQL escape hatch</td><td>SQL templates</td><td>Native queries</td><td>It is SQL</td><td>Raw exec()</td><td>SQL expressions</td></tr>
-    <tr><td>Languages</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin only</td><td>Kotlin + Java</td></tr>
+    <tr><td>N+1 handling</td><td>Single-query entity graph</td><td>Common pitfall</td><td>Manual</td><td>Batched queries</td><td>Manual</td></tr>
+    <tr><td>Full SQL escape hatch</td><td>SQL templates</td><td>Native queries</td><td>It is SQL</td><td>SQL expressions</td><td>Raw exec()</td></tr>
+    <tr><td>Languages</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin only</td></tr>
     <tr><td>License</td><td>Apache 2.0</td><td>LGPL 2.1</td><td>Commercial for some DBs</td><td>Apache 2.0</td><td>Apache 2.0</td></tr>
   </tbody>
 </table>`;


### PR DESCRIPTION
Follow-up to #179.

- Move the Jimmer column **before Exposed** in all three tables in `docs/comparison.md` and in the website at-a-glance matrix, so the column order matches the per-framework sections everywhere.
- Make the docs comparison tables horizontally scrollable so the now-wider **Runtime & Ecosystem** table fits the screen (internal scroll) instead of overflowing the page.

`npm run build` passes.