### PR TITLE
ci(docs): deploy Pages via GitHub Actions, not the legacy branch builder

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,14 +6,20 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
+# GitHub's recommended settings for Pages deployments: serialize on the "pages"
+# group and let an in-progress deployment finish (cancelling it mid-flight is
+# what left the legacy branch build in a "Deployment failed, try again later"
+# state that only cleared on a manual rerun).
 concurrency:
-  group: docs-deploy
-  cancel-in-progress: true
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -105,9 +111,20 @@ jobs:
         run: npm run build
         working-directory: website
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/build
-          force_orphan: true
+          path: ./website/build
+
+  # Deploy the artifact with the official Pages action instead of pushing to a
+  # gh-pages branch and relying on GitHub's flaky legacy branch builder.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

The docs deploy has failed on the first attempt for the last few releases and only succeeds on a manual rerun.

**Root cause (verified):** Pages is on the **legacy** branch build (`build_type: "legacy"`, source `gh-pages`). `docs.yml` force-pushes the built site to `gh-pages` via `peaceiris/actions-gh-pages@v4` (`force_orphan: true`), and GitHub's legacy auto-builder then runs `actions/deploy-pages`, which polls the deployment 10× and dies with `##[error]Deployment failed, try again later`. The deployment history shows two `github-pages` deployments per commit ~1–2 min apart — the failed first attempt and the successful rerun. The `force_orphan` history rewrite reliably trips the legacy builder on the first run.

## Change

Move to the **official GitHub Actions Pages deployment**:
- `build` job: all existing build steps (Javadoc, KDoc, llms, Docusaurus) unchanged, ending in `actions/upload-pages-artifact@v3`.
- new `deploy` job: `environment: github-pages` + `actions/deploy-pages@v4`.
- `permissions`: `pages: write` + `id-token: write` (was `contents: write`).
- `concurrency`: group `"pages"`, `cancel-in-progress: false` (GitHub's recommended setting; avoids cancelling an in-flight deploy).

This removes the `gh-pages` branch and the flaky legacy builder entirely, and `deploy-pages` serializes/retries deployments.

## ⚠️ Required coordinated setting change

This only takes effect once the repo **Pages source is set to "GitHub Actions"** (Settings → Pages → Source, or `build_type: workflow` via the API). **Do not merge without flipping it** in the same window, or the next docs deploy will fail with "not configured for GitHub Actions." I can flip it via `gh api` the moment you're ready to merge.

The `orm.st` custom domain is safe: the CNAME is stored in the Pages config and `website/static/CNAME` is included in the build artifact.