### PR TITLE
fix(website): wrap landing editor code on phones instead of scrolling

### DIFF
--- a/website/src/pages/blog/why-we-built-storm.js
+++ b/website/src/pages/blog/why-we-built-storm.js
@@ -14,7 +14,7 @@ const BODY = `
 <div class="art">
   <div class="crumbs"><a href="/blog/">Blog</a><span class="sep">/</span>Why we built ST/ORM</div>
   <h1>Why we built <span class="grad">ST/ORM</span></h1>
-  <p class="dek">This is not an ORM horror story. It is the story of how a team that was reasonably happy with its ORM still ended up building something different.</p>
+  <p class="dek"><em>&ldquo;We set out to build the model we would enjoy programming against.&rdquo;</em></p>
   <div class="meta"><span>September 2, 2025</span><span>Origin</span><span>6 min read</span></div>
 
   <h2>We used to reach for Hibernate by default</h2>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -160,6 +160,15 @@ const CSS = `
     .storm-home .nav-toggle-cb:checked ~ .nav-links{display:flex}
     .storm-home .nav-links a{padding:13px 24px;font-size:15px}
     .storm-home .nav-links a.btn{margin:10px 24px 6px;justify-content:center}
+    /* On phones the editor wraps long lines instead of scrolling them. iOS
+       Safari desyncs the painted content of a composited overflow-x scroller
+       whose DOM is mutated per frame by the typewriter (stale tiles render at
+       an old scroll offset; #188 and #189 attacked paint and scroll position
+       and neither cured it). No scroller, no bug. The gutter goes too: line
+       numbers cannot align once a logical line spans several visual rows. */
+    .storm-home .gutter{display:none}
+    .storm-home #code{white-space:pre-wrap;overflow-wrap:break-word;overflow-x:visible;font-size:12.5px;line-height:22px;padding:18px 16px}
+    .storm-home #sqlpanel{white-space:pre-wrap;overflow-wrap:break-word;overflow-x:visible}
   }
 `;
 


### PR DESCRIPTION
Third pass at the iOS landing editor bug — this one replaces the mechanism instead of nudging it.

**Why #188 and #189 didn't cure it.** Both are confirmed live (verified the deployed homepage chunk `c4f5d8e4.7af32268.js` contains the three `scrollLeft=0` resets, and the served CSS has the opaque scroller backgrounds). Yet on an iPhone the typed code still renders shifted left by a uniform number of characters (exactly 23 in the latest report, 13 earlier), and panning repaints only part of the content — only the first line tracks the finger. That is iOS Safari desyncing the painted tiles of a composited `overflow-x:auto` layer whose DOM is replaced every frame by the typewriter. The painted content sits at a stale offset regardless of the actual scroll position, so no scroll-value or background fix can reach it.

**Fix: no scroller, no bug.** Below 760px (the existing mobile breakpoint) the editor wraps long lines (`pre-wrap`) instead of scrolling them, at a slightly smaller font (12.5px) to limit wrapping. With no horizontal overflow there is no composited scroll layer to go stale, so the failure is structurally impossible rather than patched around. The gutter is hidden at that width — line numbers cannot align once a logical line spans several visual rows. The Show-SQL panel gets the same treatment. Desktop and tablet widths are unchanged; the #188/#189 changes stay as belt-and-braces for mid-size touch screens that still scroll.

Verified with a 390px-wide headless render: scenes type and wrap cleanly with no cut-off line starts.

**Also in this PR** (as requested): the why-we-built-storm blog abstract is now the post's own closing line, set as a quote — *“We set out to build the model we would enjoy programming against.”*

Verified with `npm run build` (only pre-existing broken-anchor warnings in old snapshots).