### PR TITLE
Add grouped result terminals for one-to-many loading

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -540,6 +540,82 @@ List<City> cities = orm.entity(User.class)
 
 ---
 
+## Grouped Results
+
+Group results by a related record, typically the parent entity of a foreign key. The metamodel path names the
+group key; the result is a map from parent to its children:
+
+<Tabs groupId="language">
+<TabItem value="kotlin" label="Kotlin" default>
+
+```kotlin
+// Load cities with their users in one query
+val usersByCity: Map<City, List<User>> = orm.entity<User>()
+    .select()
+    .where(User_.active eq true)
+    .orderBy(User_.city)
+    .resultGroupedBy(User_.city)
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// Load cities with their users in one query
+Map<City, List<User>> usersByCity = orm.entity(User.class)
+    .select()
+    .where(User_.active, EQUALS, true)
+    .orderBy(User_.city)
+    .getResultGroupedBy(User_.city);
+```
+
+</TabItem>
+</Tabs>
+
+The SQL is not affected by the grouping: the same select is executed and the results are grouped during
+hydration, so the whole graph loads in a single query. Hydration does not pay for the duplication in the join
+result: repeated group records are materialized once and grouped by instance identity, not by comparing record
+fields. The returned map and its lists are unmodifiable and insertion-ordered; use `orderBy()` to control the
+order of groups and of results within each group. Because duplicate entities within a result set share the same
+instance, each result's reference to its group key is the map key itself.
+
+The where clause keeps its normal meaning: it filters the results, and a group appears only when at least one of
+its results matches. The path must resolve to a non-null record for every result; narrow queries over nullable
+foreign keys with a `where()` clause first. See [Relationships](relationships.md#one-to-many) for the
+one-to-many loading pattern.
+
+The ref-based variant `resultGroupedByRef` (Java: `getResultGroupedByRef`) returns `Map<Ref<V>, List<T>>`
+instead. Refs are compared by primary key, keeping map lookups constant-cost regardless of the size of the group
+record. For eagerly fetched entity paths the keys are loaded refs: `getOrNull()` returns the record the query
+already materialized, combining primary-key lookups with direct access to the data. The path may also reference
+a `Ref` field, in which case the group is taken directly from the foreign key without fetching the referenced
+record; such refs remain unloaded, and `findAllByRef(map.keys)` fetches them in a single query when needed:
+
+<Tabs groupId="language">
+<TabItem value="kotlin" label="Kotlin" default>
+
+```kotlin
+// Group visits by pet without fetching the pets
+val visitsByPet: Map<Ref<Pet>, List<Visit>> = orm.entity<Visit>()
+    .select()
+    .resultGroupedByRef(Visit_.pet)
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// Group visits by pet without fetching the pets
+Map<Ref<Pet>, List<Visit>> visitsByPet = orm.entity(Visit.class)
+    .select()
+    .getResultGroupedByRef(Visit_.pet);
+```
+
+</TabItem>
+</Tabs>
+
+---
+
 ## Streaming
 
 <Tabs groupId="language">

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -149,6 +149,17 @@ Storm does not store collections on the "one" side of a relationship. Instead, q
 val usersInCity: List<User> = orm.findAll(User_.city eq city)
 ```
 
+To load parents with their children, group the query by the parent path. The same select is executed; the
+results are grouped during hydration:
+
+```kotlin
+// Load cities with their users in one query
+val usersByCity: Map<City, List<User>> = orm.entity<User>()
+    .select()
+    .orderBy(User_.city)
+    .resultGroupedBy(User_.city)
+```
+
 </TabItem>
 <TabItem value="java" label="Java">
 
@@ -160,8 +171,27 @@ List<User> usersInCity = orm.entity(User.class)
     .getResultList();
 ```
 
+To load parents with their children, group the query by the parent path. The same select is executed; the
+results are grouped during hydration:
+
+```java
+// Load cities with their users in one query
+Map<City, List<User>> usersByCity = orm.entity(User.class)
+    .select()
+    .orderBy(User_.city)
+    .getResultGroupedBy(User_.city);
+```
+
 </TabItem>
 </Tabs>
+
+The grouped terminal returns an unmodifiable, insertion-ordered map: parents appear in the order
+their first row is encountered, children in row order within each parent. Because duplicate entities within a
+result set share the same instance, each child's reference to its parent is the map key itself, and repeated
+parents are materialized once rather than once per row. The path must resolve to a non-null record for every
+result; narrow queries over nullable foreign keys with a `where()` clause first. This replaces the manual
+pattern of querying the many side and grouping in memory, and it loads the whole graph in a single query,
+without the N+1 queries or the join duplication handling that collection-based ORMs need.
 
 ---
 
@@ -197,6 +227,13 @@ val roles: List<Role> = userRoles.map { it.role }
 // Find all users with a specific role
 val userRoles: List<UserRole> = orm.findAll(UserRole_.role eq role)
 val users: List<User> = userRoles.map { it.user }
+
+// Find roles for many users at once, grouped per user
+val rolesByUser: Map<User, List<Role>> = orm.entity<UserRole>()
+    .select()
+    .where(UserRole_.user inList users)
+    .resultGroupedBy(UserRole_.user)
+    .mapValues { (_, userRoles) -> userRoles.map { it.role } }
 ```
 
 For more control, use explicit join queries:
@@ -235,6 +272,12 @@ List<UserRole> userRoles = orm.entity(UserRole.class)
 List<Role> roles = userRoles.stream()
     .map(UserRole::role)
     .toList();
+
+// Find roles for many users at once, grouped per user
+Map<User, List<UserRole>> rolesByUser = orm.entity(UserRole.class)
+    .select()
+    .where(UserRole_.user, IN, users)
+    .getResultGroupedBy(UserRole_.user);
 ```
 
 For more control, use explicit join queries:

--- a/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
@@ -24,11 +24,19 @@ import static st.orm.core.template.TemplateString.wrap;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.RandomAccess;
+import java.util.SequencedMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import st.orm.Data;
+import st.orm.Entity;
 import st.orm.JoinType;
 import st.orm.Metamodel;
 import st.orm.NoResultException;
@@ -39,6 +47,7 @@ import st.orm.Pageable;
 import st.orm.PersistenceException;
 import st.orm.Ref;
 import st.orm.Scrollable;
+import st.orm.TypedMetamodel;
 import st.orm.Window;
 import st.orm.core.template.impl.Elements.ObjectExpression;
 
@@ -937,6 +946,183 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public final List<R> getResultList() {
         try (var stream = getResultStream()) {
             return stream.toList();
+        }
+    }
+
+    /**
+     * Executes the query and returns the results grouped by the record reached via {@code path}, typically the
+     * parent entity of a foreign key. The SQL is not affected by the grouping; the same select is executed and the
+     * results are grouped during hydration.
+     *
+     * <p>The returned map and its lists are unmodifiable and insertion-ordered: groups appear in the order their
+     * first result is encountered, and results appear in encounter order within each group. Use {@code orderBy()} to
+     * control both. Since duplicate entities within a result set share the same instance, each result's reference to
+     * its group key is the map key itself.</p>
+     *
+     * <p>This method requires an entity query: the result type must be the table type {@code T} so that the path can
+     * be resolved against the results. The path must also resolve to a non-null record for every result; paths over
+     * nullable foreign keys must be narrowed with a {@code where()} clause first.</p>
+     *
+     * <p>The signature requires a path whose component type equals its field type, which is how the generated
+     * metamodels type eagerly fetched fields. Paths over {@code Ref} fields are typed
+     * {@code TypedMetamodel<T, V, Ref<V>>} and therefore do not compile; use
+     * {@link #getResultGroupedByRef(Metamodel)} for those.</p>
+     *
+     * @param path the metamodel path from the table type to the record to group by, for example {@code Pet_.owner}.
+     * @param <V> the type of the record to group by.
+     * @return the results grouped by the record reached via {@code path}, in encounter order.
+     * @throws PersistenceException if the query fails, if the result type is not the table type, or if the path
+     *                              resolves to null for a result.
+     * @since 1.13
+     */
+    public final <V extends Data> SequencedMap<V, List<R>> getResultGroupedBy(@Nonnull TypedMetamodel<T, V, V> path) {
+        requireNonNull(path, "path");
+        try (var stream = getResultStream()) {
+            // Duplicate records within a result set share the same instance (query-scoped interning), so the per-row
+            // lookup can use reference identity instead of hashing every field of the group record. The identity map
+            // carries no order and no value semantics; both are restored during assembly below.
+            var groups = new IdentityHashMap<V, Group<R>>();
+            var order = new ArrayList<V>();
+            stream.forEach(element -> {
+                if (!path.root().isInstance(element)) {
+                    throw new PersistenceException(
+                            "Grouped results require an entity query rooted at %s, but got a result of type %s."
+                                    .formatted(path.root().getName(),
+                                            element == null ? "null" : element.getClass().getName()));
+                }
+                // Object intermediate on purpose: assigning the typed return directly would insert a checkcast to
+                // V's bound and fail with a bare ClassCastException for dynamically built ref paths, bypassing the
+                // descriptive backstop below.
+                //noinspection unchecked
+                Object value = path.getValue((T) element);
+                if (value == null) {
+                    throw new PersistenceException(
+                            "Cannot group by %s: the path resolved to null. Narrow the query with a where() clause to exclude results without a %s."
+                                    .formatted(path, path.fieldType().getSimpleName()));
+                }
+                if (value instanceof Ref<?>) {
+                    throw new PersistenceException(
+                            "Cannot group by %s: the path resolves to a ref because %s is mapped as a Ref field. Use getResultGroupedByRef() instead."
+                                    .formatted(path, path.fieldType().getSimpleName()));
+                }
+                //noinspection unchecked
+                V group = (V) value;
+                var elements = groups.get(group);
+                if (elements == null) {
+                    elements = new Group<>();
+                    groups.put(group, elements);
+                    order.add(group);
+                }
+                elements.elements.add(element);
+            });
+            // Assembly hashes each distinct group once; equal-by-value groups merge, so the result is correct even
+            // for records that were not interned. The group count is known here, so the map is allocated at its
+            // final size. The values are unmodifiable views over the lists built above, so no copy or re-wrapping
+            // is needed.
+            var result = LinkedHashMap.<V, List<R>>newLinkedHashMap(order.size());
+            for (V group : order) {
+                var elements = groups.get(group);
+                var existing = result.putIfAbsent(group, elements);
+                if (existing != null) {
+                    ((Group<R>) existing).elements.addAll(elements);
+                }
+            }
+            return Collections.unmodifiableSequencedMap(result);
+        }
+    }
+
+    /**
+     * Executes the query and returns the results grouped by a lightweight ref to the record reached via
+     * {@code path}, typically the parent entity of a foreign key. The SQL is not affected by the grouping; the same
+     * select is executed and the results are grouped during hydration.
+     *
+     * <p>This is the ref-based variant of {@link #getResultGroupedBy(TypedMetamodel)}: the map keys are {@link Ref}
+     * instances, which are compared by primary key, keeping map lookups constant-cost regardless of the size of the
+     * group record.</p>
+     *
+     * <p>The behavior of the keys follows how the foreign key is declared on the record:</p>
+     * <ul>
+     *   <li><strong>Entity field</strong> (for example {@code @FK Owner owner}): the referenced record is fetched
+     *       eagerly, as part of the query's auto-joined graph, and is materialized with each result. The keys are
+     *       <em>loaded</em> refs wrapping that record: {@link Ref#getOrNull()} returns it directly, without touching
+     *       the database.</li>
+     *   <li><strong>Ref field</strong> (for example {@code @FK Ref<Pet> pet}): the referenced record is fetched
+     *       lazily; the query reads only the foreign key column, without joining or fetching the referenced table.
+     *       The keys are the <em>unloaded</em> refs produced by the query, carrying just the primary key. When the
+     *       records are needed, fetch them afterwards in a single query with
+     *       {@code findAllByRef(map.keySet())}.</li>
+     * </ul>
+     *
+     * <p>The returned map and its lists are unmodifiable and insertion-ordered: groups appear in the order their
+     * first result is encountered, and results appear in encounter order within each group. Use {@code orderBy()} to
+     * control both.</p>
+     *
+     * <p>This method requires an entity query: the result type must be the table type {@code T} so that the path can
+     * be resolved against the results. The path must also resolve to a non-null value for every result; paths over
+     * nullable foreign keys must be narrowed with a {@code where()} clause first.</p>
+     *
+     * @param path the metamodel path from the table type to the record to group by, for example {@code Pet_.owner}.
+     * @param <V> the type of the record to group by.
+     * @return the results grouped by a ref to the record reached via {@code path}, in encounter order.
+     * @throws PersistenceException if the query fails, if the result type is not the table type, if the path does
+     *                              not reference an entity or ref, or if the path resolves to null for a result.
+     * @since 1.13
+     */
+    public final <V extends Data> SequencedMap<Ref<V>, List<R>> getResultGroupedByRef(@Nonnull Metamodel<T, V> path) {
+        requireNonNull(path, "path");
+        try (var stream = getResultStream()) {
+            // Refs hash and compare by primary key, so the grouping map is cheap without an identity-based fast path.
+            // The values are unmodifiable views appended through their backing lists, so no copy or re-wrapping is
+            // needed when the result is returned.
+            var groups = new LinkedHashMap<Ref<V>, List<R>>();
+            stream.forEach(element -> {
+                if (!path.root().isInstance(element)) {
+                    throw new PersistenceException(
+                            "Grouped results require an entity query rooted at %s, but got a result of type %s."
+                                    .formatted(path.root().getName(),
+                                            element == null ? "null" : element.getClass().getName()));
+                }
+                //noinspection unchecked
+                Object value = path.getValue((T) element);
+                if (value == null) {
+                    throw new PersistenceException(
+                            "Cannot group by %s: the path resolved to null. Narrow the query with a where() clause to exclude results without a %s."
+                                    .formatted(path, path.fieldType().getSimpleName()));
+                }
+                Ref<V> group;
+                if (value instanceof Ref<?> ref) {
+                    //noinspection unchecked
+                    group = (Ref<V>) ref;
+                } else if (value instanceof Entity<?> entity) {
+                    //noinspection unchecked
+                    group = (Ref<V>) Ref.of(entity);
+                } else {
+                    throw new PersistenceException(
+                            "Cannot group by ref at %s: the path must reference an entity or a ref, but resolved to %s."
+                                    .formatted(path, value.getClass().getName()));
+                }
+                ((Group<R>) groups.computeIfAbsent(group, ignore -> new Group<>())).elements.add(element);
+            });
+            return Collections.unmodifiableSequencedMap(groups);
+        }
+    }
+
+    /**
+     * Unmodifiable list view over a group's elements. The grouping terminals append through {@link #elements} while
+     * building, so the map values are unmodifiable from the start and require no copy or re-wrapping when the result
+     * is returned.
+     */
+    private static final class Group<R> extends AbstractList<R> implements RandomAccess {
+        final ArrayList<R> elements = new ArrayList<>();
+
+        @Override
+        public R get(int index) {
+            return elements.get(index);
+        }
+
+        @Override
+        public int size() {
+            return elements.size();
         }
     }
 

--- a/storm-core/src/test/java/st/orm/core/QueryBuilderPredicateIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/QueryBuilderPredicateIntegrationTest.java
@@ -3,11 +3,13 @@ package st.orm.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static st.orm.Operator.EQUALS;
 import static st.orm.Operator.GREATER_THAN;
 import static st.orm.Operator.IN;
+import static st.orm.Operator.LESS_THAN;
 import static st.orm.core.template.TemplateString.raw;
 
 import java.util.List;
@@ -21,10 +23,13 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import st.orm.PersistenceException;
 import st.orm.Ref;
 import st.orm.Scrollable;
+import st.orm.TypedMetamodel;
 import st.orm.core.model.City;
 import st.orm.core.model.City_;
 import st.orm.core.model.Owner;
 import st.orm.core.model.Pet;
+import st.orm.core.model.PetOwnerRef;
+import st.orm.core.model.PetOwnerRef_;
 import st.orm.core.model.Pet_;
 import st.orm.core.model.Visit;
 import st.orm.core.model.Visit_;
@@ -542,5 +547,90 @@ public class QueryBuilderPredicateIntegrationTest {
                 .whereAny(predicate -> predicate.whereId(1).or(predicate.whereId(2)))
                 .getResultList();
         assertEquals(2, visits.size());
+    }
+
+    // QueryBuilder.getResultGroupedBy(path) - groups results by the record reached via the path.
+
+    @Test
+    public void testGetResultGroupedBy() {
+        var orm = ORMTemplate.of(dataSource);
+        var groupedPets = orm.selectFrom(Pet.class)
+                .where(Pet_.id, LESS_THAN, 13)   // Pet 13 has no owner.
+                .orderBy(Pet_.owner)
+                .getResultGroupedBy(Pet_.owner);
+        assertEquals(10, groupedPets.size());
+        assertEquals(12, groupedPets.values().stream().mapToInt(List::size).sum());
+        int previousOwnerId = 0;
+        for (var entry : groupedPets.entrySet()) {
+            Owner owner = entry.getKey();
+            assertTrue(owner.id() > previousOwnerId, "Owners must appear in encounter order.");
+            previousOwnerId = owner.id();
+            int expectedPets = owner.id() == 3 || owner.id() == 6 ? 2 : 1;
+            assertEquals(expectedPets, entry.getValue().size());
+            for (Pet pet : entry.getValue()) {
+                assertSame(owner, pet.owner(), "Grouped pets must share the owner instance of their map key.");
+            }
+        }
+    }
+
+    @Test
+    public void testGetResultGroupedByWithNullPath() {
+        var orm = ORMTemplate.of(dataSource);
+        var exception = assertThrows(PersistenceException.class, () -> orm.selectFrom(Pet.class)
+                .getResultGroupedBy(Pet_.owner));   // Pet 13 has no owner.
+        assertTrue(exception.getMessage().contains("resolved to null"));
+    }
+
+    @Test
+    public void testGetResultGroupedByWithRefPathFails() {
+        var orm = ORMTemplate.of(dataSource);
+        // Ref-mapped paths are rejected at compile time by the strict signature; the raw cast simulates a
+        // dynamically built path to exercise the runtime backstop.
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        TypedMetamodel<PetOwnerRef, Owner, Owner> refPath = (TypedMetamodel) PetOwnerRef_.owner;
+        var exception = assertThrows(PersistenceException.class, () -> orm.selectFrom(PetOwnerRef.class)
+                .where(PetOwnerRef_.id, LESS_THAN, 13)
+                .getResultGroupedBy(refPath));
+        assertTrue(exception.getMessage().contains("getResultGroupedByRef"));
+    }
+
+    // QueryBuilder.getResultGroupedByRef(path) - groups results by a ref to the record reached via the path.
+
+    @Test
+    public void testGetResultGroupedByRefWithEagerPath() {
+        var orm = ORMTemplate.of(dataSource);
+        var groupedPets = orm.selectFrom(Pet.class)
+                .where(Pet_.id, LESS_THAN, 13)   // Pet 13 has no owner.
+                .orderBy(Pet_.owner)
+                .getResultGroupedByRef(Pet_.owner);
+        assertEquals(10, groupedPets.size());
+        assertEquals(12, groupedPets.values().stream().mapToInt(List::size).sum());
+        for (var entry : groupedPets.entrySet()) {
+            for (Pet pet : entry.getValue()) {
+                assertEquals(entry.getKey().id(), pet.owner().id());
+                // Eager path: keys are loaded refs exposing the materialized record without a query.
+                assertSame(pet.owner(), entry.getKey().getOrNull());
+            }
+        }
+        // Refs compare by primary key, so lookups work with any ref for the same entity.
+        assertEquals(2, groupedPets.get(Ref.of(Owner.class, 3)).size());
+        // The map and its lists are unmodifiable.
+        assertThrows(UnsupportedOperationException.class, groupedPets::clear);
+        assertThrows(UnsupportedOperationException.class, () -> groupedPets.firstEntry().getValue().removeFirst());
+    }
+
+    @Test
+    public void testGetResultGroupedByRefWithRefPath() {
+        var orm = ORMTemplate.of(dataSource);
+        var groupedPets = orm.selectFrom(PetOwnerRef.class)
+                .where(PetOwnerRef_.id, LESS_THAN, 13)   // Pet 13 has no owner.
+                .getResultGroupedByRef(PetOwnerRef_.owner);   // Ref path: owners are not fetched.
+        assertEquals(10, groupedPets.size());
+        assertEquals(12, groupedPets.values().stream().mapToInt(List::size).sum());
+        for (var entry : groupedPets.entrySet()) {
+            for (PetOwnerRef pet : entry.getValue()) {
+                assertEquals(entry.getKey(), pet.owner());
+            }
+        }
     }
 }

