### PR TITLE
fix(website): rewind landing editor scroll when a scene renders

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -420,7 +420,7 @@ export default function Home() {
     const editorEl=document.querySelector('.storm-home .editor'), sqlBtn=document.getElementById('sqlbtn'),
           sqlBtnText=document.getElementById('sqlbtntext'), sqlPanel=document.getElementById('sqlpanel');
     let showSql=false, curIdx=0;
-    function renderSql(){ sqlPanel.innerHTML=SQL[curIdx]||'<span class="sqlc">-- no query</span>'; }
+    function renderSql(){ sqlPanel.innerHTML=SQL[curIdx]||'<span class="sqlc">-- no query</span>'; sqlPanel.scrollLeft=0; }
     function onSqlClick(){
       showSql=!showSql;
       editorEl.classList.toggle('show-sql',showSql);
@@ -504,6 +504,13 @@ export default function Home() {
 
       const text=fullText(sc.code);
       setGutter(text);
+      // Rewind the horizontal scroller before typing. Desktop resets it for
+      // free (the near-empty first render collapses scrollWidth, clamping
+      // scrollLeft to 0), but iOS Safari keeps the stale offset when content
+      // shrinks — so one touch pan (even an accidental diagonal swipe while
+      // scrolling the page) would leave every later scene with the start of
+      // each line cut off.
+      codeEl.scrollLeft=0;
 
       if(reduce){
         codeEl.innerHTML=render(sc.code,text.length,false);
@@ -524,6 +531,7 @@ export default function Home() {
       }
       if(myGen!==gen) return;
       codeEl.innerHTML=render(sc.code,text.length,false);
+      codeEl.scrollLeft=0; // settle the finished snippet at its line starts
       await wait(fast?160:360);
       if(myGen!==gen) return;
       statusTextEl.textContent=sc.caption;statusEl.classList.add('show');


### PR DESCRIPTION
Follow-up to #188, which gave the landing editor's horizontal scrollers opaque backgrounds but did not fix the reported symptom on iOS: scenes rendering with the first ~13 characters of every line cut off (screenshot in the report showed a uniform 13-character offset on all 15 lines, with the 24px left padding gone too).

**Actual cause: a retained scroll offset, not paint.** Any touch pan on the code block — including an accidental diagonal swipe while scrolling the page, which is near-unavoidable on a phone — leaves `#code` scrolled right. On desktop the next scene self-heals: the typewriter's near-empty first render collapses `scrollWidth`, and the browser clamps `scrollLeft` back to 0. iOS Safari does not clamp the offset of a composited scroller when its content shrinks, so the stale offset survives every `innerHTML` replacement and each new scene types into a shifted viewport. Nothing in the page ever reset the scroll position.

**Fix:** reset `scrollLeft` explicitly at the three points where scroller content is replaced:
- when a scene starts typing (covers auto-advance, tab clicks, and the reduced-motion path),
- when the finished snippet is rendered, so a mid-typing pan can't leave the resting scene shifted through its dwell,
- when the Show-SQL panel content is replaced.

Deliberate panning during a scene's dwell is untouched — the reset only happens when content changes.

The #188 background rules are kept; they're harmless and guard the compositing-paint case independently.

Verified with `npm run build` (only pre-existing broken-anchor warnings in old snapshots).