### PR TITLE
feat(spring): translate SQL failures to the DataAccessException hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Framework integration points are now instance-scoped (#198), and the Ktor integr
 - `Sql.dataType()`: the primary entity or projection type of a statement, now also derived for SELECT statements from the selected or queried table, and reported to query observers as the statement's data type.
 - Java Spring applications gain the full programmatic-transaction bridge: `SpringTransactionTemplateProvider` constructed with the application's transaction managers runs Storm's `Transactions.transaction(...)` blocks through Spring's `PlatformTransactionManager`, joins active `@Transactional` transactions, and picks the manager matching each template's `DataSource` in multi-data-source applications. `SpringOrmTemplate.of(dataSource, transactionManagers)` is the canonical plain-Spring composition for Java.
 - Shared Spring Boot auto-configurations in storm-spring (`st.orm.spring.boot`): `StormTransactionAutoConfiguration` (Spring-aware provider beans), `StormValidationAutoConfiguration` (startup schema validation), and the `storm.*` configuration properties (`StormProperties`), used by both starters. Configuration keys are unchanged.
+- SQL failures raised by Storm translate to Spring's `DataAccessException` hierarchy in Spring applications: `SpringExceptionMapper` (storm-spring) translates on vendor error codes with `SQLException` subclass and SQL state fallback, auto-configured by both starters (`storm.exception-translation.enabled=false` to disable) and applied by the `SpringOrmTemplate.of` / `springOrmTemplate` compositions. Failures without a `SQLException` cause keep Storm's own exceptions.
 
 ### Changed
 
@@ -49,6 +50,7 @@ Framework integration points are now instance-scoped (#198), and the Ktor integr
 - The auto-configured `ORMTemplate` and startup schema validation condition on a single `DataSource` candidate: applications exposing several `DataSource` beans (one pool per domain) boot cleanly with the auto-configured template backing off, or binding to the `@Primary` pool when one is marked.
 - The repository AOP post-processor bean is renamed from `javaRepositoryProxyingPostProcessor`/`kotlinRepositoryProxyingPostProcessor` to `stormRepositoryProxyingPostProcessor`.
 - Java applications without a `PlatformTransactionManager` no longer get a Spring-bound `ConnectionProvider`: the template falls back to Storm's own JDBC transactions (previously connections were bound through `DataSourceUtils` unconditionally).
+- Spring Boot applications: SQL failures from Storm repositories and templates now surface as Spring `DataAccessException` subtypes instead of `PersistenceException` (translation is auto-configured; see Added). Catch blocks and rollback rules that reference `PersistenceException` for SQL failures need updating, or set `storm.exception-translation.enabled=false` to keep the previous behavior.
 
 ### Removed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,8 @@ storm:
     record-mode: fail
     schema-mode: fail
     strict: false
+  exception-translation:
+    enabled: true
 ```
 
 The Spring Boot Starter binds these properties and builds a `StormConfig` that is passed to the `ORMTemplate` factory. Values not set in YAML fall back to system properties and then to built-in defaults. See [Spring Integration](spring-integration.md#configuration-via-applicationyml) for details.

--- a/docs/spring-integration.md
+++ b/docs/spring-integration.md
@@ -464,7 +464,8 @@ The starter auto-configures:
 1. **`ORMTemplate` bean** created from the auto-configured `DataSource`, composed with the Spring-aware integration strategies below. If you define your own `ORMTemplate` bean, the auto-configured one backs off.
 2. **Repository scanning** via `AutoConfiguredRepositoryBeanFactoryPostProcessor`, which discovers repository interfaces in the `@SpringBootApplication` base package (and its sub-packages). If you define your own `RepositoryBeanFactoryPostProcessor` bean, the auto-configured one backs off.
 3. **Transaction integration** through Spring-aware `ConnectionProvider` and `TransactionTemplateProvider` beans, contributed when a `PlatformTransactionManager` is present and handed to the template it creates. Nothing is registered globally: each application context gets its own, correctly matched transaction integration. Define your own `ConnectionProvider` or `TransactionTemplateProvider` bean to override, and optionally contribute `ExceptionMapper` or `QueryObserver` beans, which are applied to the template the same way.
-4. **Configuration properties** bound from `storm.*` in `application.yml`/`application.properties`, passed to the `ORMTemplate` via `StormConfig`.
+4. **Exception translation** to Spring's `DataAccessException` hierarchy through an auto-configured `ExceptionMapper` bean. Disable with `storm.exception-translation.enabled=false`, or define your own `ExceptionMapper` bean to translate differently.
+5. **Configuration properties** bound from `storm.*` in `application.yml`/`application.properties`, passed to the `ORMTemplate` via `StormConfig`.
 
 ### Minimal Spring Boot Setup (with Starter)
 
@@ -507,6 +508,8 @@ storm:
     warnings-only: false
     schema-mode: fail
     strict: false
+  exception-translation:
+    enabled: true
 ```
 
 The `schema-mode` property controls startup schema validation: `fail` (default) blocks startup if any entity definitions do not match the database schema, `warn` logs mismatches without blocking startup, and `none` skips validation. The `strict` property controls whether warnings (type narrowing, nullability mismatches) are treated as errors. See the [Configuration](configuration.md#schema-validation) guide for details.
@@ -571,6 +574,27 @@ This gives you:
 - Automatic DataSource from Spring Boot
 - Transaction integration between Spring and Storm
 - Repository auto-discovery and injection
+
+## Exception Translation
+
+Spring code is written against the `DataAccessException` hierarchy: retry setups key on `TransientDataAccessException` for deadlocks and lock timeouts, rollback rules and catch blocks reference the Spring types, and Spring's other data access integrations all translate consistently. With the starter, Storm participates in that convention out of the box: SQL failures raised by Storm repositories and templates surface as Spring exceptions, translated from vendor error codes for the application's database product, with `SQLException` subclass and SQL state translation as fallback.
+
+```kotlin
+try {
+    userRepository.insert(user)
+} catch (exception: DuplicateKeyException) {
+    // Same exception type a JdbcClient or JPA repository would raise.
+}
+```
+
+Failures without a `SQLException` cause keep Storm's own semantics: `PersistenceException` and its subtypes, such as optimistic locking and result cardinality failures, pass through unchanged. The boundary is the database: what the database reports is translated, what Storm's own logic detects stays a Storm exception in every composition. Retry setups that should also retry optimistic lock failures list both types:
+
+```kotlin
+@Retryable(retryFor = [TransientDataAccessException::class, OptimisticLockException::class])
+fun updateStudy(study: Study) = transactionBlocking { studyRepository.update(study) }
+```
+
+Translation applies to the templates composed with it: the starter's auto-configured template, and templates created with `SpringOrmTemplate.of` (Java) or `springOrmTemplate` (Kotlin). Disable it with `storm.exception-translation.enabled=false`, define your own `ExceptionMapper` bean, or compose the template yourself with the builder and leave the mapper out.
 
 ## Multiple Data Sources
 

--- a/storm-kotlin-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/storm-kotlin-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -2,3 +2,4 @@ st.orm.spring.boot.autoconfigure.StormAutoConfiguration
 st.orm.spring.boot.autoconfigure.StormRepositoryAutoConfiguration
 st.orm.spring.boot.StormTransactionAutoConfiguration
 st.orm.spring.boot.StormValidationAutoConfiguration
+st.orm.spring.boot.StormExceptionTranslationAutoConfiguration

--- a/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.kt
+++ b/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.kt
@@ -15,6 +15,7 @@
  */
 package st.orm.spring.boot.autoconfigure
 
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -34,6 +35,7 @@ import st.orm.core.spi.ConnectionProvider
 import st.orm.core.spi.TransactionTemplateProvider
 import st.orm.spring.SpringConnectionProvider
 import st.orm.spring.SpringTransactionTemplateProvider
+import st.orm.spring.boot.StormExceptionTranslationAutoConfiguration
 import st.orm.spring.boot.StormProperties
 import st.orm.spring.boot.StormTransactionAutoConfiguration
 import st.orm.spring.boot.StormValidationAutoConfiguration
@@ -53,6 +55,7 @@ class StormAutoConfigurationTest {
                 StormRepositoryAutoConfiguration::class.java,
                 StormTransactionAutoConfiguration::class.java,
                 StormValidationAutoConfiguration::class.java,
+                StormExceptionTranslationAutoConfiguration::class.java,
             ),
         )
 
@@ -375,5 +378,27 @@ class StormAutoConfigurationTest {
                 override fun getRepositoryBasePackages(): Array<String> = arrayOf("com.example")
             }
         }
+    }
+
+    @Test
+    fun `exception mapper auto-configured by default and disabled by property`() {
+        contextRunner
+            .withPropertyValues(
+                "spring.datasource.url=jdbc:h2:mem:exceptionTestKt;DB_CLOSE_DELAY=-1",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+            )
+            .run { context ->
+                context.getBean(st.orm.core.spi.ExceptionMapper::class.java)
+                    .shouldBeInstanceOf<st.orm.spring.SpringExceptionMapper>()
+            }
+        contextRunner
+            .withPropertyValues(
+                "spring.datasource.url=jdbc:h2:mem:exceptionDisabledTestKt;DB_CLOSE_DELAY=-1",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+                "storm.exception-translation.enabled=false",
+            )
+            .run { context ->
+                context.getBeanNamesForType(st.orm.core.spi.ExceptionMapper::class.java).toList().shouldBeEmpty()
+            }
     }
 }

