### PR TITLE
ci(docs): retry the Pages deployment once on transient sync failure

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -123,8 +123,23 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deploy.outputs.page_url || steps.deploy-retry.outputs.page_url }}
     steps:
+      # GitHub Pages' backend intermittently fails during "syncing_files"
+      # ("Deployment failed, try again later"), and a fresh deployment then
+      # succeeds — which is why a manual rerun always worked. actions/deploy-pages
+      # does not retry a failed deployment, so do it here: attempt once, wait,
+      # and retry once before failing the job.
       - name: Deploy to GitHub Pages
-        id: deployment
+        id: deploy
+        continue-on-error: true
+        uses: actions/deploy-pages@v4
+
+      - name: Wait before retry
+        if: steps.deploy.outcome == 'failure'
+        run: sleep 45
+
+      - name: Deploy to GitHub Pages (retry)
+        id: deploy-retry
+        if: steps.deploy.outcome == 'failure'
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Follow-up to #182.

Migrating to `actions/deploy-pages` removed the flaky legacy branch builder, but the docs deploy **still failed on a fresh run** — this time from the official action itself:

```
Getting Pages deployment status...
Current status: syncing_files
Error: Deployment failed, try again later.
```

This is a GitHub Pages backend flake in the file-sync phase: the deployment fails, and a **new** deployment (the manual rerun) succeeds. `actions/deploy-pages` does not retry a failed deployment, so the job fails on the first attempt.

**Fix:** attempt the deploy with `continue-on-error`, wait 45s, and retry once before failing the job. This automates exactly what the manual rerun did.

```yaml
- name: Deploy to GitHub Pages
  id: deploy
  continue-on-error: true
  uses: actions/deploy-pages@v4
- name: Wait before retry
  if: steps.deploy.outcome == 'failure'
  run: sleep 45
- name: Deploy to GitHub Pages (retry)
  id: deploy-retry
  if: steps.deploy.outcome == 'failure'
  uses: actions/deploy-pages@v4
```

If it still proves flaky after this, the next step would be reducing the deployed artifact's file count (the bundled Javadoc/KDoc API docs are the largest contributor to the sync). The Node-20 deprecation warning in the logs is unrelated (the actions run fine on Node 24).