### PR TITLE
docs(comparison): add Ktorm to the website at-a-glance matrix

### DIFF
--- a/website/src/pages/comparison.js
+++ b/website/src/pages/comparison.js
@@ -66,16 +66,16 @@ function buildBody() {
   const matrix = `
 <table class="cmp">
   <thead><tr>
-    <th>Feature</th><th>Storm</th><th>JPA / Hibernate</th><th>jOOQ</th><th>Jimmer</th><th>Exposed</th>
+    <th>Feature</th><th>Storm</th><th>JPA / Hibernate</th><th>jOOQ</th><th>Jimmer</th><th>Exposed</th><th>Ktorm</th>
   </tr></thead>
   <tbody>
-    <tr><td>Entity model</td><td>Immutable data class (~5 lines)</td><td>Mutable class (~30, ~10 with Lombok)</td><td>Generated from schema</td><td>Immutable interface (KSP-generated)</td><td>DSL table object (+ optional DAO)</td></tr>
-    <tr><td>Immutable entities</td><td>Yes</td><td>No</td><td>Yes</td><td>Yes</td><td>DSL only</td></tr>
-    <tr><td>Type-safe queries</td><td>Yes</td><td>Criteria API</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
-    <tr><td>N+1 handling</td><td>Single-query entity graph</td><td>Common pitfall</td><td>Manual</td><td>Batched queries</td><td>Manual</td></tr>
-    <tr><td>Full SQL escape hatch</td><td>SQL templates</td><td>Native queries</td><td>It is SQL</td><td>SQL expressions</td><td>Raw exec()</td></tr>
-    <tr><td>Languages</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin only</td></tr>
-    <tr><td>License</td><td>Apache 2.0</td><td>LGPL 2.1</td><td>Commercial for some DBs</td><td>Apache 2.0</td><td>Apache 2.0</td></tr>
+    <tr><td>Entity model</td><td>Immutable data class (~5 lines)</td><td>Mutable class (~30, ~10 with Lombok)</td><td>Generated from schema</td><td>Immutable interface (KSP-generated)</td><td>DSL table object (+ optional DAO)</td><td>Mutable interface (+ DSL table)</td></tr>
+    <tr><td>Immutable entities</td><td>Yes</td><td>No</td><td>Yes</td><td>Yes</td><td>DSL only</td><td>No</td></tr>
+    <tr><td>Type-safe queries</td><td>Yes</td><td>Criteria API</td><td>Yes</td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
+    <tr><td>N+1 handling</td><td>Single-query entity graph</td><td>Common pitfall</td><td>Manual</td><td>Batched queries</td><td>Manual</td><td>Manual</td></tr>
+    <tr><td>Full SQL escape hatch</td><td>SQL templates</td><td>Native queries</td><td>It is SQL</td><td>SQL expressions</td><td>Raw exec()</td><td>Raw JDBC</td></tr>
+    <tr><td>Languages</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin only</td><td>Kotlin only</td></tr>
+    <tr><td>License</td><td>Apache 2.0</td><td>LGPL 2.1</td><td>Commercial for some DBs</td><td>Apache 2.0</td><td>Apache 2.0</td><td>Apache 2.0</td></tr>
   </tbody>
 </table>`;
 


### PR DESCRIPTION
Ktorm already had a framework card on `/comparison` and a column in the docs comparison matrices, but was missing from the website **At a glance** table. This adds it as the last column (after Exposed, matching the docs order), with values consistent with the docs comparison:

| | Ktorm |
|---|---|
| Entity model | Mutable interface (+ DSL table) |
| Immutable entities | No |
| Type-safe queries | Yes |
| N+1 handling | Manual |
| Full SQL escape hatch | Raw JDBC |
| Languages | Kotlin only |
| License | Apache 2.0 |

`npm run build` passes.