--- a/storm-kotlin-spring/src/main/kotlin/st/orm/spring/kotlin/SpringOrmTemplate.kt
+++ b/storm-kotlin-spring/src/main/kotlin/st/orm/spring/kotlin/SpringOrmTemplate.kt
@@ -19,6 +19,7 @@ import org.springframework.transaction.PlatformTransactionManager
 import st.orm.EntityCallback
 import st.orm.StormConfig
 import st.orm.spring.SpringConnectionProvider
+import st.orm.spring.SpringExceptionMapper
 import st.orm.spring.SpringTransactionTemplateProvider
 import st.orm.template.ORMTemplate
 import javax.sql.DataSource
@@ -50,5 +51,6 @@ fun springOrmTemplate(
     .config(config)
     .connectionProvider(SpringConnectionProvider())
     .transactionTemplateProvider(SpringTransactionTemplateProvider { transactionManagers() })
+    .exceptionMapper(SpringExceptionMapper(dataSource))
     .build()
     .withEntityCallbacks(entityCallbacks)

--- a/storm-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/storm-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -2,3 +2,4 @@ st.orm.spring.boot.autoconfigure.StormAutoConfiguration
 st.orm.spring.boot.autoconfigure.StormRepositoryAutoConfiguration
 st.orm.spring.boot.StormTransactionAutoConfiguration
 st.orm.spring.boot.StormValidationAutoConfiguration
+st.orm.spring.boot.StormExceptionTranslationAutoConfiguration

--- a/storm-spring-boot-starter/src/test/java/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.java
+++ b/storm-spring-boot-starter/src/test/java/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import st.orm.EntityCallback;
 import st.orm.spring.RepositoryBeanFactoryPostProcessor;
+import st.orm.spring.boot.StormExceptionTranslationAutoConfiguration;
 import st.orm.spring.boot.StormProperties;
 import st.orm.spring.boot.StormValidationAutoConfiguration;
 import st.orm.template.ORMTemplate;
@@ -41,7 +42,8 @@ class StormAutoConfigurationTest {
                     DataSourceAutoConfiguration.class,
                     StormAutoConfiguration.class,
                     StormRepositoryAutoConfiguration.class,
-                    StormValidationAutoConfiguration.class
+                    StormValidationAutoConfiguration.class,
+                    StormExceptionTranslationAutoConfiguration.class
             ));
 
     @Test
