### PR TITLE
fix(core): resolve compound primary key component metamodels to their columns

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/impl/ColumnImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/ColumnImpl.java
@@ -41,7 +41,8 @@ import st.orm.core.template.SqlDialect;
  * @param version whether the column is a version column.
  * @param ref whether the column is a lazily fetched record.
  * @param metamodel the metamodel for the column.
- * @param secondaryMetamodel the secondary metamodel for the column, in case of foreign keys.
+ * @param secondaryMetamodel the secondary metamodel for the column: the referenced primary key metamodel for
+ *                           foreign keys, or the component's own metamodel for compound key components.
  */
 public record ColumnImpl(
         @Nonnull Name columnName,

--- a/storm-core/src/main/java/st/orm/core/template/impl/ModelFactory.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/ModelFactory.java
@@ -448,7 +448,12 @@ final class ModelFactory {
                 return;
             }
             ColumnName columnName = getColumnName(field, ctx.builder().columnNameResolver());
-            emitColumns(ctx, field, columnMetamodel, null, spec, keyScope, List.of(columnName), List.of(spec.dataType()), List.of(spec.dataType()));
+            // Compound key components are registered under the key's group metamodel so that compound
+            // lookups resolve to all key columns. The component's own metamodel is retained as the
+            // secondary metamodel so that per-component metamodels, as exposed by generated metamodel
+            // classes and Key.flatten(), resolve to their individual column as well.
+            Metamodel<Data, ?> componentMetamodel = columnMetamodel != ownMetamodel ? ownMetamodel : null;
+            emitColumns(ctx, field, columnMetamodel, componentMetamodel, spec, keyScope, List.of(columnName), List.of(spec.dataType()), List.of(spec.dataType()));
         } catch (SqlTemplateException e) {
             throw new UncheckedSqlTemplateException(e);
         }

--- a/storm-core/src/test/java/st/orm/core/ModelImplIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/ModelImplIntegrationTest.java
@@ -2,6 +2,7 @@ package st.orm.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -14,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.Metamodel;
 import st.orm.core.model.City;
 import st.orm.core.model.Owner;
 import st.orm.core.model.Pet;
@@ -320,6 +322,23 @@ public class ModelImplIntegrationTest {
         var declaredColumns = model.declaredColumns();
         long primaryKeyColumnCount = declaredColumns.stream().filter(Column::primaryKey).count();
         assertEquals(2, primaryKeyColumnCount, "VetSpecialty should have 2 primary key columns");
+    }
+
+    @Test
+    public void testVetSpecialtyCompoundPkComponentColumns() throws Exception {
+        // Per-component metamodels of a compound key resolve to their individual column, while the
+        // compound key's own metamodel keeps resolving to all key columns.
+        var orm = ORMTemplate.of(dataSource);
+        var model = orm.entity(VetSpecialty.class).model();
+        var vetIdColumns = model.getColumns(Metamodel.of(VetSpecialty.class, "id.vetId"));
+        assertEquals(1, vetIdColumns.size());
+        var specialtyIdColumns = model.getColumns(Metamodel.of(VetSpecialty.class, "id.specialtyId"));
+        assertEquals(1, specialtyIdColumns.size());
+        assertNotEquals(vetIdColumns.getFirst().name(), specialtyIdColumns.getFirst().name());
+        var compoundColumns = model.getColumns(Metamodel.of(VetSpecialty.class, "id"));
+        assertEquals(2, compoundColumns.size());
+        assertTrue(compoundColumns.contains(vetIdColumns.getFirst()));
+        assertTrue(compoundColumns.contains(specialtyIdColumns.getFirst()));
     }
 
     // Visit model with @Version timestamp

--- a/storm-core/src/test/java/st/orm/core/TemplatePreparedStatementIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/TemplatePreparedStatementIntegrationTest.java
@@ -49,6 +49,7 @@ import st.orm.DbColumn;
 import st.orm.DbTable;
 import st.orm.Entity;
 import st.orm.FK;
+import st.orm.Metamodel;
 import st.orm.PK;
 import st.orm.Persist;
 import st.orm.PersistenceException;
@@ -82,6 +83,17 @@ public class TemplatePreparedStatementIntegrationTest {
 
     @Autowired
     private PetRepository petRepository;
+
+    @Test
+    public void testSelectCompoundPkComponent() {
+        // Compound key component metamodels resolve to their individual column in templates.
+        try (var query = ORMTemplate.of(dataSource).query(raw("""
+                SELECT DISTINCT \0
+                FROM \0""", Metamodel.of(VetSpecialty.class, "id.specialtyId"), VetSpecialty.class)).prepare();
+             var stream = query.getResultStream(Integer.class)) {
+            assertFalse(stream.filter(Objects::nonNull).toList().isEmpty());
+        }
+    }
 
     @Test
     public void testSelectPet() {


### PR DESCRIPTION
## Problem

Per-component metamodels of a compound primary key (`VetSpecialty_.id.specialtyId`, `Metamodel.of(VetSpecialty.class, "id.specialtyId")`, and the leaves returned by `Key#flatten()`) fail template and predicate resolution with `Column not found for metamodel`, even though the generated metamodel classes expose these nodes. See #216 for the full analysis.

## Root cause

`ModelFactory#createColumns` registers every component column of a record-typed `@PK` under the key's *group* metamodel (via the `keyMetamodel` override), so the column map carries no entry for the component's own canonical form. The component node is a scalar leaf, so the inline prefix fallback does not apply. Plain non-key inline records keep their own metamodels, which is why `Owner_.address.city` resolves while compound key components do not.

## Fix

When the key's group metamodel overrides a component column's addressing identity, the component's own metamodel is retained as the column's `secondaryMetamodel`. `ModelImpl#initColumnMap` already indexes secondary metamodels (the mechanism foreign keys use for their referenced-PK mirror), so component lookups resolve without any change to the lookup path:

- `getColumns(id.specialtyId)` → the single component column,
- `getColumns(id)` → all key columns, exactly as before (the group registration is untouched),
- primary metamodel identity is unchanged, so PK-based WHERE compilation, value binding, and the ambiguity check are unaffected,
- depth-general: compound-PK components of foreign-key-expanded relations resolve too, since the retained metamodel carries the full path.

## Tests

- `ModelImplIntegrationTest#testVetSpecialtyCompoundPkComponentColumns`: component lookups return their distinct single columns and the compound lookup still returns both.
- `TemplatePreparedStatementIntegrationTest#testSelectCompoundPkComponent`: a `SELECT DISTINCT` template using a component metamodel compiles and executes.

Full storm-core suite passes.

Fixes #216
