### PR TITLE
fix(website): strip tags to a fixed point in the copy-text helper

### DIFF
--- a/website/src/components/tutorial/tutorialTheme.js
+++ b/website/src/components/tutorial/tutorialTheme.js
@@ -70,8 +70,17 @@ export const DATABASE_VARIANTS = [
 export function editor({file, tag, code, sql, copy, variants}) {
   // The highlighted HTML is entirely esc()'d text inside spans, so dropping
   // the tags and unescaping recovers the source text exactly.
-  const toPlain = (html) =>
-    html.replace(/<[^>]+>/g, '').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+  const toPlain = (html) => {
+    // Strip tags to a fixed point before unescaping: a single pass is not idempotent, since removing an
+    // inner tag can splice two fragments into a fresh tag, so repeat until the markup stops changing.
+    let stripped = html;
+    let previous;
+    do {
+      previous = stripped;
+      stripped = stripped.replace(/<[^>]+>/g, '');
+    } while (stripped !== previous);
+    return stripped.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+  };
   // Newlines only occur in the escaped text tokens, never inside tag markup,
   // so the line count can be taken from the HTML string directly.
   const pane = (html) => {


### PR DESCRIPTION
Resolves code scanning alert #11 (`js/incomplete-multi-character-sanitization`, high).

The tutorial editor's `toPlain` helper stripped HTML tags with a single `replace(/<[^>]+>/g, '')` pass to derive the plain text for the Copy button. A single pass is not idempotent: removing an inner tag can splice two surrounding fragments into a fresh tag (for example `<scr<span></span>ipt>` collapses to `<script>`). The strip now repeats to a fixed point before unescaping, so no tag can survive reconstruction.

## Exploitability

Not an actual injection sink: the input is trusted, build-time syntax-highlight markup authored in the tutorial pages, and the result is `esc()`'d before it reaches the `data-copy` attribute and is only ever used as clipboard text, never inserted as HTML. The fix clears the alert and removes the non-idempotent sanitization pattern from a docs site that shouldn't model it.

## Verification

The new helper round-trips legitimate highlighted markup unchanged and fully strips the splice/nesting cases a single pass would leave behind (verified in isolation). Website source only; no `versioned_docs` touched.