### PR TITLE
fix(docs): correct the streamByCity repository example

### DIFF
--- a/docs/first-query.md
+++ b/docs/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.10.0/first-query.md
+++ b/website/versioned_docs/version-1.10.0/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.11.0/first-query.md
+++ b/website/versioned_docs/version-1.11.0/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.11.1/first-query.md
+++ b/website/versioned_docs/version-1.11.1/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.11.2/first-query.md
+++ b/website/versioned_docs/version-1.11.2/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.11.3/first-query.md
+++ b/website/versioned_docs/version-1.11.3/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.11.4/first-query.md
+++ b/website/versioned_docs/version-1.11.4/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.11.5/first-query.md
+++ b/website/versioned_docs/version-1.11.5/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.11.6/first-query.md
+++ b/website/versioned_docs/version-1.11.6/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.9.0/first-query.md
+++ b/website/versioned_docs/version-1.9.0/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template

--- a/website/versioned_docs/version-1.9.1/first-query.md
+++ b/website/versioned_docs/version-1.9.1/first-query.md
@@ -84,7 +84,7 @@ interface UserRepository : EntityRepository<User, Int> {
         findAll((User_.city eq city) and (User_.name eq name))
 
     fun streamByCity(city: City): Flow<User> =
-        select { User_.city eq city }
+        select(User_.city eq city).resultFlow
 }
 
 // Get the repository from the ORM template


### PR DESCRIPTION
The **First Query** example returned `Flow<User>` from `select { User_.city eq city }`, which is wrong two ways:

1. `select { block }` returns a `QueryBuilder`, not a `Flow` — it needs a terminal (`.resultFlow`).
2. The block form expects scope calls (`where`/`orderBy`/…) and **rejects a bare predicate at runtime**: `SqlScope.validateResult` throws `IllegalStateException` ("expressions must be consumed by scope methods such as where()").

Fix uses the predicate overload + terminal:
```kotlin
fun streamByCity(city: City): Flow<User> =
    select(User_.city eq city).resultFlow
```