--- a/storm-foundation/src/main/java/st/orm/AbstractMetamodel.java
+++ b/storm-foundation/src/main/java/st/orm/AbstractMetamodel.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  * @param <V> the value type of the designated element.
  * @since 1.2
  */
-public abstract class AbstractMetamodel<T extends Data, E, V> implements Metamodel<T, E> {
+public abstract class AbstractMetamodel<T extends Data, E, V> implements TypedMetamodel<T, E, V> {
 
     private final Class<E> fieldType;
     private final String path;

--- a/storm-foundation/src/main/java/st/orm/TypedMetamodel.java
+++ b/storm-foundation/src/main/java/st/orm/TypedMetamodel.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * A {@link Metamodel} that also carries the declared component type of the field it represents.
+ *
+ * <p>The component type parameter {@code V} reflects how the field is declared on the record: for eagerly fetched
+ * fields, {@code V} equals the field type {@code E}; for {@code Ref} fields, {@code V} is {@code Ref<E>}. APIs bind
+ * both parameters to the same type variable to require an eagerly fetched path at compile time, for example
+ * {@code TypedMetamodel<T, V, V>}.</p>
+ *
+ * <p>The metamodels generated for record fields implement this interface via {@link AbstractMetamodel}.</p>
+ *
+ * @param <T> the root table type.
+ * @param <E> the field type.
+ * @param <V> the declared component type.
+ * @since 1.13
+ */
+public interface TypedMetamodel<T extends Data, E, V> extends Metamodel<T, E> {
+
+    /**
+     * Extracts the value of the field represented by this metamodel from the given record, typed as the declared
+     * component type: the field type itself for eagerly fetched fields, {@code Ref<E>} for {@code Ref} fields.
+     *
+     * @param record the root record from which the value is extracted.
+     * @return the extracted value, or {@code null} if the value cannot be resolved.
+     * @since 1.13
+     */
+    @Override
+    V getValue(@Nonnull T record);
+}

--- a/storm-foundation/src/test/java/st/orm/AbstractKeyMetamodelTest.java
+++ b/storm-foundation/src/test/java/st/orm/AbstractKeyMetamodelTest.java
@@ -32,7 +32,7 @@ class AbstractKeyMetamodelTest {
         }
 
         @Override
-        public Object getValue(TestData record) {
+        public Integer getValue(TestData record) {
             return record.id();
         }
 

--- a/storm-foundation/src/test/java/st/orm/AbstractMetamodelTest.java
+++ b/storm-foundation/src/test/java/st/orm/AbstractMetamodelTest.java
@@ -23,7 +23,7 @@ class AbstractMetamodelTest {
         }
 
         @Override
-        public Object getValue(TestData record) {
+        public TestData getValue(TestData record) {
             return record;
         }
 
@@ -44,7 +44,7 @@ class AbstractMetamodelTest {
         }
 
         @Override
-        public Object getValue(TestData record) {
+        public Integer getValue(TestData record) {
             return record.id();
         }
 
@@ -65,7 +65,7 @@ class AbstractMetamodelTest {
         }
 
         @Override
-        public Object getValue(TestData record) {
+        public InlineData getValue(TestData record) {
             return null;
         }
 

--- a/storm-foundation/src/test/java/st/orm/KeyDelegateTest.java
+++ b/storm-foundation/src/test/java/st/orm/KeyDelegateTest.java
@@ -19,7 +19,7 @@ class KeyDelegateTest {
         }
 
         @Override
-        public Object getValue(TestData record) {
+        public Integer getValue(TestData record) {
             return record.id();
         }
 
@@ -48,7 +48,7 @@ class KeyDelegateTest {
         }
 
         @Override
-        public Object getValue(TestData record) {
+        public Integer getValue(TestData record) {
             return record.id();
         }
 

--- a/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
+++ b/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
@@ -16,15 +16,24 @@
 package st.orm.template;
 
 import static java.lang.StringTemplate.RAW;
+import static java.util.Objects.requireNonNull;
 import static st.orm.Operator.EQUALS;
 import static st.orm.Operator.IN;
 
 import jakarta.annotation.Nonnull;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.RandomAccess;
+import java.util.SequencedMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import st.orm.Data;
+import st.orm.Entity;
 import st.orm.JoinType;
 import st.orm.Metamodel;
 import st.orm.NoResultException;
@@ -35,6 +44,7 @@ import st.orm.Pageable;
 import st.orm.PersistenceException;
 import st.orm.Ref;
 import st.orm.Scrollable;
+import st.orm.TypedMetamodel;
 import st.orm.Window;
 import st.orm.core.template.impl.Elements.ObjectExpression;
 
@@ -844,6 +854,184 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public final List<R> getResultList() {
         try (var stream = getResultStream()) {
             return stream.toList();
+        }
+    }
+
+
+    /**
+     * Executes the query and returns the results grouped by the record reached via {@code path}, typically the
+     * parent entity of a foreign key. The SQL is not affected by the grouping; the same select is executed and the
+     * results are grouped during hydration.
+     *
+     * <p>The returned map and its lists are unmodifiable and insertion-ordered: groups appear in the order their
+     * first result is encountered, and results appear in encounter order within each group. Use {@code orderBy()} to
+     * control both. Since duplicate entities within a result set share the same instance, each result's reference to
+     * its group key is the map key itself.</p>
+     *
+     * <p>This method requires an entity query: the result type must be the table type {@code T} so that the path can
+     * be resolved against the results. The path must also resolve to a non-null record for every result; paths over
+     * nullable foreign keys must be narrowed with a {@code where()} clause first.</p>
+     *
+     * <p>The signature requires a path whose component type equals its field type, which is how the generated
+     * metamodels type eagerly fetched fields. Paths over {@code Ref} fields are typed
+     * {@code TypedMetamodel<T, V, Ref<V>>} and therefore do not compile; use
+     * {@link #getResultGroupedByRef(Metamodel)} for those.</p>
+     *
+     * @param path the metamodel path from the table type to the record to group by, for example {@code Pet_.owner}.
+     * @param <V> the type of the record to group by.
+     * @return the results grouped by the record reached via {@code path}, in encounter order.
+     * @throws PersistenceException if the query fails, if the result type is not the table type, or if the path
+     *                              resolves to null for a result.
+     * @since 1.13
+     */
+    public final <V extends Data> SequencedMap<V, List<R>> getResultGroupedBy(@Nonnull TypedMetamodel<T, V, V> path) {
+        requireNonNull(path, "path");
+        try (var stream = getResultStream()) {
+            // Duplicate records within a result set share the same instance (query-scoped interning), so the per-row
+            // lookup can use reference identity instead of hashing every field of the group record. The identity map
+            // carries no order and no value semantics; both are restored during assembly below.
+            var groups = new IdentityHashMap<V, Group<R>>();
+            var order = new ArrayList<V>();
+            stream.forEach(element -> {
+                if (!path.root().isInstance(element)) {
+                    throw new PersistenceException(
+                            "Grouped results require an entity query rooted at %s, but got a result of type %s."
+                                    .formatted(path.root().getName(),
+                                            element == null ? "null" : element.getClass().getName()));
+                }
+                // Object intermediate on purpose: assigning the typed return directly would insert a checkcast to
+                // V's bound and fail with a bare ClassCastException for dynamically built ref paths, bypassing the
+                // descriptive backstop below.
+                //noinspection unchecked
+                Object value = path.getValue((T) element);
+                if (value == null) {
+                    throw new PersistenceException(
+                            "Cannot group by %s: the path resolved to null. Narrow the query with a where() clause to exclude results without a %s."
+                                    .formatted(path, path.fieldType().getSimpleName()));
+                }
+                if (value instanceof Ref<?>) {
+                    throw new PersistenceException(
+                            "Cannot group by %s: the path resolves to a ref because %s is mapped as a Ref field. Use getResultGroupedByRef() instead."
+                                    .formatted(path, path.fieldType().getSimpleName()));
+                }
+                //noinspection unchecked
+                V group = (V) value;
+                var elements = groups.get(group);
+                if (elements == null) {
+                    elements = new Group<>();
+                    groups.put(group, elements);
+                    order.add(group);
+                }
+                elements.elements.add(element);
+            });
+            // Assembly hashes each distinct group once; equal-by-value groups merge, so the result is correct even
+            // for records that were not interned. The group count is known here, so the map is allocated at its
+            // final size. The values are unmodifiable views over the lists built above, so no copy or re-wrapping
+            // is needed.
+            var result = LinkedHashMap.<V, List<R>>newLinkedHashMap(order.size());
+            for (V group : order) {
+                var elements = groups.get(group);
+                var existing = result.putIfAbsent(group, elements);
+                if (existing != null) {
+                    ((Group<R>) existing).elements.addAll(elements);
+                }
+            }
+            return Collections.unmodifiableSequencedMap(result);
+        }
+    }
+
+    /**
+     * Executes the query and returns the results grouped by a lightweight ref to the record reached via
+     * {@code path}, typically the parent entity of a foreign key. The SQL is not affected by the grouping; the same
+     * select is executed and the results are grouped during hydration.
+     *
+     * <p>This is the ref-based variant of {@link #getResultGroupedBy(TypedMetamodel)}: the map keys are
+     * {@link Ref} instances, which are compared by primary key, keeping map lookups constant-cost regardless of the
+     * size of the group record.</p>
+     *
+     * <p>The behavior of the keys follows how the foreign key is declared on the record:</p>
+     * <ul>
+     *   <li><strong>Entity field</strong> (for example {@code @FK Owner owner}): the referenced record is fetched
+     *       eagerly, as part of the query's auto-joined graph, and is materialized with each result. The keys are
+     *       <em>loaded</em> refs wrapping that record: {@link Ref#getOrNull()} returns it directly, without touching
+     *       the database.</li>
+     *   <li><strong>Ref field</strong> (for example {@code @FK Ref<Pet> pet}): the referenced record is fetched
+     *       lazily; the query reads only the foreign key column, without joining or fetching the referenced table.
+     *       The keys are the <em>unloaded</em> refs produced by the query, carrying just the primary key. When the
+     *       records are needed, fetch them afterwards in a single query with
+     *       {@code findAllByRef(map.keySet())}.</li>
+     * </ul>
+     *
+     * <p>The returned map and its lists are unmodifiable and insertion-ordered: groups appear in the order their
+     * first result is encountered, and results appear in encounter order within each group. Use {@code orderBy()} to
+     * control both.</p>
+     *
+     * <p>This method requires an entity query: the result type must be the table type {@code T} so that the path can
+     * be resolved against the results. The path must also resolve to a non-null value for every result; paths over
+     * nullable foreign keys must be narrowed with a {@code where()} clause first.</p>
+     *
+     * @param path the metamodel path from the table type to the record to group by, for example {@code Pet_.owner}.
+     * @param <V> the type of the record to group by.
+     * @return the results grouped by a ref to the record reached via {@code path}, in encounter order.
+     * @throws PersistenceException if the query fails, if the result type is not the table type, if the path does
+     *                              not reference an entity or ref, or if the path resolves to null for a result.
+     * @since 1.13
+     */
+    public final <V extends Data> SequencedMap<Ref<V>, List<R>> getResultGroupedByRef(@Nonnull Metamodel<T, V> path) {
+        requireNonNull(path, "path");
+        try (var stream = getResultStream()) {
+            // Refs hash and compare by primary key, so the grouping map is cheap without an identity-based fast path.
+            // The values are unmodifiable views appended through their backing lists, so no copy or re-wrapping is
+            // needed when the result is returned.
+            var groups = new LinkedHashMap<Ref<V>, List<R>>();
+            stream.forEach(element -> {
+                if (!path.root().isInstance(element)) {
+                    throw new PersistenceException(
+                            "Grouped results require an entity query rooted at %s, but got a result of type %s."
+                                    .formatted(path.root().getName(),
+                                            element == null ? "null" : element.getClass().getName()));
+                }
+                //noinspection unchecked
+                Object value = path.getValue((T) element);
+                if (value == null) {
+                    throw new PersistenceException(
+                            "Cannot group by %s: the path resolved to null. Narrow the query with a where() clause to exclude results without a %s."
+                                    .formatted(path, path.fieldType().getSimpleName()));
+                }
+                Ref<V> group;
+                if (value instanceof Ref<?> ref) {
+                    //noinspection unchecked
+                    group = (Ref<V>) ref;
+                } else if (value instanceof Entity<?> entity) {
+                    //noinspection unchecked
+                    group = (Ref<V>) Ref.of(entity);
+                } else {
+                    throw new PersistenceException(
+                            "Cannot group by ref at %s: the path must reference an entity or a ref, but resolved to %s."
+                                    .formatted(path, value.getClass().getName()));
+                }
+                ((Group<R>) groups.computeIfAbsent(group, ignore -> new Group<>())).elements.add(element);
+            });
+            return Collections.unmodifiableSequencedMap(groups);
+        }
+    }
+
+    /**
+     * Unmodifiable list view over a group's elements. The grouping terminals append through {@link #elements} while
+     * building, so the map values are unmodifiable from the start and require no copy or re-wrapping when the result
+     * is returned.
+     */
+    private static final class Group<R> extends AbstractList<R> implements RandomAccess {
+        final ArrayList<R> elements = new ArrayList<>();
+
+        @Override
+        public R get(int index) {
+            return elements.get(index);
+        }
+
+        @Override
+        public int size() {
+            return elements.size();
         }
     }
 

--- a/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
@@ -1061,6 +1061,82 @@ abstract class QueryBuilder<T : Data, R, ID> {
             }
         }
 
+    /**
+     * Executes the query and returns the results grouped by the record reached via [path], typically the parent
+     * entity of a foreign key:
+     *
+     * ```kotlin
+     * val ownersWithPets: Map<Owner, List<Pet>> = orm.entity<Pet>()
+     *     .select()
+     *     .where(Pet_.owner.city eq city)
+     *     .orderBy(Pet_.owner)
+     *     .resultGroupedBy(Pet_.owner)
+     * ```
+     *
+     * The SQL is not affected by the grouping; the same select is executed and the results are grouped during
+     * hydration. The returned map and its lists are unmodifiable and insertion-ordered: groups appear in the order
+     * their first result is encountered, and results appear in encounter order within each group. Use `orderBy()` to
+     * control both. Since duplicate entities within a result set share the same instance, each result's reference to
+     * its group key is the map key itself.
+     *
+     * This method requires an entity query: the result type must be the table type `T` so that the path can be
+     * resolved against the results. The path must also resolve to a non-null record for every result; paths over
+     * nullable foreign keys must be narrowed with a `where()` clause first.
+     *
+     * The signature requires a path whose component type equals its field type, which is how the generated
+     * metamodels type eagerly fetched fields. Paths over `Ref` fields are typed
+     * `TypedMetamodel<T, V, Ref<V>>` and therefore do not compile; use [resultGroupedByRef] for those.
+     *
+     * @param path the metamodel path from the table type to the record to group by, for example `Pet_.owner`.
+     * @param V the type of the record to group by.
+     * @return the results grouped by the record reached via [path], in encounter order.
+     * @throws PersistenceException if the query fails, if the result type is not the table type, or if the path
+     * resolves to null for a result.
+     * @since 1.13
+     */
+    abstract fun <V : Data> resultGroupedBy(path: TypedMetamodel<T, V, out V?>): Map<V, List<R>>
+
+    /**
+     * Executes the query and returns the results grouped by a lightweight ref to the record reached via [path],
+     * typically the parent entity of a foreign key.
+     *
+     * This is the ref-based variant of [resultGroupedBy]: the map keys are [Ref] instances, which are compared by
+     * primary key, keeping map lookups constant-cost regardless of the size of the group record.
+     *
+     * The behavior of the keys follows how the foreign key is declared on the record:
+     *
+     * - **Entity field** (for example `@FK val owner: Owner`): the referenced record is fetched eagerly, as part
+     *   of the query's auto-joined graph, and is materialized with each result. The keys are *loaded* refs
+     *   wrapping that record: [Ref.getOrNull] returns it directly, without touching the database.
+     * - **Ref field** (for example `@FK val pet: Ref<Pet>`): the referenced record is fetched lazily; the query
+     *   reads only the foreign key column, without joining or fetching the referenced table. The keys are the
+     *   *unloaded* refs produced by the query, carrying just the primary key. When the records are needed, fetch
+     *   them afterwards in a single query with `findAllByRef(map.keys)`:
+     *
+     * ```kotlin
+     * val visitsByPet: Map<Ref<Pet>, List<Visit>> = orm.entity<Visit>()
+     *     .select()
+     *     .resultGroupedByRef(Visit_.pet)
+     * ```
+     *
+     * The SQL is not affected by the grouping; the same select is executed and the results are grouped during
+     * hydration. The returned map and its lists are unmodifiable and insertion-ordered: groups appear in the order
+     * their first result is encountered, and results appear in encounter order within each group. Use `orderBy()` to
+     * control both.
+     *
+     * This method requires an entity query: the result type must be the table type `T` so that the path can be
+     * resolved against the results. The path must also resolve to a non-null value for every result; paths over
+     * nullable foreign keys must be narrowed with a `where()` clause first.
+     *
+     * @param path the metamodel path from the table type to the record to group by, for example `Visit_.pet`.
+     * @param V the type of the record to group by.
+     * @return the results grouped by a ref to the record reached via [path], in encounter order.
+     * @throws PersistenceException if the query fails, if the result type is not the table type, if the path does
+     * not reference an entity or ref, or if the path resolves to null for a result.
+     * @since 1.13
+     */
+    abstract fun <V : Data> resultGroupedByRef(path: Metamodel<T, V>): Map<Ref<V>, List<R>>
+
     val singleResult: R
         /**
          * Executes the query and returns a single result.

--- a/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
@@ -161,6 +161,24 @@ class QueryBuilderImpl<T : Data, R, ID>(
         get() = core.getResultStream()
 
     /**
+     * Executes the query and returns the results grouped by the record reached via [path], in encounter order.
+     *
+     * @param path the metamodel path from the table type to the record to group by.
+     * @return the results grouped by the record reached via [path], in encounter order.
+     */
+    @Suppress("UNCHECKED_CAST")
+    override fun <V : Data> resultGroupedBy(path: TypedMetamodel<T, V, out V?>): Map<V, List<R>> = core.getResultGroupedBy(path as TypedMetamodel<T, V, V>)
+
+    /**
+     * Executes the query and returns the results grouped by a ref to the record reached via [path], in encounter
+     * order.
+     *
+     * @param path the metamodel path from the table type to the record to group by.
+     * @return the results grouped by a ref to the record reached via [path], in encounter order.
+     */
+    override fun <V : Data> resultGroupedByRef(path: Metamodel<T, V>): Map<Ref<V>, List<R>> = core.getResultGroupedByRef(path)
+
+    /**
      * Adds a cross join to the query.
      *
      * @param relation the relation to join.

--- a/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
@@ -22,6 +22,7 @@ import st.orm.Operator.*
 import st.orm.PersistenceException
 import st.orm.Ref
 import st.orm.Scrollable
+import st.orm.TypedMetamodel
 import st.orm.repository.entity
 import st.orm.template.model.*
 
@@ -2326,5 +2327,52 @@ open class QueryBuilderTest(
         val idPath = metamodel<City, Int>(repo.model, "id")
         val cities = repo.select().where(idPath.between(2, 4)).resultList
         cities shouldHaveSize 3
+    }
+
+    // resultGroupedBy tests
+
+    @Test
+    fun `resultGroupedBy should group pets by their owner in encounter order`() {
+        // data.sql: 12 pets have an owner (owners 3 and 6 have two pets each); pet 13 has none.
+        @Suppress("UNCHECKED_CAST")
+        val ownerPath = Metamodel.of<Pet, Owner>(Pet::class.java, "owner") as TypedMetamodel<Pet, Owner, Owner>
+        val groupedPets = orm.entity(Pet::class).select()
+            .whereId((1..12).toList())
+            .orderBy(ownerPath)
+            .resultGroupedBy(ownerPath)
+        groupedPets.size shouldBe 10
+        groupedPets.values.sumOf { it.size } shouldBe 12
+        groupedPets.keys.map { it.id }.zipWithNext().all { (previous, next) -> previous < next } shouldBe true
+        groupedPets.forEach { (owner, pets) ->
+            pets.forEach { pet -> (pet.owner === owner) shouldBe true }
+        }
+    }
+
+    @Test
+    fun `resultGroupedBy should fail when the path resolves to null`() {
+        // data.sql: pet 13 has no owner.
+        @Suppress("UNCHECKED_CAST")
+        val ownerPath = Metamodel.of<Pet, Owner>(Pet::class.java, "owner") as TypedMetamodel<Pet, Owner, Owner>
+        assertThrows<PersistenceException> {
+            orm.entity(Pet::class).select().resultGroupedBy(ownerPath)
+        }
+    }
+
+    @Test
+    fun `resultGroupedByRef should group pets by a ref to their owner`() {
+        // data.sql: 12 pets have an owner (owners 3 and 6 have two pets each); pet 13 has none.
+        val ownerPath: Metamodel<Pet, Owner> = Metamodel.of(Pet::class.java, "owner")
+        val groupedPets = orm.entity(Pet::class).select()
+            .whereId((1..12).toList())
+            .resultGroupedByRef(ownerPath)
+        groupedPets.size shouldBe 10
+        groupedPets.values.sumOf { it.size } shouldBe 12
+        groupedPets.forEach { (ownerRef, pets) ->
+            pets.forEach { pet ->
+                pet.owner?.id shouldBe ownerRef.id()
+                // Eager path: keys are loaded refs exposing the materialized record without a query.
+                (pet.owner === ownerRef.getOrNull()) shouldBe true
+            }
+        }
     }
 }

--- a/website/static/skills/storm-query-java.md
+++ b/website/static/skills/storm-query-java.md
@@ -36,7 +36,17 @@ Repository/entity methods fall into two categories:
 
 (The `select(predicate)` / `delete(predicate)` shorthands are Kotlin-only — in Java, chain `.where(...)` on the builder.)
 
-Terminal operations: `.getResultList()`, `.getSingleResult()`, `.getOptionalResult()`, `.getResultStream()`, `.getResultCount()`, `.page()`, `.scroll()`, `.executeUpdate()`
+Terminal operations: `.getResultList()`, `.getSingleResult()`, `.getOptionalResult()`, `.getResultStream()`, `.getResultCount()`, `.getResultGroupedBy(path)`, `.getResultGroupedByRef(path)`, `.page()`, `.scroll()`, `.executeUpdate()`
+
+**One-to-many loading:** `getResultGroupedBy(path)` groups results by a related record, typically the parent entity of a foreign key. The same select is executed (single query, no SQL change) and the results are grouped during hydration into an unmodifiable, insertion-ordered `Map<Parent, List<T>>`. Repeated parents are materialized once and grouped by instance identity, so the join's duplication is not paid during hydration. The path must resolve non-null for every result. The ref-based variant returns `Map<Ref<Parent>, List<T>>` with keys compared by primary key. For eager entity paths the keys are loaded refs (`getOrNull()` returns the already-materialized record); for `Ref` foreign-key fields it groups directly on the foreign key without fetching the parent, and `findAllByRef(map.keys)` fetches the parents in one query when needed.
+
+```java
+// Load cities with their users in one query
+Map<City, List<User>> usersByCity = orm.entity(User.class)
+    .select()
+    .orderBy(User_.city)
+    .getResultGroupedBy(User_.city);
+```
 
 **Convenience methods** execute immediately and return results directly:
 - `findById()`, `findByRef()`, `findAll()`, `findAllRef()`, `findBy()`, `findAllBy()`, `getById()`, `getByRef()`, `getBy()`, `count()`, `exists()`, `remove()`, `removeById()`, `removeByRef()`, `removeAll()`, `removeAllBy()`, `page()`, `pageRef()`, `scroll()`
@@ -61,6 +71,7 @@ Prefer the simplest approach that works. Three query levels, from simplest to mo
 | Count by field | `countBy(field, value)` | `selectCount().where(field, EQUALS, value).getSingleResult()` |
 | Exists check | `existsBy(field, value)` | `countBy(field, value) > 0` |
 | Delete by field | `removeAllBy(field, value)` | `delete().where(field, EQUALS, value).executeUpdate()` |
+| Parents with their children (one-to-many) | `select().getResultGroupedBy(parentPath)` | per-parent queries in a loop (N+1) or manual grouping after `getResultList()` |
 | Filtered + **ordering/pagination** | `select().where(...).orderBy(...).getResultList()` | convenience methods (can't add ordering) |
 | Filtered + **joins** | `select().innerJoin(...).on(...).getResultList()` | convenience methods (can't add joins) |
 | Filtered + **streaming** | `select().where(...).getResultStream()` | convenience methods (return List, not Stream) |

--- a/website/static/skills/storm-query-kotlin.md
+++ b/website/static/skills/storm-query-kotlin.md
@@ -96,7 +96,17 @@ Repository/entity methods fall into two categories:
 - `selectCount()` -- build COUNT queries
 - `delete()`, `delete(predicate)`, `delete { }` -- build DELETE queries
 
-Terminal operations: `.resultList`, `.singleResult`, `.optionalResult`, `.resultFlow`, `.resultStream`, `.resultCount`, `.page()`, `.scroll()`, `.executeUpdate()`
+Terminal operations: `.resultList`, `.singleResult`, `.optionalResult`, `.resultFlow`, `.resultStream`, `.resultCount`, `.resultGroupedBy(path)`, `.resultGroupedByRef(path)`, `.page()`, `.scroll()`, `.executeUpdate()`
+
+**One-to-many loading:** `resultGroupedBy(path)` groups results by a related record, typically the parent entity of a foreign key. The same select is executed (single query, no SQL change) and the results are grouped during hydration into an unmodifiable, insertion-ordered `Map<Parent, List<T>>`. Repeated parents are materialized once and grouped by instance identity, so the join's duplication is not paid during hydration. The path must resolve non-null for every result. The ref-based variant returns `Map<Ref<Parent>, List<T>>` with keys compared by primary key. For eager entity paths the keys are loaded refs (`getOrNull()` returns the already-materialized record); for `Ref` foreign-key fields it groups directly on the foreign key without fetching the parent, and `findAllByRef(map.keys)` fetches the parents in one query when needed.
+
+```kotlin
+// Load cities with their users in one query
+val usersByCity: Map<City, List<User>> = orm.entity<User>()
+    .select()
+    .orderBy(User_.city)
+    .resultGroupedBy(User_.city)
+```
 
 **Convenience methods** execute immediately and return results directly:
 - `findById()`, `findByRef()`, `findAll()`, `findAllRef()`, `findBy()`, `findAllBy()`, `getById()`, `getByRef()`, `getBy()`, `count()`, `exists()`, `remove()`, `removeById()`, `removeByRef()`, `removeAll()`, `removeAll(predicate)`, `removeAllBy()`, `page()`, `pageRef()`, `scroll()`
@@ -125,6 +135,7 @@ Prefer the simplest approach that works. Four query levels, from simplest to mos
 | Exists check | `exists(predicate)` | `count(predicate) > 0` |
 | Delete by predicate | `removeAll(predicate)` | `delete(predicate).executeUpdate()` |
 | Delete by field | `removeAllBy(field, value)` | `delete(field eq value).executeUpdate()` |
+| Parents with their children (one-to-many) | `select().resultGroupedBy(parentPath)` | per-parent queries in a loop (N+1) or manual `groupBy` after `resultList` |
 | Filtered + **ordering/pagination** | `select(predicate).orderBy(...).resultList` | convenience methods (can't add ordering) |
 | Filtered + **joins** | `select { }` or `select().innerJoin(...)` | convenience methods (can't add joins) |
 | Filtered + **streaming** | `select(predicate).resultFlow` | convenience methods (return List, not Flow) |


### PR DESCRIPTION
Adds grouped result terminals to the query builder for loading one-to-many graphs in a single query, across the core, Kotlin, and Java APIs.

```kotlin
val ownersWithPets: Map<Owner, List<Pet>> = orm.entity<Pet>()
    .select()
    .where(Pet_.owner.city eq city)
    .orderBy(Pet_.owner)
    .resultGroupedBy(Pet_.owner)
```

The SQL is not affected by the grouping: the same select is executed and the results are grouped during hydration, in line with the SQL-first principle. The returned map and its lists are unmodifiable and insertion-ordered, and each result's reference to its group key is the map key itself.

## API

- `getResultGroupedBy(TypedMetamodel<T, V, V>)` groups by the parent record of an eagerly fetched path, returning `SequencedMap<V, List<R>>`.
- `getResultGroupedByRef(Metamodel<T, V>)` groups by a primary-key compared ref, returning `SequencedMap<Ref<V>, List<R>>`. Keys carry what the query paid for: eagerly fetched paths produce loaded refs (`getOrNull()` returns the materialized record); `Ref` fields group directly on the foreign key without fetching the referenced table, with `findAllByRef(map.keySet())` as the one-query batch fetch when the records are needed.

## Compile-time safety

The generated metamodels already encode the fetch mode in their types: eager fields are `AbstractMetamodel<T, V, V>`, `Ref` fields are `AbstractMetamodel<T, V, Ref<V>>`. The new `TypedMetamodel<T, E, V>` interface (implemented by `AbstractMetamodel`, no generator changes) exposes that component type, and the entity-keyed terminal binds both parameters to one type variable, so grouping by a `Ref`-mapped path does not compile and points users to the ref variant. A runtime check backstops dynamically built paths. There is deliberately no loose overload: overload resolution would silently route ref-typed arguments to it and undo the guarantee.

`TypedMetamodel` also narrows `getValue` to the declared component type, so programmatic extraction through metamodel paths is statically typed.

## Hydration

Grouping keys on instance identity rather than record equality: duplicate parents within a result set share the same instance (query-scoped interning, verified structurally in `RecordMapper` and pinned by `assertSame` tests), so the per-row lookup is an identity probe and each distinct group is hashed once at assembly. Values are unmodifiable `Group` views appended through their backing lists, so no copy or re-wrapping happens when the result is returned. Non-interned equal-by-value groups merge during assembly, keeping results correct without relying on the interning invariant.

In the storm-benchmarks objectGraph workload (50 parents with 2 children each, PostgreSQL 17, loopback), the terminal replaces the hand-grouped join and measures at the level of the raw JDBC join baseline; the previous idiom measured roughly 38% above it.

## Coverage

- Integration tests for both terminals in core (grouping shape, encounter order, shared-instance identity, unmodifiability, null-path and ref-path failures, ref lookups by primary key) and Kotlin.
- Docs: queries.md (Grouped Results), relationships.md (one-to-many and many-to-many loading patterns), and the query skills.

Fixes #246