@@ -440,6 +442,76 @@ class StormAutoConfigurationTest {
         @org.springframework.context.annotation.Primary
         public DataSource primaryDataSource() {
             return h2("multids");
+        }
+    }
+
+    @Test
+    void exceptionMapperAutoConfiguredByDefault() {
+        // SQL failures translate to Spring's DataAccessException hierarchy out of the box.
+        contextRunner
+                .withPropertyValues(
+                        "spring.datasource.url=jdbc:h2:mem:exceptionTest;DB_CLOSE_DELAY=-1",
+                        "spring.datasource.driver-class-name=org.h2.Driver"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(st.orm.core.spi.ExceptionMapper.class);
+                    assertThat(context).getBean(st.orm.core.spi.ExceptionMapper.class)
+                            .isInstanceOf(st.orm.spring.SpringExceptionMapper.class);
+                });
+    }
+
+    @Test
+    void exceptionTranslationCanBeDisabledByProperty() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.datasource.url=jdbc:h2:mem:exceptionDisabledTest;DB_CLOSE_DELAY=-1",
+                        "spring.datasource.driver-class-name=org.h2.Driver",
+                        "storm.exception-translation.enabled=false"
+                )
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(st.orm.core.spi.ExceptionMapper.class);
+                });
+    }
+
+    @Test
+    void userDefinedExceptionMapperTakesPrecedence() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.datasource.url=jdbc:h2:mem:exceptionCustomTest;DB_CLOSE_DELAY=-1",
+                        "spring.datasource.driver-class-name=org.h2.Driver"
+                )
+                .withUserConfiguration(CustomExceptionMapperConfig.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(st.orm.core.spi.ExceptionMapper.class);
+                    assertThat(context).getBean(st.orm.core.spi.ExceptionMapper.class)
+                            .isSameAs(context.getBean("customExceptionMapper"));
+                });
+    }
+
+    @Test
+    void autoConfiguredTemplateThrowsSpringExceptions() {
+        // The mapper bean must actually reach the auto-configured template: a duplicate key raised through
+        // the template surfaces as Spring's DuplicateKeyException, not Storm's PersistenceException.
+        contextRunner
+                .withPropertyValues(
+                        "spring.datasource.url=jdbc:h2:mem:exceptionEndToEndTest;DB_CLOSE_DELAY=-1",
+                        "spring.datasource.driver-class-name=org.h2.Driver"
+                )
+                .run(context -> {
+                    ORMTemplate orm = context.getBean(ORMTemplate.class);
+                    orm.query("CREATE TABLE dup_check (id INT PRIMARY KEY)").executeUpdate();
+                    orm.query("INSERT INTO dup_check VALUES (1)").executeUpdate();
+                    org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                                    orm.query("INSERT INTO dup_check VALUES (1)").executeUpdate())
+                            .isInstanceOf(org.springframework.dao.DuplicateKeyException.class);
+                });
+    }
+
+    @Configuration
+    static class CustomExceptionMapperConfig {
+        @Bean
+        public st.orm.core.spi.ExceptionMapper customExceptionMapper() {
+            return st.orm.core.spi.ExceptionMapper.defaultMapper();
         }
     }
 

