### PR TITLE
feat: query observability for the Ktor integration via Micrometer Observations

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,7 +62,7 @@ jobs:
           #     they are published separately as KDoc under /api/kotlin.
           #   - storm-core is the internal engine (st.orm.core.*).
           #   - dialect SPIs, storm-test and storm-metamodel-processor are not
-          #     part of the user-facing API; Spring/Jackson are integrations.
+          #     part of the user-facing API; Spring/Jackson/Micrometer are integrations.
           # Keep >= 2 named modules so javadoc stays in module mode and pages keep
           # their <module>/<package> paths (the docs link to storm.foundation/...).
           mvn javadoc:aggregate -q \
@@ -70,7 +70,7 @@ jobs:
             -Dmaven.javadoc.failOnError=false \
             -DadditionalJOption=--enable-preview \
             -Ddoclint=none \
-            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-jackson3,!:storm-ktor,!:storm-ktor-test,!:storm-compiler-plugin-2.0,!:storm-compiler-plugin-2.1,!:storm-compiler-plugin-2.2,!:storm-compiler-plugin-2.3,!:storm-compiler-plugin-2.4,!:storm-metamodel-processor,!:storm-core,!:storm-test,!:storm-jackson2,!:storm-oracle,!:storm-mssqlserver,!:storm-postgresql,!:storm-mysql,!:storm-mariadb,!:storm-sqlite,!:storm-h2,!:storm-spring'
+            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-jackson3,!:storm-micrometer,!:storm-ktor,!:storm-ktor-test,!:storm-compiler-plugin-2.0,!:storm-compiler-plugin-2.1,!:storm-compiler-plugin-2.2,!:storm-compiler-plugin-2.3,!:storm-compiler-plugin-2.4,!:storm-metamodel-processor,!:storm-core,!:storm-test,!:storm-jackson2,!:storm-oracle,!:storm-mssqlserver,!:storm-postgresql,!:storm-mysql,!:storm-mariadb,!:storm-sqlite,!:storm-h2,!:storm-spring'
 
       - name: Copy Javadoc to website/static/api/java
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,15 @@ Framework integration points are now instance-scoped (#198), and the Ktor integr
 
 - `ORMTemplate.builder(dataSource)` / `builder(connection)` (core, Java 21 and Kotlin APIs) with instance-scoped integration strategies: `connectionProvider`, `transactionTemplateProvider`, `exceptionMapper` and `queryObserver`. `ServiceLoader` discovery remains the fallback for templates built without explicit strategies.
 - `ExceptionMapper` SPI: maps failures raised during query execution to the exception thrown to the caller, enabling platform hierarchies such as Spring's `DataAccessException` (the translation itself lands with #199).
-- `QueryObserver` SPI: observes query executions (operation, entity/projection type, execution kind, timing, outcome) for metrics and tracing bindings (the Micrometer binding lands with #203 and #207).
+- `QueryObserver` SPI: observes query executions (operation, entity/projection type, execution kind, timing, outcome) for metrics and tracing bindings (the Spring Boot auto-configuration lands with #203).
 - `springOrmTemplate(dataSource) { transactionManagers }` (storm-kotlin-spring): the canonical plain-Spring composition, replacing `@EnableTransactionIntegration`.
 - `st.orm.spring.SpringTransactionTemplateProvider` (storm-spring): gives Java applications transaction-scoped entity caching under Spring-managed transactions without reflective probes.
 - The Ktor plugin gains `connectionProvider`, `transactionTemplateProvider`, `exceptionMapper` and `queryObserver` slots on `install(Storm) { }`.
 - The Ktor plugin exposes the `ORMTemplate` and every registered repository through Ktor's built-in dependency injection (`ktor-server-di`), each repository under its own interface type: `val visits: VisitRepository by dependencies`. Disable with `registerDependencies = false`.
 - The Ktor plugin supports multiple databases: `database("name") { }` blocks declare additional databases with their own template, repositories, schema validation, migration hook and lifecycle, configured in code or under `storm.databases.<name>.*` in HOCON. The packages declared per database partition repositories and schema validation; access goes through `orm("name")`, `repository<T>("name")` and named dependency injection.
+- New `storm-micrometer` module: `MicrometerQueryObserver` reports query executions as Micrometer Observations named `storm.query`, with low-cardinality key values for the operation, execution kind and data type, and the SQL statement as a high-cardinality value for trace handlers. Naming and key values are overridable via a custom `ObservationConvention`.
+- The Ktor plugin binds query observations automatically: register an `ObservationRegistry` in the dependency container and every query is observed, tagged `storm.database=<name>` (`primary` for the primary database). An explicit `queryObserver` takes precedence; without a registry, queries run unobserved.
+- `Sql.dataType()`: the primary entity or projection type of a statement, now also derived for SELECT statements from the selected or queried table, and reported to query observers as the statement's data type.
 
 ### Changed
 

--- a/docs/ktor-integration.md
+++ b/docs/ktor-integration.md
@@ -619,6 +619,45 @@ See [Validation](validation.md) for details on what is validated and how to inte
 
 ---
 
+## Observability
+
+The plugin turns query executions into [Micrometer Observations](https://docs.micrometer.io/micrometer/reference/observation.html) automatically. Register an `ObservationRegistry` in the dependency container, in any module, and every Storm query is observed from then on:
+
+```kotlin
+fun Application.module() {
+    dependencies {
+        provide<ObservationRegistry> { observationRegistry }
+    }
+    install(Storm)
+}
+```
+
+No further configuration is needed; without a registry, queries run unobserved at no cost. What each observation produces depends on the handlers attached to the registry: timing metrics, tracing spans, or both. Storm spans nest under the current trace context, so with context propagation in place (for example the OpenTelemetry agent, or micrometer-tracing with a `TracingObservationHandler`) queries appear under the active request span.
+
+Observations are named `storm.query` and carry the following key values:
+
+| Key | Cardinality | Value |
+|-----|-------------|-------|
+| `storm.operation` | low | The SQL operation: `SELECT`, `INSERT`, `UPDATE`, `DELETE`, or `UNDEFINED`. |
+| `storm.execution` | low | How the statement executed: `QUERY`, `UPDATE`, or `BATCH`. |
+| `storm.data_type` | low | Simple name of the entity or projection type the statement operates on, or `none` for raw queries. |
+| `storm.database` | low | The database name; `primary` for the primary database. |
+| `db.statement` | high | The SQL statement. Available to trace handlers as a span attribute; never a metric tag. |
+
+Queries against a named database are tagged `storm.database=<name>`; the primary database is tagged `storm.database=primary`. The tag is always present because meters of one name must share a single set of tag keys; registries such as Prometheus drop series whose tag keys differ. Queries issued during plugin installation, such as schema validation, run before the registry is resolved and are not observed.
+
+For full control, set an explicit observer in the plugin configuration; it takes precedence over the automatic binding. The `queryObserver` slot accepts any `st.orm.core.spi.QueryObserver`, including a hand-configured `MicrometerQueryObserver` from the `storm-micrometer` module (custom `ObservationConvention`, extra key values):
+
+```kotlin
+install(Storm) {
+    queryObserver = MicrometerQueryObserver(observationRegistry, KeyValues.of("app.tenant", "acme"))
+}
+```
+
+Non-Ktor applications can use `storm-micrometer` directly by configuring the observer on the template builder: `ORMTemplate.builder(dataSource).queryObserver(MicrometerQueryObserver(registry))`.
+
+---
+
 ## Testing
 
 Storm provides two complementary approaches for testing Ktor applications, both designed to eliminate database setup boilerplate.

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
         <kotlin.coroutines.version>1.9.0</kotlin.coroutines.version>
         <kotlinx.serialization.version>1.7.3</kotlinx.serialization.version>
         <ktor.version>3.2.3</ktor.version>
+        <micrometer.version>1.15.4</micrometer.version>
+        <micrometer-tracing.version>1.5.4</micrometer-tracing.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring-boot.version>3.5.6</spring-boot.version>
         <jacoco.version>0.8.12</jacoco.version>
@@ -54,6 +56,7 @@
         <module>storm-jackson2</module>
         <module>storm-jackson3</module>
         <module>storm-kotlinx-serialization</module>
+        <module>storm-micrometer</module>
         <module>storm-oracle</module>
         <module>storm-mssqlserver</module>
         <module>storm-postgresql</module>

--- a/storm-bom/pom.xml
+++ b/storm-bom/pom.xml
@@ -193,6 +193,11 @@
             </dependency>
             <dependency>
                 <groupId>st.orm</groupId>
+                <artifactId>storm-micrometer</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>st.orm</groupId>
                 <artifactId>storm-ktor</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/storm-core/src/main/java/st/orm/core/template/Sql.java
+++ b/storm-core/src/main/java/st/orm/core/template/Sql.java
@@ -138,6 +138,20 @@ public interface Sql {
     Sql affectedType(@Nullable Class<? extends Data> affectedType);
 
     /**
+     * Returns the primary entity or projection type of the statement, if known: the selected type for SELECT
+     * statements, or the affected type for INSERT, UPDATE, and DELETE statements.
+     *
+     * <p>This is purely informational metadata, exposed to query observers as the statement's data type. Unlike
+     * {@link #affectedType()}, it carries no cache invalidation semantics.</p>
+     *
+     * @return the primary entity or projection type of the statement, or empty if unknown.
+     * @since 1.13
+     */
+    default Optional<Class<? extends Data>> dataType() {
+        return affectedType();
+    }
+
+    /**
      * Returns a warning message if the statement is deemed potentially unsafe, an empty optional otherwise.
      *
      * @since 1.2

--- a/storm-core/src/main/java/st/orm/core/template/impl/DeleteProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/DeleteProcessor.java
@@ -53,6 +53,7 @@ final class DeleteProcessor implements ElementProcessor<Delete> {
     @Override
     public CompiledElement compile(@Nonnull Delete delete, @Nonnull TemplateCompiler compiler) throws SqlTemplateException {
         compiler.setAffectedType(delete.table());
+        compiler.setDataType(delete.table());
         return new CompiledElement(delete.alias().isEmpty() ? "" : delete.alias());
     }
 

--- a/storm-core/src/main/java/st/orm/core/template/impl/FromProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/FromProcessor.java
@@ -63,6 +63,11 @@ final class FromProcessor implements ElementProcessor<From> {
      * @throws SqlTemplateException if compilation fails.
      */
     public CompiledElement compile(@Nonnull From from, @Nonnull TemplateCompiler compiler) throws SqlTemplateException {
+        if (from.source() instanceof TableSource(var table)) {
+            // Observability fallback for statements without a select list, such as count queries; a preceding
+            // select element takes precedence because the first recorded data type wins.
+            compiler.setDataType(table);
+        }
         final String alias = from.alias().isEmpty() ? "" : " " + from.alias();
         return new CompiledElement(switch (from) {
             case From(TableSource ts, String s, boolean b) ->

--- a/storm-core/src/main/java/st/orm/core/template/impl/InsertProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/InsertProcessor.java
@@ -87,6 +87,7 @@ final class InsertProcessor implements ElementProcessor<Insert> {
         compiler.setGeneratedKeys(generatedKeys);
         var table = queryModel.getTable();
         compiler.setAffectedType(insert.table());
+        compiler.setDataType(insert.table());
         return new CompiledElement("%s%s (%s)".formatted(table.name(), table.alias().isEmpty() ? "" : " " + table.alias(), columns));
     }
 

--- a/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
@@ -612,6 +612,7 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
                     strategies.queryObserver(),
                     getExceptionTransformer(sql, strategies.exceptionMapper(), strategies.transactionTemplateProvider()),
                     sql.operation(),
+                    sql.dataType().orElse(null),
                     sql.statement());
             return new QueryImpl(environment, unsafe -> {
                 try {

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryImpl.java
@@ -78,6 +78,7 @@ class QueryImpl implements Query {
                        @Nonnull QueryObserver queryObserver,
                        @Nonnull Function<Throwable, RuntimeException> exceptionTransformer,
                        @Nonnull SqlOperation operation,
+                       @Nullable Class<? extends Data> dataType,
                        @Nullable String statementText) {
     }
 
@@ -213,7 +214,7 @@ class QueryImpl implements Query {
     private Observation observe(@Nonnull ExecutionKind kind) {
         try {
             return environment.queryObserver().onExecute(
-                    new QueryContextImpl(environment.operation(), affectedType, kind, environment.statementText()));
+                    new QueryContextImpl(environment.operation(), environment.dataType(), kind, environment.statementText()));
         } catch (Throwable ignore) {
             return Observation.NOOP;
         }
@@ -727,12 +728,12 @@ class QueryImpl implements Query {
      * Describes a statement execution for the query observer.
      */
     private record QueryContextImpl(@Nonnull SqlOperation operation,
-                                    @Nullable Class<? extends Data> affectedType,
+                                    @Nullable Class<? extends Data> type,
                                     @Nonnull ExecutionKind kind,
                                     @Nullable String statementText) implements QueryContext {
         @Override
         public Optional<Class<? extends Data>> dataType() {
-            return ofNullable(affectedType);
+            return ofNullable(type);
         }
 
         @Override

--- a/storm-core/src/main/java/st/orm/core/template/impl/SelectProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SelectProcessor.java
@@ -52,6 +52,7 @@ final class SelectProcessor implements ElementProcessor<Select> {
      */
     @Override
     public CompiledElement compile(@Nonnull Select select, @Nonnull TemplateCompiler compiler) {
+        compiler.setDataType(select.table());
         return new CompiledElement(compiler.getQueryModel().getColumns(select.table(), select.mode()).stream()
                 .map(ColumnExpression::toSql)
                 .collect(joining(", ")));

--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlImpl.java
@@ -39,6 +39,7 @@ import st.orm.core.template.SqlTemplate.Parameter;
  * @param bindVariables a bind variables object that can be used to add bind variables to a batch.
  * @param generatedKeys the primary key that have been auto generated as part of in insert statement.
  * @param affectedType  the type affected by INSERT, UPDATE, or DELETE operations.
+ * @param dataType      the primary entity or projection type of the statement, recorded for observability.
  * @param versionAware  true if the statement is version aware, false otherwise.
  * @param unsafeWarning a warning message if the statement is deemed potentially unsafe, an empty optional otherwise.
  */
@@ -49,6 +50,7 @@ record SqlImpl(
         @Nonnull Optional<BindVariables> bindVariables,
         @Nonnull List<String> generatedKeys,
         @Nonnull Optional<Class<? extends Data>> affectedType,
+        @Nonnull Optional<Class<? extends Data>> dataType,
         boolean versionAware,
         @Nonnull Optional<String> unsafeWarning
 ) implements Sql {
@@ -58,6 +60,7 @@ record SqlImpl(
         parameters = copyOf(parameters);
         generatedKeys = copyOf(generatedKeys);
         requireNonNull(affectedType, "affectedType");
+        requireNonNull(dataType, "dataType");
         requireNonNull(unsafeWarning, "unsafeWarning");
     }
 
@@ -69,7 +72,7 @@ record SqlImpl(
      */
     @Override
     public Sql operation(@Nonnull SqlOperation operation) {
-        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, versionAware, unsafeWarning);
+        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, dataType, versionAware, unsafeWarning);
     }
 
     /**
@@ -80,7 +83,7 @@ record SqlImpl(
      */
     @Override
     public Sql statement(@Nonnull String statement) {
-        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, versionAware, unsafeWarning);
+        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, dataType, versionAware, unsafeWarning);
     }
 
     /**
@@ -91,7 +94,7 @@ record SqlImpl(
      */
     @Override
     public Sql parameters(@Nonnull List<Parameter> parameters) {
-        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, versionAware, unsafeWarning);
+        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, dataType, versionAware, unsafeWarning);
     }
 
     /**
@@ -102,7 +105,7 @@ record SqlImpl(
      */
     @Override
     public Sql bindVariables(@Nullable SqlTemplate.BindVariables bindVariables) {
-        return new SqlImpl(operation, statement, parameters, ofNullable(bindVariables), generatedKeys, affectedType, versionAware, unsafeWarning);
+        return new SqlImpl(operation, statement, parameters, ofNullable(bindVariables), generatedKeys, affectedType, dataType, versionAware, unsafeWarning);
     }
 
     /**
@@ -114,7 +117,7 @@ record SqlImpl(
      */
     @Override
     public Sql generatedKeys(@Nonnull List<String> generatedKeys) {
-        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, versionAware, unsafeWarning);
+        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, dataType, versionAware, unsafeWarning);
     }
 
     /**
@@ -126,7 +129,7 @@ record SqlImpl(
      */
     @Override
     public Sql affectedType(@Nullable Class<? extends Data> affectedType) {
-        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, ofNullable(affectedType), versionAware, unsafeWarning);
+        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, ofNullable(affectedType), dataType, versionAware, unsafeWarning);
     }
 
     /**
@@ -138,7 +141,7 @@ record SqlImpl(
      */
     @Override
     public Sql versionAware(boolean versionAware) {
-        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, versionAware, unsafeWarning);
+        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, dataType, versionAware, unsafeWarning);
     }
 
     /**
@@ -150,6 +153,6 @@ record SqlImpl(
      */
     @Override
     public Sql unsafeWarning(@Nullable String unsafeWarning) {
-        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, versionAware, ofNullable(unsafeWarning));
+        return new SqlImpl(operation, statement, parameters, bindVariables, generatedKeys, affectedType, dataType, versionAware, ofNullable(unsafeWarning));
     }
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplateCompiler.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplateCompiler.java
@@ -215,4 +215,15 @@ interface TemplateCompiler {
      * @param type the type affected by the operation.
      */
     void setAffectedType(@Nonnull Class<? extends Data> type);
+
+    /**
+     * Records the primary entity or projection type of the statement for observability purposes.
+     *
+     * <p>Unlike {@link #setAffectedType(Class)}, this is purely informational metadata: the first recorded type wins
+     * and subsequent calls are ignored, so the outermost select takes precedence over the sources it queries.</p>
+     *
+     * @param type the entity or projection type the statement operates on.
+     * @since 1.13
+     */
+    void setDataType(@Nonnull Class<? extends Data> type);
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplateProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplateProcessor.java
@@ -162,6 +162,12 @@ class TemplateProcessor {
     private Class<? extends Data> affectedType;
 
     /**
+     * Compile-time only: the primary entity or projection type of the statement, recorded for observability.
+     */
+    @Nullable
+    private Class<? extends Data> dataType;
+
+    /**
      * The compiled SQL string.
      *
      * <p>This is set exactly once by {@link #compile(CompilationContext, boolean)}.</p>
@@ -538,6 +544,7 @@ class TemplateProcessor {
                 ofNullable(session.bindVariables),
                 generatedKeys != null ? generatedKeys : List.of(),
                 ofNullable(affectedType),
+                ofNullable(dataType != null ? dataType : affectedType),
                 versionAware != null && versionAware,
                 checkSafety(sql, operation)
         );
@@ -839,6 +846,20 @@ class TemplateProcessor {
                 throw new IllegalStateException("Affected type already set.");
             }
             affectedType = type;
+        }
+
+        /**
+         * Records the primary entity or projection type of the statement for observability purposes.
+         *
+         * <p>The first recorded type wins, so the outermost select takes precedence over the sources it queries.</p>
+         *
+         * @param type the entity or projection type the statement operates on.
+         */
+        @Override
+        public void setDataType(@Nonnull Class<? extends Data> type) {
+            if (dataType == null) {
+                dataType = type;
+            }
         }
 
         /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/UpdateProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/UpdateProcessor.java
@@ -57,6 +57,7 @@ final class UpdateProcessor implements ElementProcessor<Update> {
         assert queryModel.getTable().type() == update.table();
         var table = queryModel.getTable();
         compiler.setAffectedType(update.table());
+        compiler.setDataType(update.table());
         return new CompiledElement("%s%s".formatted(table.name(), table.alias().isEmpty() ? "" : " " + table.alias()));
     }
 

--- a/storm-core/src/test/java/st/orm/core/template/impl/FetchSizeTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/FetchSizeTest.java
@@ -80,6 +80,7 @@ public class FetchSizeTest {
                         ? persistenceException
                         : new PersistenceException(e),
                 st.orm.core.template.SqlOperation.SELECT,
+                null,
                 sql);
         return new QueryImpl(
                 environment,

--- a/storm-core/src/test/java/st/orm/core/template/impl/SqlImplTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/SqlImplTest.java
@@ -25,6 +25,7 @@ public class SqlImplTest {
                 Optional.empty(),
                 List.of(),
                 Optional.empty(),
+                Optional.empty(),
                 false,
                 Optional.empty()
         );
@@ -39,6 +40,7 @@ public class SqlImplTest {
         assertTrue(sql.bindVariables().isEmpty());
         assertTrue(sql.generatedKeys().isEmpty());
         assertTrue(sql.affectedType().isEmpty());
+        assertTrue(sql.dataType().isEmpty());
         assertFalse(sql.versionAware());
         assertTrue(sql.unsafeWarning().isEmpty());
     }
@@ -113,6 +115,7 @@ public class SqlImplTest {
                 Optional.empty(),
                 List.of(),
                 Optional.empty(),
+                Optional.empty(),
                 false,
                 Optional.of("existing warning")
         );
@@ -129,6 +132,7 @@ public class SqlImplTest {
                 Optional.empty(),
                 List.of(),
                 Optional.empty(),
+                Optional.empty(),
                 false,
                 Optional.empty()
         ));
@@ -142,6 +146,7 @@ public class SqlImplTest {
                 List.of(),
                 Optional.empty(),
                 List.of(),
+                Optional.empty(),
                 Optional.empty(),
                 false,
                 Optional.empty()
@@ -157,6 +162,7 @@ public class SqlImplTest {
                     List.of(),
                     Optional.empty(),
                     List.of(),
+                    Optional.empty(),
                     Optional.empty(),
                     false,
                     Optional.empty()
@@ -176,6 +182,7 @@ public class SqlImplTest {
                 Optional.empty(),
                 List.of(),
                 Optional.empty(),
+                Optional.empty(),
                 false,
                 Optional.empty()
         );
@@ -190,6 +197,7 @@ public class SqlImplTest {
                 List.of(),
                 Optional.empty(),
                 List.of("id"),
+                Optional.empty(),
                 Optional.empty(),
                 false,
                 Optional.empty()

--- a/storm-ktor/pom.xml
+++ b/storm-ktor/pom.xml
@@ -191,6 +191,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>st.orm</groupId>
+            <artifactId>storm-micrometer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.ktor</groupId>
             <artifactId>ktor-server-core-jvm</artifactId>
             <version>${ktor.version}</version>
@@ -227,6 +232,12 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation-test</artifactId>
+            <version>${micrometer.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/DelegatingQueryObserver.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/DelegatingQueryObserver.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.ktor
+
+import st.orm.core.spi.QueryContext
+import st.orm.core.spi.QueryObserver
+
+/**
+ * [QueryObserver] whose target can be swapped after the ORM template has been built. The plugin installs it when
+ * no explicit observer is configured, then binds it to the `ObservationRegistry` from the dependency container
+ * once the application has started, since the registry only becomes resolvable after all modules have run.
+ * Until then, and when no registry is registered, the observer stays no-op.
+ */
+internal class DelegatingQueryObserver : QueryObserver {
+
+    @Volatile
+    var delegate: QueryObserver = QueryObserver.noop()
+
+    override fun onExecute(context: QueryContext): QueryObserver.Observation = delegate.onExecute(context)
+}

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
@@ -16,12 +16,17 @@
 package st.orm.ktor
 
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStarted
 import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.createApplicationPlugin
 import io.ktor.server.application.log
 import io.ktor.server.plugins.di.DependencyKey
 import io.ktor.server.plugins.di.dependencies
+import io.ktor.server.plugins.di.getBlocking
 import io.ktor.util.reflect.TypeInfo
+import io.micrometer.common.KeyValues
+import io.micrometer.observation.ObservationRegistry
+import st.orm.micrometer.MicrometerQueryObserver
 import st.orm.template.ORMTemplate
 import st.orm.template.impl.CoroutineAwareConnectionProviderImpl
 import st.orm.template.impl.TransactionTemplateProviderImpl
@@ -94,6 +99,11 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
         }
     }
 
+    // Query observers, keyed by database name (null for the primary database). An explicit queryObserver always
+    // wins; otherwise a delegating observer is installed that binds to the ObservationRegistry from the
+    // dependency container once the application has started.
+    val delegatingObservers = LinkedHashMap<String?, DelegatingQueryObserver>()
+
     // ---- Primary database ----
 
     val dataSource = pluginConfig.dataSource ?: createDataSourceFromConfig(application)
@@ -111,7 +121,9 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
         .connectionProvider(pluginConfig.connectionProvider ?: CoroutineAwareConnectionProviderImpl())
         .transactionTemplateProvider(pluginConfig.transactionTemplateProvider ?: TransactionTemplateProviderImpl())
     pluginConfig.exceptionMapper?.let { builder.exceptionMapper(it) }
-    pluginConfig.queryObserver?.let { builder.queryObserver(it) }
+    builder.queryObserver(
+        pluginConfig.queryObserver ?: DelegatingQueryObserver().also { delegatingObservers[null] = it },
+    )
     var ormTemplate = builder.build()
     if (pluginConfig.entityCallbacks.isNotEmpty()) {
         ormTemplate = ormTemplate.withEntityCallbacks(pluginConfig.entityCallbacks)
@@ -151,7 +163,9 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
                 databaseConfig.transactionTemplateProvider ?: TransactionTemplateProviderImpl(),
             )
         databaseConfig.exceptionMapper?.let { databaseBuilder.exceptionMapper(it) }
-        databaseConfig.queryObserver?.let { databaseBuilder.queryObserver(it) }
+        databaseBuilder.queryObserver(
+            databaseConfig.queryObserver ?: DelegatingQueryObserver().also { delegatingObservers[name] = it },
+        )
         var databaseTemplate = databaseBuilder.build()
         if (databaseConfig.entityCallbacks.isNotEmpty()) {
             databaseTemplate = databaseTemplate.withEntityCallbacks(databaseConfig.entityCallbacks)
@@ -213,11 +227,43 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
         ) { type -> databaseConfig.repositoryPackages.any { type.java.name.startsWith("$it.") } }
     }
 
+    // ---- Observability ----
+
+    // The ObservationRegistry may be registered by any module, so it only becomes resolvable once the
+    // application has started. Bind the delegating observers then; without a registry they stay no-op. Queries
+    // issued during installation (such as schema validation) run before binding and are not observed.
+    if (delegatingObservers.isNotEmpty()) {
+        application.monitor.subscribe(ApplicationStarted) {
+            application.bindQueryObservations(delegatingObservers)
+        }
+    }
+
     // Register shutdown hook to close the DataSources that are managed HikariDataSources.
     application.monitor.subscribe(ApplicationStopped) {
         closeDataSourceIfManaged(dataSource)
         namedDataSources.values.forEach { closeDataSourceIfManaged(it) }
     }
+}
+
+/**
+ * Binds the delegating query observers to the [ObservationRegistry] from the dependency container, if one is
+ * registered. Every observation carries a `storm.database` key value: the database name, or `primary` for the
+ * primary database. The tag is always present because meters of one name must share a single set of tag keys;
+ * registries such as Prometheus drop series whose tag keys differ.
+ */
+private fun Application.bindQueryObservations(delegatingObservers: Map<String?, DelegatingQueryObserver>) {
+    val registryKey = DependencyKey(TypeInfo(ObservationRegistry::class, ObservationRegistry::class.starProjectedType))
+    if (!dependencies.contains(registryKey)) {
+        return
+    }
+    val observationRegistry = dependencies.getBlocking<ObservationRegistry>(registryKey)
+    for ((databaseName, observer) in delegatingObservers) {
+        observer.delegate = MicrometerQueryObserver(
+            observationRegistry,
+            KeyValues.of("storm.database", databaseName ?: "primary"),
+        )
+    }
+    log.info("Storm query observations enabled via the ObservationRegistry from the dependency container.")
 }
 
 /**

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormObservabilityTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormObservabilityTest.kt
@@ -1,0 +1,182 @@
+package st.orm.ktor
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.plugins.di.dependencies
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.tck.TestObservationRegistry
+import io.micrometer.observation.tck.TestObservationRegistryAssert
+import org.junit.jupiter.api.Test
+import st.orm.core.spi.QueryObserver
+import st.orm.ktor.model.PetRepository
+import st.orm.ktor.vet.VetRepository
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Verifies the automatic observability binding of the [Storm] plugin: registering an
+ * [ObservationRegistry] in the dependency container turns query executions into Micrometer observations,
+ * named databases are tagged with `storm.database`, an explicit `queryObserver` wins over the automatic
+ * binding, and without a registry queries run unobserved.
+ */
+class StormObservabilityTest {
+
+    private fun createTestDataSource(name: String, schemaResource: String): HikariDataSource {
+        val config = HikariConfig().apply {
+            jdbcUrl = "jdbc:h2:mem:$name-${System.nanoTime()};DB_CLOSE_DELAY=-1"
+            driverClassName = "org.h2.Driver"
+            username = "sa"
+            password = ""
+            maximumPoolSize = 2
+        }
+        val dataSource = HikariDataSource(config)
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                val sql = this::class.java.getResourceAsStream(schemaResource)!!.bufferedReader().readText()
+                for (line in sql.split(";")) {
+                    val trimmed = line.trim()
+                    if (trimmed.isNotEmpty()) {
+                        statement.execute(trimmed)
+                    }
+                }
+            }
+        }
+        return dataSource
+    }
+
+    @Test
+    fun `queries are observed when an ObservationRegistry is registered`() {
+        val observationRegistry = TestObservationRegistry.create()
+        val dataSource = createTestDataSource("storm-observed", "/schema.sql")
+        try {
+            testApplication {
+                application {
+                    dependencies {
+                        provide<ObservationRegistry> { observationRegistry }
+                    }
+                    install(Storm) {
+                        this.dataSource = dataSource
+                    }
+                    routing {
+                        get("/pets") {
+                            call.respondText(repository<PetRepository>().findAll().size.toString())
+                        }
+                    }
+                }
+                client.get("/pets").status shouldBe HttpStatusCode.OK
+                TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasObservationWithNameEqualTo("storm.query")
+                    .that()
+                    .hasLowCardinalityKeyValue("storm.operation", "SELECT")
+                    .hasLowCardinalityKeyValue("storm.data_type", "Pet")
+                    // The primary database is tagged too: meters of one name must share a single set of
+                    // tag keys, or registries such as Prometheus drop the named databases' series.
+                    .hasLowCardinalityKeyValue("storm.database", "primary")
+                    .hasBeenStarted()
+                    .hasBeenStopped()
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `named database observations carry the database name`() {
+        val observationRegistry = TestObservationRegistry.create()
+        val clinicDataSource = createTestDataSource("storm-observed-clinic", "/schema.sql")
+        val vetsDataSource = createTestDataSource("storm-observed-vets", "/schema-vets.sql")
+        try {
+            testApplication {
+                application {
+                    dependencies {
+                        provide<ObservationRegistry> { observationRegistry }
+                    }
+                    install(Storm) {
+                        dataSource = clinicDataSource
+                        database("vets") {
+                            dataSource = vetsDataSource
+                            repositories("st.orm.ktor.vet")
+                        }
+                    }
+                    routing {
+                        get("/vets") {
+                            call.respondText(repository<VetRepository>("vets").findAll().size.toString())
+                        }
+                    }
+                }
+                client.get("/vets").status shouldBe HttpStatusCode.OK
+                TestObservationRegistryAssert.assertThat(observationRegistry)
+                    .hasObservationWithNameEqualTo("storm.query")
+                    .that()
+                    .hasLowCardinalityKeyValue("storm.database", "vets")
+            }
+        } finally {
+            clinicDataSource.close()
+            vetsDataSource.close()
+        }
+    }
+
+    @Test
+    fun `explicit queryObserver wins over the automatic binding`() {
+        val observationRegistry = TestObservationRegistry.create()
+        val observedExecutions = AtomicInteger()
+        val explicitObserver = QueryObserver { _ ->
+            observedExecutions.incrementAndGet()
+            QueryObserver.Observation.NOOP
+        }
+        val dataSource = createTestDataSource("storm-explicit-observer", "/schema.sql")
+        try {
+            testApplication {
+                application {
+                    dependencies {
+                        provide<ObservationRegistry> { observationRegistry }
+                    }
+                    install(Storm) {
+                        this.dataSource = dataSource
+                        queryObserver = explicitObserver
+                    }
+                    routing {
+                        get("/pets") {
+                            call.respondText(repository<PetRepository>().findAll().size.toString())
+                        }
+                    }
+                }
+                client.get("/pets").status shouldBe HttpStatusCode.OK
+                observedExecutions.get() shouldBeGreaterThan 0
+                TestObservationRegistryAssert.assertThat(observationRegistry).doesNotHaveAnyObservation()
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `queries run unobserved when no ObservationRegistry is registered`() {
+        val dataSource = createTestDataSource("storm-unobserved", "/schema.sql")
+        try {
+            testApplication {
+                application {
+                    install(Storm) {
+                        this.dataSource = dataSource
+                    }
+                    routing {
+                        get("/pets") {
+                            call.respondText(repository<PetRepository>().findAll().size.toString())
+                        }
+                    }
+                }
+                client.get("/pets").status shouldBe HttpStatusCode.OK
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+}

--- a/storm-micrometer/pom.xml
+++ b/storm-micrometer/pom.xml
@@ -1,0 +1,92 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>st.orm</groupId>
+        <artifactId>storm-framework</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>storm-micrometer</artifactId>
+    <name>Storm Micrometer</name>
+    <description>Micrometer Observation binding for Storm's query observer, providing metrics and tracing for query execution.</description>
+    <url>https://github.com/storm-repo/storm-framework</url>
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Leon van Zantvoort</name>
+            <email>zantvoort@orm.st</email>
+        </developer>
+    </developers>
+    <scm>
+        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-repo/storm-framework/</url>
+    </scm>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                    <argLine>
+                        @{argLine}
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>st.orm</groupId>
+            <artifactId>storm-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <!-- Test -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation-test</artifactId>
+            <version>${micrometer.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing</artifactId>
+            <version>${micrometer-tracing.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-test</artifactId>
+            <version>${micrometer-tracing.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/storm-micrometer/src/main/java/module-info.java
+++ b/storm-micrometer/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module storm.micrometer {
+    exports st.orm.micrometer;
+    requires storm.foundation;
+    requires storm.core;
+    requires micrometer.observation;
+    requires micrometer.commons;
+    requires jakarta.annotation;
+}

--- a/storm-micrometer/src/main/java/st/orm/micrometer/MicrometerQueryObserver.java
+++ b/storm-micrometer/src/main/java/st/orm/micrometer/MicrometerQueryObserver.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.micrometer;
+
+import static java.util.Objects.requireNonNull;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.ObservationRegistry;
+import jakarta.annotation.Nonnull;
+import st.orm.core.spi.QueryContext;
+import st.orm.core.spi.QueryObserver;
+
+/**
+ * {@link QueryObserver} that reports Storm query executions as Micrometer
+ * {@link io.micrometer.observation.Observation}s.
+ *
+ * <p>Configure it on the template builder, or let an integration wire it: the Ktor plugin binds this observer
+ * automatically when an {@link ObservationRegistry} is available through the application's dependency injection.
+ * Depending on the handlers attached to the registry, each query execution produces timing metrics, tracing spans,
+ * or both. Spans nest under the current trace context, so with context propagation in place (for example the
+ * OpenTelemetry agent) Storm queries appear under the active request span.</p>
+ *
+ * <p>Naming and key values come from the {@link StormQueryObservationConvention} by default; supply a custom
+ * {@link ObservationConvention} to override. Extra low-cardinality key values, such as the database name in a
+ * multi-database setup, are appended to every observation.</p>
+ *
+ * @since 1.13
+ */
+public class MicrometerQueryObserver implements QueryObserver {
+
+    private final ObservationRegistry observationRegistry;
+    private final ObservationConvention<StormQueryObservationContext> convention;
+    private final KeyValues extraLowCardinalityKeyValues;
+
+    /**
+     * Creates an observer reporting to the given registry with the default convention.
+     *
+     * @param observationRegistry the registry to report observations to.
+     */
+    public MicrometerQueryObserver(@Nonnull ObservationRegistry observationRegistry) {
+        this(observationRegistry, KeyValues.empty());
+    }
+
+    /**
+     * Creates an observer reporting to the given registry with the default convention and extra low-cardinality
+     * key values appended to every observation.
+     *
+     * @param observationRegistry the registry to report observations to.
+     * @param extraLowCardinalityKeyValues extra key values, such as {@code storm.database} in a multi-database
+     *                                     setup.
+     */
+    public MicrometerQueryObserver(@Nonnull ObservationRegistry observationRegistry,
+                                   @Nonnull KeyValues extraLowCardinalityKeyValues) {
+        this(observationRegistry, new StormQueryObservationConvention(), extraLowCardinalityKeyValues);
+    }
+
+    /**
+     * Creates an observer reporting to the given registry with a custom convention.
+     *
+     * @param observationRegistry the registry to report observations to.
+     * @param convention the convention that names the observations and derives their key values.
+     * @param extraLowCardinalityKeyValues extra key values, exposed to the convention via
+     *                                     {@link StormQueryObservationContext#extraLowCardinalityKeyValues()}.
+     */
+    public MicrometerQueryObserver(@Nonnull ObservationRegistry observationRegistry,
+                                   @Nonnull ObservationConvention<StormQueryObservationContext> convention,
+                                   @Nonnull KeyValues extraLowCardinalityKeyValues) {
+        this.observationRegistry = requireNonNull(observationRegistry, "observationRegistry");
+        this.convention = requireNonNull(convention, "convention");
+        this.extraLowCardinalityKeyValues = requireNonNull(extraLowCardinalityKeyValues, "extraLowCardinalityKeyValues");
+    }
+
+    @Override
+    public Observation onExecute(@Nonnull QueryContext context) {
+        var observationContext = new StormQueryObservationContext(context, extraLowCardinalityKeyValues);
+        var observation = io.micrometer.observation.Observation
+                .createNotStarted(convention, () -> observationContext, observationRegistry)
+                .start();
+        return new Observation() {
+            @Override
+            public void error(@Nonnull Throwable throwable) {
+                observation.error(throwable);
+            }
+
+            @Override
+            public void close() {
+                observation.stop();
+            }
+        };
+    }
+}

--- a/storm-micrometer/src/main/java/st/orm/micrometer/StormQueryObservationContext.java
+++ b/storm-micrometer/src/main/java/st/orm/micrometer/StormQueryObservationContext.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.micrometer;
+
+import static java.util.Objects.requireNonNull;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import jakarta.annotation.Nonnull;
+import st.orm.core.spi.QueryContext;
+
+/**
+ * {@link Observation.Context} for a Storm query execution.
+ *
+ * <p>Carries the {@link QueryContext} of the observed execution, so custom
+ * {@link io.micrometer.observation.ObservationConvention}s and
+ * {@link io.micrometer.observation.ObservationHandler}s can derive their own names, key values or attributes from
+ * the full execution context.</p>
+ *
+ * @since 1.13
+ */
+public class StormQueryObservationContext extends Observation.Context {
+
+    private final QueryContext queryContext;
+    private final KeyValues extraLowCardinalityKeyValues;
+
+    public StormQueryObservationContext(@Nonnull QueryContext queryContext,
+                                        @Nonnull KeyValues extraLowCardinalityKeyValues) {
+        this.queryContext = requireNonNull(queryContext, "queryContext");
+        this.extraLowCardinalityKeyValues = requireNonNull(extraLowCardinalityKeyValues, "extraLowCardinalityKeyValues");
+    }
+
+    /**
+     * Returns the query execution context being observed.
+     *
+     * @return the query context; never {@code null}.
+     */
+    public QueryContext queryContext() {
+        return queryContext;
+    }
+
+    /**
+     * Returns the additional low-cardinality key values configured on the observer, such as the database name of a
+     * multi-database setup.
+     *
+     * @return the extra low-cardinality key values; never {@code null}.
+     */
+    public KeyValues extraLowCardinalityKeyValues() {
+        return extraLowCardinalityKeyValues;
+    }
+}

--- a/storm-micrometer/src/main/java/st/orm/micrometer/StormQueryObservationConvention.java
+++ b/storm-micrometer/src/main/java/st/orm/micrometer/StormQueryObservationConvention.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.micrometer;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import jakarta.annotation.Nonnull;
+import java.util.Locale;
+
+/**
+ * Default {@link ObservationConvention} for Storm query observations.
+ *
+ * <p>Observations are named {@code storm.query} with a contextual name of the form {@code "select pet"}. The
+ * contextual name doubles as the span name and is all lowercase, since tracing handlers rewrite capitalized
+ * names into hyphenated form. The low-cardinality key values are suitable as metric tags:</p>
+ *
+ * <ul>
+ *   <li>{@code storm.operation} — {@code SELECT}, {@code INSERT}, {@code UPDATE}, {@code DELETE} or
+ *   {@code UNDEFINED}</li>
+ *   <li>{@code storm.execution} — {@code QUERY}, {@code UPDATE} or {@code BATCH}</li>
+ *   <li>{@code storm.data_type} — the simple name of the targeted entity or projection, or {@code none}</li>
+ * </ul>
+ *
+ * <p>The SQL statement is exposed as the high-cardinality key value {@code db.statement}; tracing handlers turn it
+ * into a span attribute, and it is never used as a metric tag.</p>
+ *
+ * <p>Extend this class or supply your own {@link ObservationConvention} to the
+ * {@link MicrometerQueryObserver} to customize naming and key values.</p>
+ *
+ * @since 1.13
+ */
+public class StormQueryObservationConvention implements ObservationConvention<StormQueryObservationContext> {
+
+    /**
+     * The observation name for Storm query executions.
+     */
+    public static final String OBSERVATION_NAME = "storm.query";
+
+    @Override
+    public boolean supportsContext(@Nonnull Observation.Context context) {
+        return context instanceof StormQueryObservationContext;
+    }
+
+    @Override
+    public String getName() {
+        return OBSERVATION_NAME;
+    }
+
+    @Override
+    public String getContextualName(@Nonnull StormQueryObservationContext context) {
+        var queryContext = context.queryContext();
+        var dataType = queryContext.dataType().map(Class::getSimpleName).orElse("query");
+        // All lowercase: tracing handlers use the contextual name as the span name and rewrite capitalized
+        // names into hyphenated form ("SELECT Pet" would surface as "s-e-l-e-c-t -pet").
+        return (queryContext.operation().name() + " " + dataType).toLowerCase(Locale.ROOT);
+    }
+
+    @Override
+    public KeyValues getLowCardinalityKeyValues(@Nonnull StormQueryObservationContext context) {
+        var queryContext = context.queryContext();
+        return KeyValues.of(
+                        "storm.operation", queryContext.operation().name(),
+                        "storm.execution", queryContext.kind().name(),
+                        "storm.data_type", queryContext.dataType().map(Class::getSimpleName).orElse("none"))
+                .and(context.extraLowCardinalityKeyValues());
+    }
+
+    @Override
+    public KeyValues getHighCardinalityKeyValues(@Nonnull StormQueryObservationContext context) {
+        return context.queryContext().statement()
+                .map(statement -> KeyValues.of("db.statement", statement))
+                .orElseGet(KeyValues::empty);
+    }
+}

--- a/storm-micrometer/src/test/java/st/orm/micrometer/MicrometerQueryObserverTest.java
+++ b/storm-micrometer/src/test/java/st/orm/micrometer/MicrometerQueryObserverTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.micrometer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static st.orm.core.template.TemplateString.raw;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.OptionalInt;
+import org.junit.jupiter.api.Test;
+import st.orm.Data;
+import st.orm.Entity;
+import st.orm.PK;
+import st.orm.PersistenceException;
+import st.orm.core.spi.QueryContext;
+import st.orm.core.template.ORMTemplate;
+import st.orm.core.template.SqlOperation;
+
+/**
+ * Tests for {@link MicrometerQueryObserver}: observation lifecycle, naming and key values from the default
+ * convention, and end-to-end behavior on a live template.
+ */
+public class MicrometerQueryObserverTest {
+
+    record TestPet(Integer id) implements Entity<Integer> {
+    }
+
+    record City(@PK Integer id, String name) implements Entity<Integer> {
+    }
+
+    private record FakeQueryContext(SqlOperation operation,
+                                    Class<? extends Data> type,
+                                    ExecutionKind kind,
+                                    String sql) implements QueryContext {
+        @Override
+        public Optional<Class<? extends Data>> dataType() {
+            return Optional.ofNullable(type);
+        }
+
+        @Override
+        public OptionalInt batchSize() {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public Optional<String> statement() {
+            return Optional.ofNullable(sql);
+        }
+    }
+
+    @Test
+    public void observationCarriesConventionNameAndKeyValues() {
+        var registry = TestObservationRegistry.create();
+        var observer = new MicrometerQueryObserver(registry);
+        var observation = observer.onExecute(new FakeQueryContext(
+                SqlOperation.SELECT, TestPet.class, QueryContext.ExecutionKind.QUERY, "SELECT id FROM test_pet"));
+        observation.close();
+        TestObservationRegistryAssert.assertThat(registry)
+                .hasObservationWithNameEqualTo("storm.query")
+                .that()
+                .hasContextualNameEqualTo("select testpet")
+                .hasLowCardinalityKeyValue("storm.operation", "SELECT")
+                .hasLowCardinalityKeyValue("storm.execution", "QUERY")
+                .hasLowCardinalityKeyValue("storm.data_type", "TestPet")
+                .hasHighCardinalityKeyValue("db.statement", "SELECT id FROM test_pet")
+                .hasBeenStarted()
+                .hasBeenStopped();
+    }
+
+    @Test
+    public void extraKeyValuesAreAppended() {
+        var registry = TestObservationRegistry.create();
+        var observer = new MicrometerQueryObserver(registry, KeyValues.of("storm.database", "vets"));
+        observer.onExecute(new FakeQueryContext(
+                SqlOperation.UPDATE, null, QueryContext.ExecutionKind.UPDATE, "UPDATE vet SET x = 1")).close();
+        TestObservationRegistryAssert.assertThat(registry)
+                .hasObservationWithNameEqualTo("storm.query")
+                .that()
+                .hasLowCardinalityKeyValue("storm.database", "vets")
+                .hasLowCardinalityKeyValue("storm.data_type", "none");
+    }
+
+    @Test
+    public void errorIsRecordedOnTheObservation() {
+        var registry = TestObservationRegistry.create();
+        var observer = new MicrometerQueryObserver(registry);
+        var observation = observer.onExecute(new FakeQueryContext(
+                SqlOperation.SELECT, null, QueryContext.ExecutionKind.QUERY, "SELECT broken"));
+        var failure = new SQLException("Table not found");
+        observation.error(failure);
+        observation.close();
+        TestObservationRegistryAssert.assertThat(registry)
+                .hasObservationWithNameEqualTo("storm.query")
+                .that()
+                .hasError()
+                .hasBeenStopped();
+    }
+
+    @Test
+    public void observesQueriesOfALiveTemplate() throws SQLException {
+        var dataSource = new SimpleDataSource("jdbc:h2:mem:micrometerObserver-" + System.nanoTime() + ";DB_CLOSE_DELAY=-1");
+        try (var connection = dataSource.getConnection(); var statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE city (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255))");
+            statement.execute("INSERT INTO city (name) VALUES ('Sun Paririe'), ('Madison')");
+        }
+        var registry = TestObservationRegistry.create();
+        var orm = ORMTemplate.builder(dataSource)
+                .queryObserver(new MicrometerQueryObserver(registry))
+                .build();
+        var rows = orm.entity(City.class).findAll();
+        assertFalse(rows.isEmpty());
+        TestObservationRegistryAssert.assertThat(registry)
+                .hasObservationWithNameEqualTo("storm.query")
+                .that()
+                .hasContextualNameEqualTo("select city")
+                .hasLowCardinalityKeyValue("storm.data_type", "City")
+                .hasBeenStarted()
+                .hasBeenStopped();
+    }
+
+    @Test
+    public void failedQueryOfALiveTemplateRecordsAnError() throws SQLException {
+        var dataSource = new SimpleDataSource("jdbc:h2:mem:micrometerObserverError-" + System.nanoTime() + ";DB_CLOSE_DELAY=-1");
+        try (var connection = dataSource.getConnection(); var statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE city (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255))");
+        }
+        var registry = TestObservationRegistry.create();
+        var orm = ORMTemplate.builder(dataSource)
+                .queryObserver(new MicrometerQueryObserver(registry))
+                .build();
+        assertThrows(PersistenceException.class, () -> orm.query(raw("SELECT * FROM does_not_exist")).getResultList());
+        TestObservationRegistryAssert.assertThat(registry)
+                .hasObservationWithNameEqualTo("storm.query")
+                .that()
+                .hasError()
+                .hasBeenStopped();
+    }
+}

--- a/storm-micrometer/src/test/java/st/orm/micrometer/SimpleDataSource.java
+++ b/storm-micrometer/src/test/java/st/orm/micrometer/SimpleDataSource.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.micrometer;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+/**
+ * Minimal {@link DataSource} over {@link DriverManager}, avoiding vendor DataSource classes and their JNDI
+ * dependencies in tests.
+ */
+final class SimpleDataSource implements DataSource {
+
+    private final String url;
+
+    SimpleDataSource(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(url, "sa", "");
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return DriverManager.getConnection(url, username, password);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+        return null;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) {
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) {
+    }
+
+    @Override
+    public int getLoginTimeout() {
+        return 0;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        throw new SQLException("Not a wrapper.");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) {
+        return false;
+    }
+}

--- a/storm-micrometer/src/test/java/st/orm/micrometer/SpanNestingTest.java
+++ b/storm-micrometer/src/test/java/st/orm/micrometer/SpanNestingTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.micrometer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import java.util.Optional;
+import java.util.OptionalInt;
+import org.junit.jupiter.api.Test;
+import st.orm.Data;
+import st.orm.core.spi.QueryContext;
+import st.orm.core.template.SqlOperation;
+
+/**
+ * Verifies that Storm query observations become spans that nest under the enclosing observation, which is how they
+ * appear under a server request span when tracing handlers (micrometer-tracing or an OpenTelemetry bridge) are
+ * attached to the registry.
+ */
+public class SpanNestingTest {
+
+    private record FakeQueryContext(SqlOperation operation) implements QueryContext {
+        @Override
+        public Optional<Class<? extends Data>> dataType() {
+            return Optional.empty();
+        }
+
+        @Override
+        public ExecutionKind kind() {
+            return ExecutionKind.QUERY;
+        }
+
+        @Override
+        public OptionalInt batchSize() {
+            return OptionalInt.empty();
+        }
+
+        @Override
+        public Optional<String> statement() {
+            return Optional.of("SELECT 1");
+        }
+    }
+
+    @Test
+    public void querySpanNestsUnderTheEnclosingObservation() {
+        var tracer = new SimpleTracer();
+        var registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(new DefaultTracingObservationHandler(tracer));
+
+        var observer = new MicrometerQueryObserver(registry);
+        var serverObservation = Observation.start("http.server.request", registry);
+        try (var ignored = serverObservation.openScope()) {
+            observer.onExecute(new FakeQueryContext(SqlOperation.SELECT)).close();
+        } finally {
+            serverObservation.stop();
+        }
+
+        var spans = tracer.getSpans();
+        assertEquals(2, spans.size(), "Expected the server span and the Storm query span.");
+        var serverSpan = spans.stream()
+                .filter(span -> "http.server.request".equals(span.getName()))
+                .findFirst().orElseThrow();
+        var querySpan = spans.stream()
+                .filter(span -> !"http.server.request".equals(span.getName()))
+                .findFirst().orElseThrow();
+        assertNotNull(querySpan.getParentId(), "The query span must have a parent.");
+        assertEquals(serverSpan.getSpanId(), querySpan.getParentId(),
+                "The Storm query span must nest under the enclosing server span.");
+    }
+}


### PR DESCRIPTION
Adds query observability via Micrometer Observations: a new shared `storm-micrometer` module and an automatic, DI-driven binding in the Ktor plugin.

Fixes #207

## storm-micrometer (new module)

- `MicrometerQueryObserver` implements the `QueryObserver` SPI (#218) and reports every query execution as a Micrometer Observation named `storm.query`. Depending on the handlers attached to the registry, that yields timing metrics, tracing spans, or both; spans nest under the current trace context, so with context propagation in place (OpenTelemetry agent, micrometer-tracing) queries appear under the active request span.
- `StormQueryObservationConvention` (overridable) defines naming and key values. Low-cardinality: `storm.operation`, `storm.execution`, `storm.data_type`. High-cardinality: `db.statement`, so the SQL lands on spans but never on metric tags. Contextual names are lowercase (`select pet`) because tracing handlers use them as span names and rewrite capitalized names into hyphenated form.
- Extra low-cardinality key values can be appended per observer, used by the Ktor binding for the database tag.
- The module is shared by design: #203 reuses it for the Spring Boot auto-configuration.

## Ktor binding

- Register an `ObservationRegistry` in the dependency container and every query is observed; no plugin configuration needed. The plugin installs a delegating observer per database and binds it once the application has started (the registry may be provided by any module). Without a registry, observers stay no-op.
- Every observation carries `storm.database`: the database name, or `primary` for the primary database. The tag is always present because meters of one name must share a single set of tag keys; registries such as Prometheus drop series whose tag keys differ.
- An explicit `queryObserver` in the plugin configuration takes precedence over the automatic binding.
- Queries issued during installation (schema validation) run before binding and are unobserved; documented.

## storm-core: `Sql.dataType()`

The SPI previously reported a data type only for DML (`affectedType`), so all reads surfaced as `storm.data_type=none`. `Sql.dataType()` now derives the primary entity or projection type for SELECT statements from the select or from clause (first recorded type wins, so the outermost select takes precedence over subqueries, and `INSERT ... SELECT` keeps the inserted type). `affectedType` keeps its DML-only cache-invalidation semantics.

## Scope note

The `repository` tag mentioned in #203 is deferred: the SPI deliberately does not carry repository identity, and `storm.data_type` identifies the aggregate for repository operations.

## Verification

- storm-micrometer: 6 tests (convention naming/tags, extra key values, error path, live H2 end-to-end, span nesting under a parent observation via `SimpleTracer`).
- storm-ktor: 51 tests, including 4 new `StormObservabilityTest` cases (auto-binding, named-database tag, explicit observer precedence, no-registry no-op).
- Full reactor: 13,588 tests green.
- Output validated end-to-end with a Prometheus scrape and a span tree from a live demo run; that run surfaced the span-name mangling, the Prometheus label-set conflict, and the missing read attribution fixed in this PR.
