### PR TITLE
feat(website): unify the closing button row with the hero actions

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -320,8 +320,8 @@ const BODY = `
   <h2>Write code worth reading.</h2>
   <p class="sub" style="margin:0 auto 30px;text-align:center;max-width:940px">Concise entities and one-line queries keep you productive. Immutable records simplify your architecture by letting the same types flow through your application layers. Storm is built for engineers who care about beautiful code.</p>
   <div class="cta" style="justify-content:center;margin-top:56px">
-    <a href="/quickstart" class="btn primary">Get started →</a>
-    <a href="/examples/" class="btn">Example apps</a>
+    <a href="/quickstart" class="btn primary go">Try it in 5 minutes →</a>
+    <a href="/comparison" class="btn">Compare with your ORM</a>
     <a href="https://github.com/storm-orm/storm-framework" target="_blank" rel="noopener" class="btn">Star on GitHub</a>
   </div>
 </div></section>


### PR DESCRIPTION
The landing page's closing section used its own button vocabulary ("Get started →", "Example apps") while the hero offers "Try it in 5 minutes →" and "Compare with your ORM". The closing row now repeats the hero pair, with the gradient fill on the primary, and keeps "Star on GitHub" as the third action.

Example apps remain reachable via the nav; no other pages touched. Build verified locally.