### PR TITLE
fix(website): paint landing code editor scroller on iOS

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -75,7 +75,11 @@ const CSS = `
   .storm-home .sqlbtn .ico{width:13px;height:13px;opacity:.9}
   .storm-home .sqlconsole{display:none;border-top:1px solid var(--border-soft);background:var(--statusbg)}
   .storm-home .editor.show-sql .sqlconsole{display:block}
-  .storm-home #sqlpanel{margin:0;padding:14px 18px 18px;font-family:var(--mono);font-size:12.5px;line-height:1.75;white-space:pre;overflow-x:auto;color:var(--plain)}
+  /* Solid background required on the horizontal scroller: on iOS Safari an
+     overflow-x:auto element gets its own compositing layer, and a transparent
+     one paints the scrolled-in region black instead of showing the ancestor
+     background. Match .sqlconsole so it's visually identical. */
+  .storm-home #sqlpanel{margin:0;padding:14px 18px 18px;font-family:var(--mono);font-size:12.5px;line-height:1.75;white-space:pre;overflow-x:auto;color:var(--plain);background:var(--statusbg)}
   .storm-home .statusbar .sqllabel{display:none;align-items:center;gap:9px;font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint)}
   .storm-home .statusbar .sqllabel .ar{color:var(--accent)}
   .storm-home .editor.show-sql .statusbar #status,
@@ -89,7 +93,10 @@ const CSS = `
   .storm-home .gutter{padding:22px 0;width:48px;text-align:right;color:#3b3b46;font-family:var(--mono);font-size:13px;
     line-height:26px;user-select:none;border-right:1px solid var(--border-soft);flex:none}
   .storm-home .gutter div{padding-right:15px}
-  .storm-home #code{margin:0;padding:22px 24px;font-family:var(--mono);font-size:14px;line-height:26px;white-space:pre;overflow-x:auto;flex:1}
+  /* Opaque background (see #sqlpanel note): the horizontal scroller must paint
+     its own background or iOS renders the off-screen columns black. --panel is
+     the codearea gradient's top stop, so the seam is imperceptible. */
+  .storm-home #code{margin:0;padding:22px 24px;font-family:var(--mono);font-size:14px;line-height:26px;white-space:pre;overflow-x:auto;flex:1;background:var(--panel)}
   /* Docusaurus styles bare <pre> with a light code-block background (and rounded box) in
      light color mode; neutralize it so the landing editor keeps its dark chrome regardless
      of the active Docusaurus theme. */


### PR DESCRIPTION
## Problem

On iOS, scrolling the landing-page code editor horizontally (to reach code that runs off-screen) reveals a **black region** instead of the code — the off-screen columns are unreadable.

## Cause

The code editor's `#code` `<pre>` and the "Show SQL" panel `#sqlpanel` use `overflow-x:auto` for horizontal scrolling on narrow screens. Both were **transparent** and relied on their parent's background (`.codearea` gradient / `.sqlconsole`) showing through.

iOS Safari puts an `overflow-x:auto` element on its own compositing layer. When that layer has no background of its own, Safari does not paint the ancestor's background into the scrolled-in region — it composites black backing store instead. That's the black area users see when scrolling to off-screen code.

## Fix

Give each horizontal scroller its own opaque background matching its container:

- `#code` → `var(--panel)` (the codearea gradient's top stop, so the seam is imperceptible)
- `#sqlpanel` → `var(--statusbg)` (exactly matches `.sqlconsole`, no visual change)

Both are `id` selectors, so they override `.storm-home pre{background:transparent}` by specificity. Desktop appearance is effectively unchanged; the difference only matters on the iOS scroll layer.

## Verification

- [ ] Confirm on a real iOS device: scroll a long code line horizontally in the landing editor and in the "Show SQL" panel — the off-screen text should render normally, not black.

Note: I could not test on a physical iOS device. This opaque-background approach is the standard remedy for this iOS symptom and is low-risk. If any black region somehow persists, the fallback would be a compositing hint (`transform:translateZ(0)`) on `#code`, deliberately avoided here to keep the change minimal.