--- a/storm-spring/src/main/java/st/orm/spring/SpringExceptionMapper.java
+++ b/storm-spring/src/main/java/st/orm/spring/SpringExceptionMapper.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.UncategorizedSQLException;
+import org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator;
+import org.springframework.jdbc.support.SQLExceptionSubclassTranslator;
+import org.springframework.jdbc.support.SQLExceptionTranslator;
+import st.orm.PersistenceException;
+import st.orm.core.spi.ExceptionContext;
+import st.orm.core.spi.ExceptionMapper;
+
+/**
+ * Exception mapper that translates SQL failures to Spring's {@link DataAccessException} hierarchy.
+ *
+ * <p>When the failure carries a {@link SQLException}, it is translated with Spring's
+ * {@link SQLExceptionTranslator}: vendor error codes when the data source is known, falling back to
+ * {@code SQLException} subclass and SQL state translation. This gives Storm repositories the same exception
+ * semantics as Spring's other data access integrations: deadlocks and lock timeouts surface as
+ * {@code TransientDataAccessException} subtypes (enabling retry setups), constraint violations as
+ * {@code DataIntegrityViolationException} subtypes, and so on.</p>
+ *
+ * <p>Failures without a {@code SQLException} in their cause chain keep Storm's own semantics:
+ * {@link PersistenceException} and its subtypes (such as optimistic locking and result cardinality failures)
+ * pass through unchanged.</p>
+ *
+ * <p>The Spring Boot starters apply this mapper automatically to the template they auto-configure; disable with
+ * {@code storm.exception-translation.enabled=false} or by defining your own {@code ExceptionMapper} bean.</p>
+ *
+ * @since 1.13
+ */
+public class SpringExceptionMapper implements ExceptionMapper {
+
+    private final SQLExceptionTranslator translator;
+
+    /**
+     * Creates a mapper that translates on {@code SQLException} subclass and SQL state alone.
+     */
+    public SpringExceptionMapper() {
+        this.translator = new SQLExceptionSubclassTranslator();
+    }
+
+    /**
+     * Creates a mapper that also translates vendor error codes for the database product of the given data source.
+     *
+     * @param dataSource the data source used to determine the database product for error-code translation.
+     */
+    public SpringExceptionMapper(@Nonnull DataSource dataSource) {
+        this.translator = new SQLErrorCodeSQLExceptionTranslator(dataSource);
+    }
+
+    @Override
+    public RuntimeException map(@Nonnull Throwable cause, @Nonnull ExceptionContext context) {
+        SQLException sqlException = findSqlException(cause);
+        if (sqlException == null) {
+            return cause instanceof PersistenceException persistenceException
+                    ? persistenceException
+                    : new PersistenceException(cause);
+        }
+        String task = "Storm " + context.operation()
+                + context.dataType().map(type -> " for " + type.getSimpleName()).orElse("");
+        String sql = context.statement().orElse(null);
+        DataAccessException translated = translator.translate(task, sql, sqlException);
+        if (translated == null) {
+            translated = new UncategorizedSQLException(task, sql, sqlException);
+        }
+        // The translated exception keeps the SQLException as its cause, but drops any wrapper between the
+        // reported failure and the SQLException. The framework attaches SQL diagnostics as suppressed
+        // exceptions to the reported failure, so carry the suppressed exceptions of the dropped wrappers over.
+        for (Throwable wrapper = cause; wrapper != null && wrapper != sqlException; wrapper = wrapper.getCause()) {
+            for (Throwable suppressed : wrapper.getSuppressed()) {
+                translated.addSuppressed(suppressed);
+            }
+        }
+        return translated;
+    }
+
+    private static @Nullable SQLException findSqlException(@Nonnull Throwable cause) {
+        for (Throwable current = cause; current != null; current = current.getCause()) {
+            if (current instanceof SQLException sqlException) {
+                return sqlException;
+            }
+        }
+        return null;
+    }
+}

