### PR TITLE
fix(ci): drop removed storm-ktor-koin from the javadoc aggregate exclusions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,7 +70,7 @@ jobs:
             -Dmaven.javadoc.failOnError=false \
             -DadditionalJOption=--enable-preview \
             -Ddoclint=none \
-            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-jackson3,!:storm-ktor,!:storm-ktor-test,!:storm-ktor-koin,!:storm-compiler-plugin-2.0,!:storm-compiler-plugin-2.1,!:storm-compiler-plugin-2.2,!:storm-compiler-plugin-2.3,!:storm-compiler-plugin-2.4,!:storm-metamodel-processor,!:storm-core,!:storm-test,!:storm-jackson2,!:storm-oracle,!:storm-mssqlserver,!:storm-postgresql,!:storm-mysql,!:storm-mariadb,!:storm-sqlite,!:storm-h2,!:storm-spring'
+            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-jackson3,!:storm-ktor,!:storm-ktor-test,!:storm-compiler-plugin-2.0,!:storm-compiler-plugin-2.1,!:storm-compiler-plugin-2.2,!:storm-compiler-plugin-2.3,!:storm-compiler-plugin-2.4,!:storm-metamodel-processor,!:storm-core,!:storm-test,!:storm-jackson2,!:storm-oracle,!:storm-mssqlserver,!:storm-postgresql,!:storm-mysql,!:storm-mariadb,!:storm-sqlite,!:storm-h2,!:storm-spring'
 
       - name: Copy Javadoc to website/static/api/java
         run: |


### PR DESCRIPTION
Every Deploy Documentation run on main has failed since #220 merged:

```
[ERROR] Could not find the selected project in the reactor: :storm-ktor-koin
```

The javadoc aggregate step excludes non-public modules via `-pl` project selectors, and Maven fails the build when a selected project does not exist. #220 removed the storm-ktor-koin module but the exclusion list still named it. This removes the stale selector; all other excluded modules still exist (the `storm-compiler-plugin-2.x` entries resolve through the nested `storm-compiler-plugin` reactor).

Note for #222: the new `storm-micrometer` module needs adding to this exclusion list (it is an integration, like storm-spring and storm-jackson2); that will go on the #222 branch after this merges, since the module does not exist on main yet.