### PR TITLE
feat(ktor): support multiple databases in the Storm plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Framework integration points are now instance-scoped (#198), and the Ktor integr
 - `st.orm.spring.SpringTransactionTemplateProvider` (storm-spring): gives Java applications transaction-scoped entity caching under Spring-managed transactions without reflective probes.
 - The Ktor plugin gains `connectionProvider`, `transactionTemplateProvider`, `exceptionMapper` and `queryObserver` slots on `install(Storm) { }`.
 - The Ktor plugin exposes the `ORMTemplate` and every registered repository through Ktor's built-in dependency injection (`ktor-server-di`), each repository under its own interface type: `val visits: VisitRepository by dependencies`. Disable with `registerDependencies = false`.
+- The Ktor plugin supports multiple databases: `database("name") { }` blocks declare additional databases with their own template, repositories, schema validation, migration hook and lifecycle, configured in code or under `storm.databases.<name>.*` in HOCON. The packages declared per database partition repositories and schema validation; access goes through `orm("name")`, `repository<T>("name")` and named dependency injection.
 
 ### Changed
 

--- a/docs/ktor-integration.md
+++ b/docs/ktor-integration.md
@@ -356,6 +356,37 @@ fun Application.visitRoutes(visits: VisitRepository) {
 
 Install the Storm plugin before any module that injects Storm types, so the providers are registered by the time they are resolved. With auto-registration (the default), the container covers the application's entire repository layer; repositories created lazily after installation (`autoRegisterRepositories = false`) are not added automatically. Set `registerDependencies = false` in the plugin configuration to leave the dependency container untouched.
 
+### Multiple Databases
+
+Working with one database requires no extra configuration. Additional databases are declared as named `database` blocks inside the plugin, each with the same options as the primary:
+
+```kotlin
+install(Storm) {
+    // primary database: zero-config from storm.datasource
+
+    database("analytics") {
+        repositories("com.myapp.analytics")
+    }
+}
+```
+
+Each named database gets its own `ORMTemplate`, repositories, schema validation, migration hook, and lifecycle. Provide a `dataSource` in the block, or let the plugin create one from the HOCON configuration under `storm.databases.<name>.datasource`, with the same properties as the primary's `storm.datasource` section. Storm configuration overrides for the database are read from `storm.databases.<name>.*`.
+
+The packages declared with `repositories(...)` partition the application between the databases: repository interfaces and entity types under those packages belong to that database. They are registered against its template, validated against its schema, and excluded from the primary database's registration and validation. Requesting a claimed repository from the primary fails with an error naming the owning database.
+
+Access the named database through the name-taking variants of the standard accessors, or through dependency injection:
+
+```kotlin
+val analytics = orm("analytics")
+val reports = repository<ReportRepository>("analytics")
+
+// Dependency injection: templates resolve by name, repositories simply by their type.
+val analyticsTemplate = dependencies.resolve<ORMTemplate>("analytics")
+val reportsByType: ReportRepository by dependencies
+```
+
+Repositories keep unnamed dependency keys because package partitioning makes each repository type belong to exactly one database; only the templates need names. Transactions bind to one database per physical transaction: a `transaction { }` block binds to the database of the first template that runs in it, and a single block cannot atomically span databases.
+
 ### Using with Koin
 
 If your project uses Koin for dependency injection, the same integration is a few lines of application code, because the plugin exposes `Application.orm` and the repository registry, which any DI framework can consume:

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/RepositoryRegistry.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/RepositoryRegistry.kt
@@ -38,12 +38,34 @@ class RepositoryRegistry internal constructor(
     private val repositories = ConcurrentHashMap<KClass<*>, Any>()
 
     /**
+     * Packages claimed by other, named databases (package name to database name). Types under these packages must
+     * not be created against this registry's template; lookups fail fast pointing to the owning database.
+     */
+    internal var claimedPackages: Map<String, String> = emptyMap()
+
+    private fun ownerOf(type: KClass<*>): String? {
+        val typeName = type.java.name
+        return claimedPackages.entries.firstOrNull { (packageName, _) -> typeName.startsWith("$packageName.") }?.value
+    }
+
+    private fun requireUnclaimed(type: KClass<*>) {
+        val owner = ownerOf(type)
+        if (owner != null) {
+            throw IllegalStateException(
+                "Repository ${type.simpleName} belongs to database '$owner'. " +
+                    "Use repository<${type.simpleName}>(\"$owner\") or orm(\"$owner\") to access it.",
+            )
+        }
+    }
+
+    /**
      * Registers a custom repository type. The repository proxy is created immediately and cached.
      *
      * @param type the repository interface to register.
      * @return the created repository instance.
      */
     fun <T : Repository> register(type: KClass<T>): T {
+        requireUnclaimed(type)
         val repository = ormTemplate.repository(type)
         repositories[type] = repository
         return repository
@@ -65,10 +87,11 @@ class RepositoryRegistry internal constructor(
     fun register(vararg packages: String) {
         val discovered = TypeDiscovery.getRepositoryTypes()
         for (type in discovered) {
-            if (packages.isNotEmpty()) {
-                val typeName = type.name
-                if (packages.none { typeName.startsWith("$it.") }) continue
-            }
+            val typeName = type.name
+            if (packages.isNotEmpty() && packages.none { typeName.startsWith("$it.") }) continue
+            // Skip types that belong to another, named database; they are registered against that database's
+            // template instead.
+            if (claimedPackages.keys.any { typeName.startsWith("$it.") }) continue
             val kotlinType = type.kotlin as KClass<out Repository>
             if (!repositories.containsKey(kotlinType)) {
                 val repository = ormTemplate.repository(kotlinType)
@@ -117,7 +140,10 @@ class RepositoryRegistry internal constructor(
      * @since 1.12
      */
     @Suppress("UNCHECKED_CAST")
-    fun <T : Repository> getOrCreate(type: KClass<T>): T = repositories.computeIfAbsent(type) { ormTemplate.repository(type) } as T
+    fun <T : Repository> getOrCreate(type: KClass<T>): T = repositories.computeIfAbsent(type) {
+        requireUnclaimed(type)
+        ormTemplate.repository(type)
+    } as T
 }
 
 /**

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
@@ -15,16 +15,18 @@
  */
 package st.orm.ktor
 
+import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.createApplicationPlugin
 import io.ktor.server.application.log
 import io.ktor.server.plugins.di.DependencyKey
 import io.ktor.server.plugins.di.dependencies
 import io.ktor.util.reflect.TypeInfo
-import st.orm.core.template.impl.SchemaValidator
 import st.orm.template.ORMTemplate
 import st.orm.template.impl.CoroutineAwareConnectionProviderImpl
 import st.orm.template.impl.TransactionTemplateProviderImpl
+import javax.sql.DataSource
+import kotlin.reflect.KClass
 import kotlin.reflect.full.starProjectedType
 
 /**
@@ -59,13 +61,40 @@ import kotlin.reflect.full.starProjectedType
  *
  *         // Optional: narrow repository auto-registration
  *         repositories("com.myapp.repository")
+ *
+ *         // Optional: additional, named databases
+ *         database("analytics") {
+ *             repositories("com.myapp.analytics")
+ *         }
  *     }
  * }
  * ```
  *
+ * Additional databases declared with `database("name") { }` get their own template, repositories, schema
+ * validation, and lifecycle, exposed under their name: `orm("name")`, `repository<T>("name")`, and named
+ * dependency injection. The packages declared inside a database block partition repositories and schema
+ * validation between the databases.
+ *
  * @since 1.11
  */
 val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::StormPluginConfig) {
+
+    // Packages claimed by the named databases (package name to database name). These partition repository
+    // registration and schema validation: types under a claimed package belong to that database only.
+    val claimedPackages = mutableMapOf<String, String>()
+    for (databaseConfig in pluginConfig.databases.values) {
+        for (packageName in databaseConfig.repositoryPackages) {
+            val existingOwner = claimedPackages.put(packageName, databaseConfig.name)
+            if (existingOwner != null && existingOwner != databaseConfig.name) {
+                throw IllegalStateException(
+                    "Package '$packageName' is declared by both database '$existingOwner' and " +
+                        "database '${databaseConfig.name}'. Each package can belong to only one database.",
+                )
+            }
+        }
+    }
+
+    // ---- Primary database ----
 
     val dataSource = pluginConfig.dataSource ?: createDataSourceFromConfig(application)
     val stormConfig = pluginConfig.config ?: readStormConfig(application)
@@ -75,9 +104,9 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
     pluginConfig.migration?.invoke(dataSource)
 
     // Compose the template with explicit, plugin-scoped integration strategies: one provider instance per
-    // install, so all repositories of this application share transactions, and the ambient transaction { }
-    // API binds to this template's provider when it executes inside a transaction block.
-    val builder = st.orm.template.ORMTemplate.builder(dataSource)
+    // database, so all repositories of a database share transactions, and the ambient transaction { }
+    // API binds to the database's provider when its template executes inside a transaction block.
+    val builder = ORMTemplate.builder(dataSource)
         .config(stormConfig)
         .connectionProvider(pluginConfig.connectionProvider ?: CoroutineAwareConnectionProviderImpl())
         .transactionTemplateProvider(pluginConfig.transactionTemplateProvider ?: TransactionTemplateProviderImpl())
@@ -95,48 +124,132 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
     // Eager registration creates the proxies now, so a broken repository definition fails at startup
     // rather than at first request. Narrow with repositories("com.myapp") or disable with
     // autoRegisterRepositories = false; unregistered types are still created lazily on first access.
+    // Types under packages claimed by a named database are excluded here and registered there instead.
     val repositoryRegistry = RepositoryRegistry(ormTemplate, application)
+    repositoryRegistry.claimedPackages = claimedPackages
     if (pluginConfig.autoRegisterRepositories) {
         repositoryRegistry.register(*pluginConfig.repositoryPackages.toTypedArray())
     }
     application.attributes.put(RepositoryRegistryKey, repositoryRegistry)
 
-    // Expose the template and the registered repositories through Ktor's dependency injection, each
-    // repository under its own interface type, so modules and routes can inject them directly:
-    // `val visits: VisitRepository by dependencies`. Repositories created lazily after installation
-    // (autoRegisterRepositories = false) are not added to the container; register those yourself if needed.
+    // ---- Named databases ----
+
+    val namedTemplates = LinkedHashMap<String, ORMTemplate>()
+    val namedDataSources = LinkedHashMap<String, DataSource>()
+    val namedRegistries = LinkedHashMap<String, RepositoryRegistry>()
+    for (databaseConfig in pluginConfig.databases.values) {
+        val name = databaseConfig.name
+        val databaseDataSource = databaseConfig.dataSource
+            ?: createDataSourceFromConfig(application, "storm.databases.$name.datasource")
+        val databaseStormConfig = databaseConfig.config
+            ?: readStormConfig(application, "storm.databases.$name")
+        databaseConfig.migration?.invoke(databaseDataSource)
+        val databaseBuilder = ORMTemplate.builder(databaseDataSource)
+            .config(databaseStormConfig)
+            .connectionProvider(databaseConfig.connectionProvider ?: CoroutineAwareConnectionProviderImpl())
+            .transactionTemplateProvider(
+                databaseConfig.transactionTemplateProvider ?: TransactionTemplateProviderImpl(),
+            )
+        databaseConfig.exceptionMapper?.let { databaseBuilder.exceptionMapper(it) }
+        databaseConfig.queryObserver?.let { databaseBuilder.queryObserver(it) }
+        var databaseTemplate = databaseBuilder.build()
+        if (databaseConfig.entityCallbacks.isNotEmpty()) {
+            databaseTemplate = databaseTemplate.withEntityCallbacks(databaseConfig.entityCallbacks)
+        }
+        val databaseRegistry = RepositoryRegistry(databaseTemplate, application)
+        databaseRegistry.claimedPackages = claimedPackages.filterValues { it != name }
+        if (databaseConfig.repositoryPackages.isNotEmpty()) {
+            databaseRegistry.register(*databaseConfig.repositoryPackages.toTypedArray())
+        }
+        namedTemplates[name] = databaseTemplate
+        namedDataSources[name] = databaseDataSource
+        namedRegistries[name] = databaseRegistry
+    }
+    application.attributes.put(NamedOrmTemplatesKey, namedTemplates)
+    application.attributes.put(NamedDataSourcesKey, namedDataSources)
+    application.attributes.put(NamedRepositoryRegistriesKey, namedRegistries)
+
+    // ---- Dependency injection ----
+
+    // Expose the templates and the registered repositories through Ktor's dependency injection. The primary
+    // template is registered unnamed and each named database's template under its name. Repositories are always
+    // registered unnamed under their own interface type: package partitioning guarantees each type belongs to
+    // exactly one database, so `val visits: VisitRepository by dependencies` works regardless of the database.
+    // Repositories created lazily after installation are not added to the container.
     if (pluginConfig.registerDependencies) {
         application.dependencies {
             provide<ORMTemplate> { ormTemplate }
         }
-        repositoryRegistry.forEach { type, instance ->
+        application.registerRepositories(repositoryRegistry)
+        for ((name, template) in namedTemplates) {
             application.dependencies {
-                set(DependencyKey(TypeInfo(type, type.starProjectedType))) { instance }
+                provide<ORMTemplate>(name) { template }
             }
+            application.registerRepositories(namedRegistries.getValue(name))
         }
     }
 
-    // Run schema validation. The mode comes from the plugin configuration, falling back to the
-    // application configuration (storm.validation.schemaMode), matching the Spring Boot starter.
-    val configuredSchemaMode = pluginConfig.schemaValidation
-        ?: application.environment.config.propertyOrNull("storm.validation.schemaMode")?.getString()
-        ?: application.environment.config.propertyOrNull("storm.validation.schema_mode")?.getString()
-        ?: "fail"
-    val schemaMode = configuredSchemaMode.trim().lowercase()
-    if (schemaMode != "none" && schemaMode.isNotBlank()) {
-        val validator = SchemaValidator.of(dataSource)
-        when (schemaMode) {
-            "fail" -> {
-                validator.validateOrThrow()
-                application.log.info("Storm schema validation passed (mode=fail).")
-            }
-            "warn" -> validator.validateOrWarn()
-            else -> application.log.warn("Unknown schema validation mode: '$configuredSchemaMode'. Expected 'none', 'warn', or 'fail'.")
-        }
+    // ---- Schema validation ----
+
+    // The packages declared by the named databases partition validation: each database validates only the entity
+    // and projection types under its packages, and the primary validates everything else.
+    application.runSchemaValidation(
+        template = ormTemplate,
+        configuredMode = pluginConfig.schemaValidation
+            ?: application.environment.config.propertyOrNull("storm.validation.schemaMode")?.getString()
+            ?: application.environment.config.propertyOrNull("storm.validation.schema_mode")?.getString()
+            ?: "fail",
+        description = "primary database",
+    ) { type -> claimedPackages.keys.none { type.java.name.startsWith("$it.") } }
+    for (databaseConfig in pluginConfig.databases.values) {
+        val name = databaseConfig.name
+        application.runSchemaValidation(
+            template = namedTemplates.getValue(name),
+            configuredMode = databaseConfig.schemaValidation
+                ?: application.environment.config.propertyOrNull("storm.databases.$name.validation.schemaMode")?.getString()
+                ?: application.environment.config.propertyOrNull("storm.databases.$name.validation.schema_mode")?.getString()
+                ?: "fail",
+            description = "database '$name'",
+        ) { type -> databaseConfig.repositoryPackages.any { type.java.name.startsWith("$it.") } }
     }
 
-    // Register shutdown hook to close the DataSource if it is a managed HikariDataSource.
+    // Register shutdown hook to close the DataSources that are managed HikariDataSources.
     application.monitor.subscribe(ApplicationStopped) {
         closeDataSourceIfManaged(dataSource)
+        namedDataSources.values.forEach { closeDataSourceIfManaged(it) }
+    }
+}
+
+/**
+ * Registers every repository of the given registry in the dependency container, each under its own interface type.
+ */
+private fun Application.registerRepositories(registry: RepositoryRegistry) {
+    registry.forEach { type, instance ->
+        dependencies {
+            set(DependencyKey(TypeInfo(type, type.starProjectedType))) { instance }
+        }
+    }
+}
+
+/**
+ * Runs schema validation for one database's template, limited to the types accepted by [filter].
+ */
+private fun Application.runSchemaValidation(
+    template: ORMTemplate,
+    configuredMode: String,
+    description: String,
+    filter: (KClass<out st.orm.Data>) -> Boolean,
+) {
+    val schemaMode = configuredMode.trim().lowercase()
+    if (schemaMode == "none" || schemaMode.isBlank()) {
+        return
+    }
+    when (schemaMode) {
+        "fail" -> {
+            template.validateSchemaOrThrow(filter)
+            log.info("Storm schema validation passed for $description (mode=fail).")
+        }
+        "warn" -> template.validateSchema(filter).forEach { log.warn(it) }
+        else -> log.warn("Unknown schema validation mode: '$configuredMode'. Expected 'none', 'warn', or 'fail'.")
     }
 }

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormAttributes.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormAttributes.kt
@@ -27,3 +27,12 @@ internal val DataSourceKey = AttributeKey<DataSource>("StormDataSource")
 
 @PublishedApi
 internal val RepositoryRegistryKey = AttributeKey<RepositoryRegistry>("StormRepositoryRegistry")
+
+/**
+ * Attribute keys for the additional, named databases configured via `database("name") { }`.
+ */
+internal val NamedOrmTemplatesKey = AttributeKey<Map<String, ORMTemplate>>("StormNamedORMTemplates")
+internal val NamedDataSourcesKey = AttributeKey<Map<String, DataSource>>("StormNamedDataSources")
+
+@PublishedApi
+internal val NamedRepositoryRegistriesKey = AttributeKey<Map<String, RepositoryRegistry>>("StormNamedRepositoryRegistries")

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormConfigReader.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormConfigReader.kt
@@ -58,7 +58,7 @@ import st.orm.StormConfig.VALIDATION_STRICT
  * }
  * ```
  */
-internal fun readStormConfig(application: Application): StormConfig {
+internal fun readStormConfig(application: Application, prefix: String = "storm"): StormConfig {
     val config = application.environment.config
     val properties = mutableMapOf<String, String>()
     val keys = listOf(
@@ -74,10 +74,13 @@ internal fun readStormConfig(application: Application): StormConfig {
         VALIDATION_INTERPOLATION_MODE,
     )
     for (key in keys) {
+        // Storm property keys are rooted at "storm."; secondary databases read the same keys relative to their
+        // own prefix, e.g. "storm.databases.analytics.update.default_mode". The prefix itself (which may contain
+        // a user-chosen database name) is looked up verbatim; only the relative key gets the camelCase variant.
+        val relativeKey = key.removePrefix("storm")
         // Try camelCase (HOCON convention) first, then snake_case (Storm convention).
-        val hoconKey = snakeToCamel(key)
-        val value = config.propertyOrNull(hoconKey)?.getString()
-            ?: config.propertyOrNull(key)?.getString()
+        val value = config.propertyOrNull(prefix + snakeToCamel(relativeKey))?.getString()
+            ?: config.propertyOrNull(prefix + relativeKey)?.getString()
             ?: continue
         properties[key] = value
     }

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormDataSource.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormDataSource.kt
@@ -36,32 +36,32 @@ import javax.sql.DataSource
  * }
  * ```
  */
-internal fun createDataSourceFromConfig(application: Application): DataSource {
+internal fun createDataSourceFromConfig(application: Application, path: String = "storm.datasource"): DataSource {
     val config = application.environment.config
     val hikariConfig = HikariConfig().apply {
-        jdbcUrl = config.property("storm.datasource.jdbcUrl").getString()
-        config.propertyOrNull("storm.datasource.driverClassName")?.getString()?.let {
+        jdbcUrl = config.property("$path.jdbcUrl").getString()
+        config.propertyOrNull("$path.driverClassName")?.getString()?.let {
             driverClassName = it
         }
-        config.propertyOrNull("storm.datasource.username")?.getString()?.let {
+        config.propertyOrNull("$path.username")?.getString()?.let {
             username = it
         }
-        config.propertyOrNull("storm.datasource.password")?.getString()?.let {
+        config.propertyOrNull("$path.password")?.getString()?.let {
             password = it
         }
-        config.propertyOrNull("storm.datasource.maximumPoolSize")?.getString()?.toIntOrNull()?.let {
+        config.propertyOrNull("$path.maximumPoolSize")?.getString()?.toIntOrNull()?.let {
             maximumPoolSize = it
         }
-        config.propertyOrNull("storm.datasource.connectionTimeout")?.getString()?.toLongOrNull()?.let {
+        config.propertyOrNull("$path.connectionTimeout")?.getString()?.toLongOrNull()?.let {
             connectionTimeout = it
         }
-        config.propertyOrNull("storm.datasource.idleTimeout")?.getString()?.toLongOrNull()?.let {
+        config.propertyOrNull("$path.idleTimeout")?.getString()?.toLongOrNull()?.let {
             idleTimeout = it
         }
-        config.propertyOrNull("storm.datasource.maxLifetime")?.getString()?.toLongOrNull()?.let {
+        config.propertyOrNull("$path.maxLifetime")?.getString()?.toLongOrNull()?.let {
             maxLifetime = it
         }
-        config.propertyOrNull("storm.datasource.minimumIdle")?.getString()?.toIntOrNull()?.let {
+        config.propertyOrNull("$path.minimumIdle")?.getString()?.toIntOrNull()?.let {
             minimumIdle = it
         }
     }

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormDatabaseConfig.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormDatabaseConfig.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.ktor
+
+import st.orm.EntityCallback
+import st.orm.StormConfig
+import javax.sql.DataSource
+
+/**
+ * Configuration for an additional, named database of the [Storm] plugin.
+ *
+ * Declared inside `install(Storm) { database("name") { ... } }`; the options mirror the primary database's
+ * configuration on [StormPluginConfig]. The database's template and repositories are exposed under the given name:
+ * `orm("name")`, `repository<T>("name")`, and named dependency injection (`@Named("name")`).
+ *
+ * The packages declared with [repositories] partition the application: repository interfaces and entity types under
+ * these packages belong to this database. They are registered against this database's template, excluded from the
+ * primary database's registration and schema validation, and validated against this database's schema instead.
+ *
+ * @since 1.13
+ */
+class StormDatabaseConfig internal constructor(internal val name: String) {
+
+    /**
+     * The [DataSource] to use for this database. If not provided, one is created from the HOCON configuration
+     * under `storm.databases.<name>.datasource`.
+     */
+    var dataSource: DataSource? = null
+
+    /**
+     * Optional [StormConfig] override for this database. If not provided, configuration is read from the HOCON
+     * configuration under `storm.databases.<name>`, falling back to defaults.
+     */
+    var config: StormConfig? = null
+
+    /**
+     * Optional [st.orm.core.spi.ConnectionProvider] override. When not set, this database uses its own
+     * coroutine-aware provider instance.
+     */
+    var connectionProvider: st.orm.core.spi.ConnectionProvider? = null
+
+    /**
+     * Optional [st.orm.core.spi.TransactionTemplateProvider] override. When not set, this database uses its own
+     * JDBC transaction provider instance. Each database has its own transaction provider, so a `transaction { }`
+     * block binds to one database; blocks cannot atomically span databases.
+     */
+    var transactionTemplateProvider: st.orm.core.spi.TransactionTemplateProvider? = null
+
+    /**
+     * Optional [st.orm.core.spi.ExceptionMapper] for this database's template.
+     */
+    var exceptionMapper: st.orm.core.spi.ExceptionMapper? = null
+
+    /**
+     * Optional [st.orm.core.spi.QueryObserver] for this database's template.
+     */
+    var queryObserver: st.orm.core.spi.QueryObserver? = null
+
+    /**
+     * Schema validation mode for this database: `"none"`, `"warn"`, or `"fail"`.
+     *
+     * When not set, the mode is read from the HOCON configuration under
+     * `storm.databases.<name>.validation.schemaMode` (or `schema_mode`), defaulting to `"fail"`. Validation covers
+     * the entity and projection types under the packages declared with [repositories].
+     */
+    var schemaValidation: String? = null
+
+    internal var migration: ((DataSource) -> Unit)? = null
+
+    /**
+     * Registers a migration hook for this database, running after its [DataSource] is available but before the
+     * template is created and the schema is validated.
+     */
+    fun migration(block: (DataSource) -> Unit) {
+        migration = block
+    }
+
+    internal val entityCallbacks = mutableListOf<EntityCallback<*>>()
+
+    /**
+     * Registers an entity callback on this database's template.
+     */
+    fun entityCallback(callback: EntityCallback<*>) {
+        entityCallbacks += callback
+    }
+
+    internal val repositoryPackages = mutableListOf<String>()
+
+    /**
+     * Declares the packages that belong to this database.
+     *
+     * Repository interfaces from the compile-time type index under these packages (including sub-packages) are
+     * registered against this database's template, and entity and projection types under these packages are
+     * validated against this database's schema. The primary database excludes these packages from its own
+     * registration and validation.
+     *
+     * A database without declared packages exposes its template (`orm("name")`) but registers no repositories
+     * automatically.
+     */
+    fun repositories(vararg packages: String) {
+        repositoryPackages += packages
+    }
+}

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormExtensions.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormExtensions.kt
@@ -79,6 +79,68 @@ val RoutingContext.orm: ORMTemplate
     get() = call.application.orm
 
 /**
+ * Returns the Storm [ORMTemplate] of the named database.
+ *
+ * Named databases are configured inside the [Storm] plugin via `database("name") { }`.
+ *
+ * @param name the database name as declared in the plugin configuration.
+ * @throws IllegalStateException if the Storm plugin is not installed or no database with the given name is
+ * configured.
+ * @since 1.13
+ */
+fun Application.orm(name: String): ORMTemplate {
+    val namedTemplates = attributes.getOrNull(NamedOrmTemplatesKey)
+        ?: throw IllegalStateException(
+            "Storm plugin is not installed. Call install(Storm) in your application module.",
+        )
+    return namedTemplates[name] ?: throw IllegalStateException(
+        "No database named '$name' is configured. Configured databases: " +
+            (namedTemplates.keys.takeIf { it.isNotEmpty() }?.joinToString(", ") ?: "<none>") +
+            ". Declare it with database(\"$name\") { } inside install(Storm).",
+    )
+}
+
+/**
+ * Returns the Storm [ORMTemplate] of the named database.
+ *
+ * Convenience extension for use in route handlers.
+ *
+ * @throws IllegalStateException if the Storm plugin is not installed or no database with the given name is
+ * configured.
+ * @since 1.13
+ */
+fun ApplicationCall.orm(name: String): ORMTemplate = application.orm(name)
+
+/**
+ * Returns the Storm [ORMTemplate] of the named database.
+ *
+ * Convenience extension for use in route handlers.
+ *
+ * @throws IllegalStateException if the Storm plugin is not installed or no database with the given name is
+ * configured.
+ * @since 1.13
+ */
+fun RoutingContext.orm(name: String): ORMTemplate = call.application.orm(name)
+
+/**
+ * Returns the [DataSource] of the named database.
+ *
+ * @param name the database name as declared in the plugin configuration.
+ * @throws IllegalStateException if the Storm plugin is not installed or no database with the given name is
+ * configured.
+ * @since 1.13
+ */
+fun Application.stormDataSource(name: String): DataSource {
+    val namedDataSources = attributes.getOrNull(NamedDataSourcesKey)
+        ?: throw IllegalStateException(
+            "Storm plugin is not installed. Call install(Storm) in your application module.",
+        )
+    return namedDataSources[name] ?: throw IllegalStateException(
+        "No database named '$name' is configured. Declare it with database(\"$name\") { } inside install(Storm).",
+    )
+}
+
+/**
  * Retrieves a Storm repository.
  *
  * Repositories from the compile-time type index are registered automatically when the [Storm] plugin is
@@ -95,6 +157,52 @@ inline fun <reified T : Repository> Application.repository(): T {
         )
     return registry.getOrCreate(T::class)
 }
+
+/**
+ * Retrieves a Storm repository from the named database.
+ *
+ * Repositories under the packages declared in the database's `repositories(...)` configuration are registered at
+ * startup; other types are created lazily against the named database's template and cached.
+ *
+ * @param name the database name as declared in the plugin configuration.
+ * @throws IllegalStateException if the Storm plugin is not installed or no database with the given name is
+ * configured.
+ * @since 1.13
+ */
+inline fun <reified T : Repository> Application.repository(name: String): T {
+    val namedRegistries = attributes.getOrNull(NamedRepositoryRegistriesKey)
+        ?: throw IllegalStateException(
+            "Storm plugin is not installed. Call install(Storm) in your application module.",
+        )
+    val registry = namedRegistries[name] ?: throw IllegalStateException(
+        "No database named '$name' is configured. Declare it with database(\"$name\") { } inside install(Storm).",
+    )
+    return registry.getOrCreate(T::class)
+}
+
+/**
+ * Retrieves a Storm repository from the named database.
+ *
+ * Convenience extension for use in route handlers. See [Application.repository] for registration and caching
+ * semantics.
+ *
+ * @throws IllegalStateException if the Storm plugin is not installed or no database with the given name is
+ * configured.
+ * @since 1.13
+ */
+inline fun <reified T : Repository> ApplicationCall.repository(name: String): T = application.repository<T>(name)
+
+/**
+ * Retrieves a Storm repository from the named database.
+ *
+ * Convenience extension for use in route handlers. See [Application.repository] for registration and caching
+ * semantics.
+ *
+ * @throws IllegalStateException if the Storm plugin is not installed or no database with the given name is
+ * configured.
+ * @since 1.13
+ */
+inline fun <reified T : Repository> RoutingContext.repository(name: String): T = call.application.repository<T>(name)
 
 /**
  * Retrieves a Storm repository.

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormPluginConfig.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormPluginConfig.kt
@@ -167,4 +167,37 @@ class StormPluginConfig {
     fun repositories(vararg packages: String) {
         repositoryPackages.addAll(packages)
     }
+
+    internal val databases = LinkedHashMap<String, StormDatabaseConfig>()
+
+    /**
+     * Configures an additional, named database.
+     *
+     * The block mirrors the primary database's options: provide a [StormDatabaseConfig.dataSource] or let the
+     * plugin create one from the HOCON configuration under `storm.databases.<name>.datasource`. The database's
+     * template and repositories are exposed under the given name via `orm("name")`, `repository<T>("name")`, and
+     * named dependency injection.
+     *
+     * Declare the packages that belong to this database with [StormDatabaseConfig.repositories]; they partition
+     * repository registration and schema validation between the databases:
+     *
+     * ```kotlin
+     * install(Storm) {
+     *     // primary database: unchanged, zero-config from storm.datasource
+     *
+     *     database("analytics") {
+     *         repositories("com.myapp.analytics")
+     *     }
+     * }
+     * ```
+     *
+     * @param name the database name; must be unique and not blank.
+     * @param block the configuration for the named database.
+     * @since 1.13
+     */
+    fun database(name: String, block: StormDatabaseConfig.() -> Unit) {
+        require(name.isNotBlank()) { "Database name must not be blank." }
+        require(name !in databases) { "Database '$name' is already configured." }
+        databases[name] = StormDatabaseConfig(name).apply(block)
+    }
 }

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/RepositoryTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/RepositoryTest.kt
@@ -140,7 +140,8 @@ class RepositoryTest {
                     }
                     val types = mutableListOf<String>()
                     stormRepositories { }.forEach { type, _ -> types.add(type.simpleName!!) }
-                    types shouldBe listOf("PetRepository")
+                    // Without named databases, all indexed repositories register against the primary.
+                    types.sorted() shouldBe listOf("PetRepository", "VetRepository")
                 }
             }
         } finally {
@@ -212,7 +213,8 @@ class RepositoryTest {
                     }
                     val types = mutableListOf<String>()
                     registry.forEach { type, _ -> types.add(type.simpleName!!) }
-                    types shouldBe listOf("PetRepository")
+                    // Without named databases, all indexed repositories register against the primary.
+                    types.sorted() shouldBe listOf("PetRepository", "VetRepository")
                 }
             }
         } finally {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormMultipleDatabasesTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormMultipleDatabasesTest.kt
@@ -1,0 +1,127 @@
+package st.orm.ktor
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.ktor.server.application.install
+import io.ktor.server.plugins.di.dependencies
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import st.orm.ktor.model.PetRepository
+import st.orm.ktor.vet.Vet
+import st.orm.ktor.vet.VetRepository
+import st.orm.template.ORMTemplate
+
+/**
+ * Verifies the named-database support of the [Storm] plugin: per-database templates and repositories, package
+ * partitioning of registration and schema validation, named accessors, and dependency injection.
+ *
+ * The scenario follows the pet clinic domain: the clinic's own database holds the pets, while the vet registry
+ * lives in a separate, named database.
+ */
+class StormMultipleDatabasesTest {
+
+    private fun createTestDataSource(name: String, schemaResource: String): HikariDataSource {
+        val config = HikariConfig().apply {
+            jdbcUrl = "jdbc:h2:mem:$name-${System.nanoTime()};DB_CLOSE_DELAY=-1"
+            driverClassName = "org.h2.Driver"
+            username = "sa"
+            password = ""
+            maximumPoolSize = 2
+        }
+        val dataSource = HikariDataSource(config)
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                val sql = this::class.java.getResourceAsStream(schemaResource)!!.bufferedReader().readText()
+                for (line in sql.split(";")) {
+                    val trimmed = line.trim()
+                    if (trimmed.isNotEmpty()) {
+                        statement.execute(trimmed)
+                    }
+                }
+            }
+        }
+        return dataSource
+    }
+
+    private fun withClinicAndVetsDatabases(block: io.ktor.server.application.Application.() -> Unit) {
+        val clinicDataSource = createTestDataSource("storm-multi-clinic", "/schema.sql")
+        val vetsDataSource = createTestDataSource("storm-multi-vets", "/schema-vets.sql")
+        try {
+            testApplication {
+                application {
+                    install(Storm) {
+                        dataSource = clinicDataSource
+                        // The primary must not see the vet package; partitioning also keeps schema
+                        // validation (mode "fail" by default) green for both databases.
+                        database("vets") {
+                            dataSource = vetsDataSource
+                            repositories("st.orm.ktor.vet")
+                        }
+                    }
+                    block()
+                }
+            }
+        } finally {
+            clinicDataSource.close()
+            vetsDataSource.close()
+        }
+    }
+
+    @Test
+    fun `each database gets its own template and repositories`() = withClinicAndVetsDatabases {
+        val vetsDatabase = orm("vets")
+        vetsDatabase shouldNotBe orm
+        val vets = repository<VetRepository>("vets")
+        vets.findAll().size shouldBe 2
+        // The clinic's own database keeps working against its own schema.
+        repository<PetRepository>().findAll().shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `repositories of a claimed package are not served by the primary database`() = withClinicAndVetsDatabases {
+        val exception = shouldThrow<IllegalStateException> {
+            repository<VetRepository>()
+        }
+        exception.message!! shouldContain "vets"
+    }
+
+    @Test
+    fun `named template and repositories are resolvable through dependency injection`() = withClinicAndVetsDatabases {
+        // The primary template resolves unnamed; each named database's template resolves under its name.
+        val primary = runBlocking { dependencies.resolve<ORMTemplate>() }
+        primary shouldBeSameInstanceAs orm
+        val vetsDatabase = runBlocking { dependencies.resolve<ORMTemplate>("vets") }
+        vetsDatabase shouldBeSameInstanceAs orm("vets")
+        // Repositories are registered unnamed under their own type, regardless of database.
+        val vets: VetRepository by dependencies
+        vets shouldBeSameInstanceAs repository<VetRepository>("vets")
+        val pets: PetRepository by dependencies
+        pets shouldBeSameInstanceAs repository<PetRepository>()
+    }
+
+    @Test
+    fun `writes go to the right database`() = withClinicAndVetsDatabases {
+        val vets = repository<VetRepository>("vets")
+        val insertedVet = vets.insertAndFetch(Vet(firstName = "Sharon", lastName = "Jenkins"))
+        insertedVet.id shouldNotBe 0
+        vets.findAll().size shouldBe 3
+        // The clinic database has no vet rows; its repositories are untouched.
+        repository<PetRepository>().findAll().size shouldBe 3
+    }
+
+    @Test
+    fun `unknown database name fails with a descriptive error`() = withClinicAndVetsDatabases {
+        val exception = shouldThrow<IllegalStateException> {
+            orm("specialties")
+        }
+        exception.message!! shouldContain "No database named 'specialties'"
+        exception.message!! shouldContain "vets"
+    }
+}

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/vet/Vet.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/vet/Vet.kt
@@ -1,0 +1,10 @@
+package st.orm.ktor.vet
+
+import st.orm.Entity
+import st.orm.PK
+
+data class Vet(
+    @PK val id: Int = 0,
+    val firstName: String,
+    val lastName: String,
+) : Entity<Int>

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/vet/VetRepository.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/vet/VetRepository.kt
@@ -1,0 +1,5 @@
+package st.orm.ktor.vet
+
+import st.orm.repository.EntityRepository
+
+interface VetRepository : EntityRepository<Vet, Int>

--- a/storm-ktor/src/test/resources/schema-vets.sql
+++ b/storm-ktor/src/test/resources/schema-vets.sql
@@ -1,0 +1,6 @@
+drop table if exists vet CASCADE;
+
+create table vet (id integer auto_increment, first_name varchar(255) not null, last_name varchar(255) not null, primary key (id));
+
+INSERT INTO vet (first_name, last_name) VALUES ('James', 'Carter');
+INSERT INTO vet (first_name, last_name) VALUES ('Helen', 'Leary');

--- a/storm-ktor/src/test/resources/schema.sql
+++ b/storm-ktor/src/test/resources/schema.sql
@@ -1,5 +1,8 @@
 drop table if exists pet CASCADE;
 drop table if exists pet_type CASCADE;
+drop table if exists vet CASCADE;
+
+create table vet (id integer auto_increment, first_name varchar(255) not null, last_name varchar(255) not null, primary key (id));
 
 create table pet_type (id integer, name varchar(255) not null, primary key (id));
 create table pet (id integer auto_increment, name varchar(255) not null, type_id integer not null, primary key (id));


### PR DESCRIPTION
Adds native multiple-database support to the Ktor plugin. Fixes #219.

**Design goal, per the issue: one database stays as simple as it is today; additional databases are a small, native step from there.** Plain `install(Storm)` is unchanged and zero-config.

## Named database blocks

```kotlin
install(Storm) {
    // primary database: zero-config from storm.datasource

    database("vets") {
        repositories("com.myapp.vet")
    }
}
```

Each named database gets its own `ORMTemplate` (with its own integration strategies, so transactions bind per database), repositories, schema validation, migration hook, entity callbacks, and lifecycle shutdown. The DataSource comes from the block or from HOCON under `storm.databases.<name>.datasource`; Storm configuration overrides are read from `storm.databases.<name>.*`, mirroring the primary's sections.

## Package partitioning

The packages declared per database partition the application: repository interfaces and entity types under those packages register and validate against that database and are excluded from the primary's registration and validation. Requesting a claimed repository from the primary fails fast naming the owning database, and two databases claiming the same package fail at installation.

Schema validation now runs through the template's filtered `validateSchemaOrThrow { }` so each database validates only its own types; behavior is unchanged for single-database applications (the filter accepts everything when no database blocks are declared).

## Access

`orm("vets")`, `repository<T>("vets")` and `stormDataSource("vets")` on Application, ApplicationCall and RoutingContext, plus dependency injection: templates resolve by name (`dependencies.resolve<ORMTemplate>("vets")`), while repositories keep unnamed keys — package partitioning makes each repository type belong to exactly one database, so `val vets: VetRepository by dependencies` works without qualifiers.

## Tests

`StormMultipleDatabasesTest` follows the pet clinic domain (the clinic database holds the pets, the vet registry is the named database) and covers per-database templates and repositories, the claimed-package fail-fast, named and unnamed dependency resolution, writes routing to the right database, and the unknown-name error. Full storm-ktor suite: 47 tests, 0 failures.