### PR TITLE
perf: skip fetch-size hint and observer overhead for eager reads

### DIFF
--- a/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
@@ -409,7 +409,7 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      *         problems or invalid input parameters.
      */
     public List<E> findAllById(@Nonnull Iterable<ID> ids) {
-        try (var stream = selectById(toStream(ids))) {
+        try (var stream = selectByIdMaterialized(toStream(ids))) {
             return stream.toList();
         }
     }
@@ -432,9 +432,36 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      *         problems or invalid input parameters.
      */
     public List<E> findAllByRef(@Nonnull Iterable<Ref<E>> refs) {
-        try (var stream = selectByRef(toStream(refs))) {
+        try (var stream = selectByRefMaterialized(toStream(refs))) {
             return stream.toList();
         }
+    }
+
+    /**
+     * Streams entities by id in batches, materializing each batch without the fetch-size hint.
+     *
+     * <p>Backs {@link #findAllById(Iterable)}, which buffers the full result anyway. Cursor-based fetching would only
+     * add overhead here, wrapping each batch in a transaction on dialects where cursors require one. Unlike
+     * {@link #selectById(Stream)} this does not stream rows within a batch, so it is kept private rather than exposed
+     * as a lazy API.</p>
+     *
+     * @param ids a stream of entity IDs to retrieve from the repository.
+     * @return a stream of entities, materialized one batch at a time.
+     */
+    private Stream<E> selectByIdMaterialized(@Nonnull Stream<ID> ids) {
+        return chunked(ids, getDefaultChunkSize(), batch -> select().whereId(batch).getResultList().stream());
+    }
+
+    /**
+     * Streams entities by ref in batches, materializing each batch without the fetch-size hint.
+     *
+     * <p>The ref counterpart to {@link #selectByIdMaterialized(Stream)}, backing {@link #findAllByRef(Iterable)}.</p>
+     *
+     * @param refs a stream of refs to retrieve from the repository.
+     * @return a stream of entities, materialized one batch at a time.
+     */
+    private Stream<E> selectByRefMaterialized(@Nonnull Stream<Ref<E>> refs) {
+        return chunked(refs, getDefaultChunkSize(), batch -> select().whereRef(batch).getResultList().stream());
     }
 
     // Stream based methods. These methods operate in multiple batches.

--- a/storm-core/src/main/java/st/orm/core/spi/QueryObserver.java
+++ b/storm-core/src/main/java/st/orm/core/spi/QueryObserver.java
@@ -142,7 +142,13 @@ public interface QueryObserver {
      *
      * @return the no-op query observer.
      */
+    /**
+     * Observer that ignores all executions. Exposed as a constant so hot paths can skip context creation with an
+     * identity check.
+     */
+    QueryObserver NOOP = context -> Observation.NOOP;
+
     static QueryObserver noop() {
-        return context -> Observation.NOOP;
+        return NOOP;
     }
 }

--- a/storm-core/src/main/java/st/orm/core/template/Query.java
+++ b/storm-core/src/main/java/st/orm/core/template/Query.java
@@ -32,6 +32,22 @@ import st.orm.Ref;
 public interface Query {
 
     /**
+     * Returns a query that executes without a fetch-size hint, intended for results that are consumed eagerly and
+     * fully, such as {@code getResultList()} and {@code getSingleResult()}.
+     *
+     * <p>On dialects where cursor-based fetching requires a transaction, the fetch-size hint
+     * causes queries on auto-commit connections to be wrapped in a transaction, adding round trips. Eagerly consumed
+     * results gain nothing from cursor-based fetching, so executing them without the hint avoids that cost. Lazily
+     * consumed streams should keep the fetch-size hint to bound memory usage.</p>
+     *
+     * @return a query without a fetch-size hint; may return {@code this} if no hint is configured.
+     * @since 1.13
+     */
+    default Query withoutFetchSize() {
+        return this;
+    }
+
+    /**
      * Prepares the query for execution.
      *
      * <p>Queries are normally constructed in a lazy fashion, unlike prepared queries which are constructed eagerly.

--- a/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
@@ -925,6 +925,26 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public abstract Stream<R> getResultStream();
 
     /**
+     * Executes the query and returns a stream of results for eager, full consumption.
+     *
+     * <p>Unlike {@link #getResultStream()}, implementations may execute without a fetch-size hint, since eagerly
+     * consumed results gain nothing from cursor-based fetching. On dialects where cursors require a
+     * transaction, this avoids wrapping auto-commit queries in a transaction. The eager terminal
+     * operations, such as {@link #getResultList()} and {@link #getSingleResult()}, consume this stream.</p>
+     *
+     * <p>The same resource-handling rules as {@link #getResultStream()} apply: close the stream after usage,
+     * preferably with a {@code try-with-resources} block.</p>
+     *
+     * @return a stream of results for eager consumption.
+     * @throws PersistenceException if the query operation fails due to underlying database issues, such as
+     *                              connectivity.
+     * @since 1.13
+     */
+    protected Stream<R> getMaterializedResultStream() {
+        return getResultStream();
+    }
+
+    /**
      * Returns the number of results of this query.
      *
      * @return the total number of results of this query as a long value.
@@ -944,7 +964,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @throws PersistenceException if the query fails.
      */
     public final List<R> getResultList() {
-        try (var stream = getResultStream()) {
+        try (var stream = getMaterializedResultStream()) {
             return stream.toList();
         }
     }
@@ -977,7 +997,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      */
     public final <V extends Data> SequencedMap<V, List<R>> getResultGroupedBy(@Nonnull TypedMetamodel<T, V, V> path) {
         requireNonNull(path, "path");
-        try (var stream = getResultStream()) {
+        try (var stream = getMaterializedResultStream()) {
             // Duplicate records within a result set share the same instance (query-scoped interning), so the per-row
             // lookup can use reference identity instead of hashing every field of the group record. The identity map
             // carries no order and no value semantics; both are restored during assembly below.
@@ -1070,7 +1090,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      */
     public final <V extends Data> SequencedMap<Ref<V>, List<R>> getResultGroupedByRef(@Nonnull Metamodel<T, V> path) {
         requireNonNull(path, "path");
-        try (var stream = getResultStream()) {
+        try (var stream = getMaterializedResultStream()) {
             // Refs hash and compare by primary key, so the grouping map is cheap without an identity-based fast path.
             // The values are unmodifiable views appended through their backing lists, so no copy or re-wrapping is
             // needed when the result is returned.
@@ -1135,7 +1155,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @throws PersistenceException if the single row's value is null, or the query fails.
      */
     public final R getSingleResult() {
-        try (var stream = getResultStream()) {
+        try (var stream = getMaterializedResultStream()) {
             var iterator = stream.iterator();
             if (!iterator.hasNext()) {
                 throw new NoResultException("Expected single result, but found none.");
@@ -1159,7 +1179,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @throws PersistenceException if the single row's value is null, or the query fails.
      */
     public final Optional<R> getOptionalResult() {
-        try (var stream = getResultStream()) {
+        try (var stream = getMaterializedResultStream()) {
             var iterator = stream.iterator();
             if (!iterator.hasNext()) {
                 return Optional.empty();

--- a/storm-core/src/main/java/st/orm/core/template/impl/MonitoredResource.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/MonitoredResource.java
@@ -42,12 +42,13 @@ final class MonitoredResource {
     }
 
     private static <T extends AutoCloseable> T wrap(@Nonnull T resource, AtomicInteger openCount) {
-        Exception createStackTrace = new Exception("Create stack trace");
+        // Capturing the creation stack trace is expensive; only do so when debug logging is enabled.
+        Exception createStackTrace = LOGGER.isDebugEnabled() ? new Exception("Create stack trace") : null;
         openCount.getAndIncrement();
         var cleanable = new AtomicReference<Cleanable>();
         //noinspection unchecked
         T proxy = (T) Proxy.newProxyInstance(resource.getClass().getClassLoader(),
-                getInterfaces(resource.getClass()), (p, method, args) -> {
+                INTERFACES.get(resource.getClass()), (p, method, args) -> {
                     if (method.getName().equals("close")) {
                         // We can safely use plain mode here.
                         openCount.setPlain(-1);
@@ -72,7 +73,11 @@ final class MonitoredResource {
             // invoked by the garbage collector. It will be invoked at most once.
             int count = openCount.decrementAndGet();
             if (count == 0) {
-                LOGGER.warn("Resource was not closed properly.", createStackTrace);
+                if (createStackTrace != null) {
+                    LOGGER.warn("Resource was not closed properly.", createStackTrace);
+                } else {
+                    LOGGER.warn("Resource was not closed properly. Enable debug logging for 'st.orm.resource' to capture creation stack traces.");
+                }
             }
             if (count <= 0) {
                 try {
@@ -88,13 +93,17 @@ final class MonitoredResource {
         return proxy;
     }
 
-    private static Class<?>[] getInterfaces(Class<?> clazz) {
-        Set<Class<?>> allInterfaces = new HashSet<>();
-        Class<?> current = clazz;
-        while (current != null) {
-            allInterfaces.addAll(Arrays.asList(current.getInterfaces()));
-            current = current.getSuperclass();
+    /** Interface arrays per class; the walk is only performed once per resource type. */
+    private static final ClassValue<Class<?>[]> INTERFACES = new ClassValue<>() {
+        @Override
+        protected Class<?>[] computeValue(@Nonnull Class<?> clazz) {
+            Set<Class<?>> allInterfaces = new HashSet<>();
+            Class<?> current = clazz;
+            while (current != null) {
+                allInterfaces.addAll(Arrays.asList(current.getInterfaces()));
+                current = current.getSuperclass();
+            }
+            return allInterfaces.toArray(new Class<?>[0]);
         }
-        return allInterfaces.toArray(new Class<?>[0]);
-    }
+    };
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryImpl.java
@@ -158,7 +158,11 @@ class QueryImpl implements Query {
         return new QueryImpl(environment, statement, bindVarsHandle, affectedType, versionAware, managed, true, defaultFetchSize, streamOnlyFetchSize, streamingRequiresTransaction);
     }
 
-    private QueryImpl withoutFetchSize() {
+    @Override
+    public QueryImpl withoutFetchSize() {
+        if (defaultFetchSize == 0) {
+            return this;
+        }
         return new QueryImpl(environment, statement, bindVarsHandle, affectedType, versionAware, managed, unsafe, 0, false, false);
     }
 
@@ -213,7 +217,12 @@ class QueryImpl implements Query {
      */
     private Observation observe(@Nonnull ExecutionKind kind) {
         try {
-            return environment.queryObserver().onExecute(
+            var queryObserver = environment.queryObserver();
+            if (queryObserver == QueryObserver.NOOP) {
+                // Fast path: skip context creation when nothing is observing.
+                return Observation.NOOP;
+            }
+            return queryObserver.onExecute(
                     new QueryContextImpl(environment.operation(), environment.dataType(), kind, environment.statementText()));
         } catch (Throwable ignore) {
             return Observation.NOOP;

--- a/storm-core/src/main/java/st/orm/core/template/impl/SelectBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SelectBuilderImpl.java
@@ -338,7 +338,19 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
      */
     @Override
     public Stream<R> getResultStream() {
-        Query query = build();
+        return getResultStream(build());
+    }
+
+    /**
+     * Executes without the fetch-size hint: eagerly consumed results gain nothing from cursor-based fetching, and
+     * on dialects where cursors require a transaction this avoids wrapping auto-commit queries in a transaction.
+     */
+    @Override
+    protected Stream<R> getMaterializedResultStream() {
+        return getResultStream(build().withoutFetchSize());
+    }
+
+    private Stream<R> getResultStream(@Nonnull Query query) {
         if (refType != null) {
             assert pkType != null : "Primary key type must be specified for ref queries.";
             //noinspection unchecked

--- a/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
+++ b/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
@@ -833,6 +833,26 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public abstract Stream<R> getResultStream();
 
     /**
+     * Executes the query and returns a stream of results for eager, full consumption.
+     *
+     * <p>Unlike {@link #getResultStream()}, implementations may execute without a fetch-size hint, since eagerly
+     * consumed results gain nothing from cursor-based fetching. On dialects where cursors require a
+     * transaction, this avoids wrapping auto-commit queries in a transaction. The eager terminal
+     * operations, such as {@link #getResultList()} and {@link #getSingleResult()}, consume this stream.</p>
+     *
+     * <p>The same resource-handling rules as {@link #getResultStream()} apply: close the stream after usage,
+     * preferably with a {@code try-with-resources} block.</p>
+     *
+     * @return a stream of results for eager consumption.
+     * @throws PersistenceException if the query operation fails due to underlying database issues, such as
+     *                              connectivity.
+     * @since 1.13
+     */
+    protected Stream<R> getMaterializedResultStream() {
+        return getResultStream();
+    }
+
+    /**
      * Returns the number of results of this query.
      *
      * @return the total number of results of this query as a long value.
@@ -851,8 +871,8 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the list of results.
      * @throws PersistenceException if the query fails.
      */
-    public final List<R> getResultList() {
-        try (var stream = getResultStream()) {
+    public List<R> getResultList() {
+        try (var stream = getMaterializedResultStream()) {
             return stream.toList();
         }
     }
@@ -884,9 +904,9 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      *                              resolves to null for a result.
      * @since 1.13
      */
-    public final <V extends Data> SequencedMap<V, List<R>> getResultGroupedBy(@Nonnull TypedMetamodel<T, V, V> path) {
+    public <V extends Data> SequencedMap<V, List<R>> getResultGroupedBy(@Nonnull TypedMetamodel<T, V, V> path) {
         requireNonNull(path, "path");
-        try (var stream = getResultStream()) {
+        try (var stream = getMaterializedResultStream()) {
             // Duplicate records within a result set share the same instance (query-scoped interning), so the per-row
             // lookup can use reference identity instead of hashing every field of the group record. The identity map
             // carries no order and no value semantics; both are restored during assembly below.
@@ -977,9 +997,9 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      *                              not reference an entity or ref, or if the path resolves to null for a result.
      * @since 1.13
      */
-    public final <V extends Data> SequencedMap<Ref<V>, List<R>> getResultGroupedByRef(@Nonnull Metamodel<T, V> path) {
+    public <V extends Data> SequencedMap<Ref<V>, List<R>> getResultGroupedByRef(@Nonnull Metamodel<T, V> path) {
         requireNonNull(path, "path");
-        try (var stream = getResultStream()) {
+        try (var stream = getMaterializedResultStream()) {
             // Refs hash and compare by primary key, so the grouping map is cheap without an identity-based fast path.
             // The values are unmodifiable views appended through their backing lists, so no copy or re-wrapping is
             // needed when the result is returned.
@@ -1043,8 +1063,8 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @throws NonUniqueResultException if more than one result.
      * @throws PersistenceException if the query fails.
      */
-    public final R getSingleResult() {
-        try (var stream = getResultStream()) {
+    public R getSingleResult() {
+        try (var stream = getMaterializedResultStream()) {
             return stream
                     .reduce((_, _) -> {
                         throw new NonUniqueResultException("Expected single result, but found more than one.");
@@ -1059,8 +1079,8 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @throws NonUniqueResultException if more than one result.
      * @throws PersistenceException if the query fails.
      */
-    public final Optional<R> getOptionalResult() {
-        try (var stream = getResultStream()) {
+    public Optional<R> getOptionalResult() {
+        try (var stream = getMaterializedResultStream()) {
             return stream.reduce((_, _) -> {
                 throw new NonUniqueResultException("Expected single result, but found more than one.");
             });

--- a/storm-java21/src/main/java/st/orm/template/impl/QueryBuilderImpl.java
+++ b/storm-java21/src/main/java/st/orm/template/impl/QueryBuilderImpl.java
@@ -23,6 +23,8 @@ import static st.orm.JoinType.right;
 import static st.orm.template.impl.StringTemplates.convert;
 
 import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import st.orm.Data;
@@ -221,6 +223,35 @@ public final class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<
     @Override
     public Stream<R> getResultStream() {
         return core.getResultStream();
+    }
+
+    /**
+     * Eager terminals delegate to the core builder, which executes them without the fetch-size hint, avoiding
+     * transaction wrapping for eagerly consumed results.
+     */
+    @Override
+    public List<R> getResultList() {
+        return core.getResultList();
+    }
+
+    @Override
+    public R getSingleResult() {
+        return core.getSingleResult();
+    }
+
+    @Override
+    public Optional<R> getOptionalResult() {
+        return core.getOptionalResult();
+    }
+
+    @Override
+    public <V extends st.orm.Data> java.util.SequencedMap<V, List<R>> getResultGroupedBy(@Nonnull st.orm.TypedMetamodel<T, V, V> path) {
+        return core.getResultGroupedBy(path);
+    }
+
+    @Override
+    public <V extends st.orm.Data> java.util.SequencedMap<st.orm.Ref<V>, List<R>> getResultGroupedByRef(@Nonnull st.orm.Metamodel<T, V> path) {
+        return core.getResultGroupedByRef(path);
     }
 
     /**

--- a/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
@@ -1048,7 +1048,7 @@ abstract class QueryBuilder<T : Data, R, ID> {
             }
         }
 
-    val resultList: List<R>
+    open val resultList: List<R>
         /**
          * Executes the query and returns a list of results.
          *
@@ -1137,7 +1137,7 @@ abstract class QueryBuilder<T : Data, R, ID> {
      */
     abstract fun <V : Data> resultGroupedByRef(path: Metamodel<T, V>): Map<Ref<V>, List<R>>
 
-    val singleResult: R
+    open val singleResult: R
         /**
          * Executes the query and returns a single result.
          *
@@ -1163,7 +1163,7 @@ abstract class QueryBuilder<T : Data, R, ID> {
             }
         }
 
-    val optionalResult: R?
+    open val optionalResult: R?
         /**
          * Executes the query and returns an optional result.
          *

--- a/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
@@ -160,6 +160,19 @@ class QueryBuilderImpl<T : Data, R, ID>(
          */
         get() = core.getResultStream()
 
+    override val resultList: List<R>
+        /**
+         * Eager terminals delegate to the core builder, which executes them without the fetch-size hint,
+         * avoiding transaction wrapping for eagerly consumed results.
+         */
+        get() = core.resultList
+
+    override val singleResult: R
+        get() = core.singleResult
+
+    override val optionalResult: R?
+        get() = core.optionalResult.orElse(null)
+
     /**
      * Executes the query and returns the results grouped by the record reached via [path], in encounter order.
      *

--- a/storm-postgresql/src/main/java/st/orm/spi/postgresql/PostgreSQLSqlDialect.java
+++ b/storm-postgresql/src/main/java/st/orm/spi/postgresql/PostgreSQLSqlDialect.java
@@ -203,6 +203,21 @@ public class PostgreSQLSqlDialect extends DefaultSqlDialect implements SqlDialec
     }
 
     /**
+     * Returns {@code true} so the fetch size only applies to streaming result consumption.
+     *
+     * <p>Cursor-based fetching requires a transaction on PostgreSQL, so applying the fetch size to eagerly
+     * consumed results would wrap every auto-commit query in a transaction, adding round trips without any
+     * benefit: eager methods materialize the full result either way.</p>
+     *
+     * @return {@code true}.
+     * @since 1.13
+     */
+    @Override
+    public boolean streamOnlyFetchSize() {
+        return true;
+    }
+
+    /**
      * Returns {@code true} because the PostgreSQL JDBC driver requires the connection to be in non-auto-commit
      * mode for the fetch size hint to activate cursor-based result batching. When auto-commit is enabled, the
      * driver silently ignores the fetch size and buffers the entire result set in memory.


### PR DESCRIPTION
Trims the read path for eagerly consumed results across the core, Java 21, and Kotlin APIs. The eager terminals materialize the full result set, so they no longer need the streaming machinery that lazy consumption relies on.

## Fetch-size hint

The eager terminals (`getResultList`, `getSingleResult`, `getOptionalResult`, `getResultGroupedBy`, `getResultGroupedByRef`) now run through a new `getMaterializedResultStream()` that executes without the fetch-size hint. On dialects where cursor-based fetching requires a transaction, applying the hint forces auto-commit queries onto a transaction-wrapped cursor, adding round trips for results that gain nothing from batched fetching.

- `Query.withoutFetchSize()` returns a query that executes without the hint (identity when no hint is configured).
- `SqlDialect.streamOnlyFetchSize()` gates whether the fetch size applies to streaming consumption only; PostgreSQL overrides it to `true`, since its cursors require a transaction.
- The repository read methods inherit this: `getById`/`findById`/`getByRef`/`findByRef`/`getBy`/`findBy`/`findAll`/`findAllRef`/`count` are all built on the `select()` DSL terminals, and the Java 21 and Kotlin facades delegate straight to the core repository.
- `findAllById`/`findAllByRef` materialize a full `List` but were implemented on the lazy `selectById`/`selectByRef` streaming helpers, so each batch carried the hint. They now materialize each batch through the eager terminal; the public lazy `selectById`/`selectByRef` streaming APIs are untouched and keep the hint.
- Lazily consumed streams (`getResultStream`, `selectById`/`selectByRef`) are unchanged and keep the hint to bound memory.

## Observer fast path

`QueryObserver.NOOP` is now a shared constant. `QueryImpl.observe` short-circuits on an identity check against it, skipping the per-execution `QueryContext` allocation when nothing is observing.

## Resource monitoring

`MonitoredResource` captured a creation stack trace and walked the interface hierarchy for every wrapped resource. It now captures the stack trace only when debug logging for `st.orm.resource` is enabled (the leak warning names the flag when the trace is absent) and caches the interface walk per class with `ClassValue`.

## Notes

No caller-visible change to laziness: every method that returns a lazy `Stream` still applies the fetch-size hint (still cursor-based). Only the terminals that already materialized their full result skip it. Compiles clean across the affected modules; javadoc is annotated `@since 1.13`.

Fixes #249