--- a/storm-spring/src/main/java/st/orm/spring/SpringOrmTemplate.java
+++ b/storm-spring/src/main/java/st/orm/spring/SpringOrmTemplate.java
@@ -70,6 +70,7 @@ public final class SpringOrmTemplate {
                 .config(config)
                 .connectionProvider(new SpringConnectionProvider())
                 .transactionTemplateProvider(new SpringTransactionTemplateProvider(transactionManagers))
+                .exceptionMapper(new SpringExceptionMapper(dataSource))
                 .build()
                 .withEntityCallbacks(entityCallbacks);
     }

--- a/storm-spring/src/main/java/st/orm/spring/boot/StormExceptionTranslationAutoConfiguration.java
+++ b/storm-spring/src/main/java/st/orm/spring/boot/StormExceptionTranslationAutoConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring.boot;
+
+import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
+import org.springframework.context.annotation.Bean;
+import st.orm.core.spi.ExceptionMapper;
+import st.orm.spring.SpringExceptionMapper;
+
+/**
+ * Auto-configuration that translates SQL failures raised by Storm to Spring's {@code DataAccessException}
+ * hierarchy. Shared by the Java and Kotlin Spring Boot starters.
+ *
+ * <p>The exception mapper is handed to the {@code ORMTemplate} created by the starter's auto-configuration.
+ * Disable with {@code storm.exception-translation.enabled=false}, or define your own {@link ExceptionMapper}
+ * bean to translate differently.</p>
+ *
+ * @since 1.13
+ */
+@AutoConfiguration
+@ConditionalOnSingleCandidate(DataSource.class)
+@ConditionalOnProperty(name = "storm.exception-translation.enabled", havingValue = "true", matchIfMissing = true)
+public class StormExceptionTranslationAutoConfiguration {
+
+    /**
+     * Provides the exception mapper that translates SQL failures to Spring's {@code DataAccessException}
+     * hierarchy, using vendor error codes for the database product of the application's data source.
+     */
+    @Bean
+    @ConditionalOnMissingBean(ExceptionMapper.class)
+    public ExceptionMapper stormExceptionMapper(DataSource dataSource) {
+        return new SpringExceptionMapper(dataSource);
+    }
+}

--- a/storm-spring/src/main/java/st/orm/spring/boot/StormProperties.java
+++ b/storm-spring/src/main/java/st/orm/spring/boot/StormProperties.java
@@ -54,6 +54,9 @@ public class StormProperties {
     /** Validation configuration. */
     private Validation validation = new Validation();
 
+    /** Exception translation configuration. */
+    private ExceptionTranslation exceptionTranslation = new ExceptionTranslation();
+
     /** Whether to enable ANSI escape sequences in Storm's log output. */
     private Boolean ansiEscaping;
 
@@ -77,6 +80,12 @@ public class StormProperties {
 
     /** Returns the validation configuration. */
     public Validation getValidation() { return validation; }
+
+    /** Returns the exception translation configuration. */
+    public ExceptionTranslation getExceptionTranslation() { return exceptionTranslation; }
+
+    /** Sets the exception translation configuration. */
+    public void setExceptionTranslation(ExceptionTranslation exceptionTranslation) { this.exceptionTranslation = exceptionTranslation; }
 
     /** Sets the validation configuration. */
     public void setValidation(Validation validation) { this.validation = validation; }
@@ -214,6 +223,19 @@ public class StormProperties {
      *
      * @since 1.13
      */
+    /** Exception translation configuration. */
+    public static class ExceptionTranslation {
+
+        /** Whether SQL failures are translated to Spring's DataAccessException hierarchy. Defaults to true. */
+        private Boolean enabled;
+
+        /** Returns whether exception translation is enabled. */
+        public Boolean getEnabled() { return enabled; }
+
+        /** Sets whether exception translation is enabled. */
+        public void setEnabled(Boolean enabled) { this.enabled = enabled; }
+    }
+
     public StormConfig toStormConfig() {
         Map<String, String> map = new HashMap<>();
         if (update.getDefaultMode() != null) {

--- a/storm-spring/src/test/java/st/orm/spring/SpringExceptionMapperTest.java
+++ b/storm-spring/src/test/java/st/orm/spring/SpringExceptionMapperTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import st.orm.PersistenceException;
+import st.orm.core.spi.ExceptionContext;
+import st.orm.spring.model.PetType;
+import st.orm.template.ORMTemplate;
+
+/**
+ * Verifies that {@link SpringExceptionMapper} translates SQL failures to Spring's
+ * {@link DataAccessException} hierarchy while leaving Storm's own exceptions untouched.
+ */
+class SpringExceptionMapperTest {
+
+    private DataSource dataSource;
+
+    @BeforeEach
+    void setUp() {
+        dataSource = DataSourceBuilder.create()
+                .url("jdbc:h2:mem:exceptionmappertest;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false")
+                .username("sa")
+                .password("")
+                .driverClassName("org.h2.Driver")
+                .build();
+        new ResourceDatabasePopulator(new ClassPathResource("data.sql")).execute(dataSource);
+    }
+
+    @Test
+    void duplicateKeyTranslatesToDataAccessException() {
+        ORMTemplate orm = ORMTemplate.builder(dataSource)
+                .exceptionMapper(new SpringExceptionMapper(dataSource))
+                .build();
+        // Pet type 1 exists in the test data; inserting it again violates the primary key.
+        assertThrows(DuplicateKeyException.class, () ->
+                orm.entity(PetType.class).insert(new PetType(1, "duplicate")));
+    }
+
+    @Test
+    void duplicateKeyTranslatesThroughSpringComposedTemplate() {
+        // The canonical Spring composition applies the mapper automatically.
+        ORMTemplate orm = SpringOrmTemplate.of(dataSource, () -> List.of(new DataSourceTransactionManager(dataSource)));
+        assertThrows(DuplicateKeyException.class, () ->
+                orm.entity(PetType.class).insert(new PetType(1, "duplicate")));
+    }
+
+    @Test
+    void subclassTranslationWorksWithoutDataSource() {
+        ORMTemplate orm = ORMTemplate.builder(dataSource)
+                .exceptionMapper(new SpringExceptionMapper())
+                .build();
+        assertThrows(DataAccessException.class, () ->
+                orm.entity(PetType.class).insert(new PetType(1, "duplicate")));
+    }
+
+    @Test
+    void withoutTheMapperStormThrowsPersistenceException() {
+        ORMTemplate orm = ORMTemplate.builder(dataSource).build();
+        assertThrows(PersistenceException.class, () ->
+                orm.entity(PetType.class).insert(new PetType(1, "duplicate")));
+    }
+
+    @Test
+    void failuresWithoutSqlExceptionPassThroughUnchanged() {
+        SpringExceptionMapper mapper = new SpringExceptionMapper(dataSource);
+        PersistenceException storm = new PersistenceException("model constraint violated");
+        assertSame(storm, mapper.map(storm, emptyContext()));
+        assertInstanceOf(PersistenceException.class, mapper.map(new IllegalStateException("no sql"), emptyContext()));
+    }
+
+    @Test
+    void suppressedDiagnosticsSurviveTranslationOfWrappedFailures() {
+        SpringExceptionMapper mapper = new SpringExceptionMapper(dataSource);
+        // The framework attaches SQL diagnostics as a suppressed exception on the reported failure, which
+        // may wrap the SQLException. Translation drops the wrapper but must keep its suppressed exceptions.
+        java.sql.SQLException sqlException = new java.sql.SQLException("Unique index violation", "23505", 23505);
+        PersistenceException wrapper = new PersistenceException(sqlException);
+        RuntimeException diagnostics = new RuntimeException("SQL:\nINSERT INTO pet_type ...");
+        wrapper.addSuppressed(diagnostics);
+        RuntimeException translated = mapper.map(wrapper, emptyContext());
+        assertInstanceOf(DataAccessException.class, translated);
+        org.assertj.core.api.Assertions.assertThat(translated.getSuppressed()).contains(diagnostics);
+    }
+
+    @Test
+    void transientSqlFailuresTranslateToTransientDataAccessException() {
+        // Deadlocks and lock timeouts must land in the transient branch of the hierarchy: that is what
+        // retry setups key on, and the reason the translation exists.
+        SpringExceptionMapper mapper = new SpringExceptionMapper();
+        RuntimeException translated = mapper.map(
+                new java.sql.SQLTransactionRollbackException("Deadlock found when trying to get lock", "40001", 1213),
+                emptyContext());
+        assertInstanceOf(org.springframework.dao.TransientDataAccessException.class, translated);
+    }
+
+    private static ExceptionContext emptyContext() {
+        return new ExceptionContext() {
+            @Override
+            public st.orm.core.template.SqlOperation operation() {
+                return st.orm.core.template.SqlOperation.UNDEFINED;
+            }
+
+            @Override
+            public java.util.Optional<String> statement() {
+                return java.util.Optional.empty();
+            }
+
+            @Override
+            public java.util.Optional<Class<? extends st.orm.Data>> dataType() {
+                return java.util.Optional.empty();
+            }
+
+            @Override
+            public java.util.Optional<String> transactionDescription() {
+                return java.util.Optional.empty();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Spring code is written against the `DataAccessException` hierarchy: retry setups key on `TransientDataAccessException` for deadlocks and lock timeouts, rollback rules and catch blocks reference the Spring types, and Spring's other data access integrations all translate consistently. Storm now participates in that convention.

Fixes #199

## What's included

- **`SpringExceptionMapper`** (storm-spring): implements the `ExceptionMapper` SPI (#218) on Spring's `SQLExceptionTranslator` — vendor error-code translation for the application's database product, with `SQLException`-subclass and SQL-state fallback; untranslatable SQL failures surface as `UncategorizedSQLException`. The `ExceptionContext` supplies the translator's task description (operation and affected type) and the SQL statement. Suppressed SQL diagnostics attached by the framework are carried over when translation drops a wrapper exception, so failure output keeps the statement and transaction description.
- **`StormExceptionTranslationAutoConfiguration`** (`st.orm.spring.boot`, shared by both starters): contributes the mapper bean, consumed by the starter's auto-configured `ORMTemplate`. Backs off to a user-defined `ExceptionMapper` bean; conditional on a single `DataSource` candidate; disable with `storm.exception-translation.enabled=false`.
- **Canonical compositions**: `SpringOrmTemplate.of` (Java) and `springOrmTemplate` (Kotlin) apply the mapper, matching the starter; composing with the builder directly opts out.

## Translation boundary

What the database reports is translated; what Storm's own logic detects stays a Storm exception in every composition: failures without a `SQLException` cause — optimistic locking, result cardinality, model constraints — pass through unchanged. The docs cover the boundary and show retry setups listing both exception families.

## Verification

- Full reactor green (13,682 tests).
- New `SpringExceptionMapperTest`: duplicate-key translation through a bare template and through the Spring composition, subclass-only translation without a DataSource, no-mapper baseline, non-SQL passthrough, and suppressed-diagnostics preservation across wrapper-dropping translation.
- Starter suites in both languages: mapper bean present by default, disabled via property, user-defined bean back-off. The unchanged kotlin-spring suite (252 tests) passes with the mapper active in `springOrmTemplate`.

Docs: new Exception Translation section in spring-integration.md, starter feature list, `storm.exception-translation.enabled` in both yaml examples; CHANGELOG entry with the semantics.