### PR TITLE
perf: capture connection settings only when a transaction changes them

### DIFF
--- a/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
@@ -448,7 +448,7 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      * @param ids a stream of entity IDs to retrieve from the repository.
      * @return a stream of entities, materialized one batch at a time.
      */
-    private Stream<E> selectByIdMaterialized(@Nonnull Stream<ID> ids) {
+    protected Stream<E> selectByIdMaterialized(@Nonnull Stream<ID> ids) {
         return chunked(ids, getDefaultChunkSize(), batch -> select().whereId(batch).getResultList().stream());
     }
 
@@ -460,7 +460,7 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      * @param refs a stream of refs to retrieve from the repository.
      * @return a stream of entities, materialized one batch at a time.
      */
-    private Stream<E> selectByRefMaterialized(@Nonnull Stream<Ref<E>> refs) {
+    protected Stream<E> selectByRefMaterialized(@Nonnull Stream<Ref<E>> refs) {
         return chunked(refs, getDefaultChunkSize(), batch -> select().whereRef(batch).getResultList().stream());
     }
 

--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -778,6 +779,71 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
             }
         }
         return super.getByRef(ref);
+    }
+
+    /**
+     * Partitions a batch into cached entities and uncached items, fetching the uncached remainder with the given
+     * function. Shared by the cache-aware batch select variants.
+     */
+    private <X> Stream<E> partitionByCache(@Nonnull EntityCache<E, ID> entityCache,
+                                           @Nonnull List<X> batch,
+                                           @Nonnull Function<X, ID> idOf,
+                                           @Nonnull Function<List<X>, Stream<E>> fetchUncached) {
+        List<E> cached = new ArrayList<>();
+        List<X> uncached = new ArrayList<>();
+        for (X item : batch) {
+            Optional<E> cachedEntity = entityCache.get(idOf.apply(item));
+            if (cachedEntity.isPresent()) {
+                cached.add(cachedEntity.get());
+            } else {
+                uncached.add(item);
+            }
+        }
+        if (uncached.isEmpty()) {
+            return cached.stream();
+        }
+        return Stream.concat(cached.stream(), fetchUncached.apply(uncached));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation partitions IDs into cached and uncached (when isolation is REPEATABLE_READ or higher),
+     * returning cached entities immediately and only querying the database for uncached IDs.</p>
+     */
+    @Override
+    protected Stream<E> selectByIdMaterialized(@Nonnull Stream<ID> ids) {
+        if (!isRepeatableRead()) {
+            return super.selectByIdMaterialized(ids);
+        }
+        var cache = entityCache();
+        if (cache.isEmpty()) {
+            return super.selectByIdMaterialized(ids);
+        }
+        EntityCache<E, ID> entityCache = cache.get();
+        return chunked(ids, getDefaultChunkSize(), batch -> partitionByCache(entityCache, batch,
+                Function.identity(), uncached -> select().whereId(uncached).getResultList().stream()));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This implementation partitions refs into cached and uncached (when isolation is REPEATABLE_READ or higher),
+     * returning cached entities immediately and only querying the database for uncached refs.</p>
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Stream<E> selectByRefMaterialized(@Nonnull Stream<Ref<E>> refs) {
+        if (!isRepeatableRead()) {
+            return super.selectByRefMaterialized(refs);
+        }
+        var cache = entityCache();
+        if (cache.isEmpty()) {
+            return super.selectByRefMaterialized(refs);
+        }
+        EntityCache<E, ID> entityCache = cache.get();
+        return chunked(refs, getDefaultChunkSize(), batch -> partitionByCache(entityCache, batch,
+                ref -> (ID) ref.id(), uncached -> select().whereRef(uncached).getResultList().stream()));
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/spi/JdbcTransactionContext.java
+++ b/storm-core/src/main/java/st/orm/core/spi/JdbcTransactionContext.java
@@ -438,10 +438,9 @@ public final class JdbcTransactionContext implements TransactionContext {
             state.savepoint = savepoint;
             state.ownsConnection = false;
             // Share caches since this is the same JDBC connection/transaction. If we roll back to this
-            // savepoint, we will clear the shared cache to avoid stale state.
+            // savepoint, we will clear the shared cache to avoid stale state. The connection settings are not
+            // captured: close() only restores settings on frames that own the connection.
             state.entityCacheMap = outer.entityCacheMap;
-            state.originalIsolationLevel = outerConnection.getTransactionIsolation();
-            state.originalReadOnly = outerConnection.isReadOnly();
             Long innerRequested = state.timeoutSeconds == null ? null : deadlineFromNow(state.timeoutSeconds);
             if (outer.deadlineNanos == null && innerRequested == null) {
                 state.deadlineNanos = null;
@@ -612,12 +611,15 @@ public final class JdbcTransactionContext implements TransactionContext {
             if (!connection.getAutoCommit()) {
                 throw new PersistenceException("Connection returned from DataSource must be in auto-commit mode.");
             }
-            state.originalIsolationLevel = connection.getTransactionIsolation();
-            state.originalReadOnly = connection.isReadOnly();
+            // Only read and change the connection settings when explicitly requested: reading the isolation
+            // level can cost a round trip on some drivers, and close() restores (another round trip) only what
+            // was captured here.
             if (state.isolationLevel != null) {
+                state.originalIsolationLevel = connection.getTransactionIsolation();
                 connection.setTransactionIsolation(state.isolationLevel);
             }
             if (state.readOnly != null) {
+                state.originalReadOnly = connection.isReadOnly();
                 connection.setReadOnly(state.readOnly);
             }
             connection.setAutoCommit(false);
@@ -685,26 +687,21 @@ public final class JdbcTransactionContext implements TransactionContext {
         if (connection == null) {
             throw new PersistenceException("No outer connection to join.");
         }
-        try {
-            state.dataSource = outer.dataSource;
-            state.ownsConnection = false;
-            // Share the entity cache map with the transaction we joined.
-            state.entityCacheMap = outer.entityCacheMap;
-            state.originalIsolationLevel = connection.getTransactionIsolation();
-            state.originalReadOnly = connection.isReadOnly();
-            Long innerRequested = state.timeoutSeconds == null ? null : deadlineFromNow(state.timeoutSeconds);
-            if (outer.deadlineNanos == null && innerRequested == null) {
-                // Keep any deadline already set when the frame began.
-            } else if (outer.deadlineNanos == null) {
-                state.deadlineNanos = innerRequested;
-            } else if (innerRequested == null) {
-                state.deadlineNanos = outer.deadlineNanos;
-            } else {
-                state.deadlineNanos = Math.min(outer.deadlineNanos, innerRequested);
-            }
-            state.connection = connection;
-        } catch (SQLException e) {
-            throw new PersistenceException("Failed to join transaction.", e);
+        state.dataSource = outer.dataSource;
+        state.ownsConnection = false;
+        // Share the entity cache map with the transaction we joined. The connection settings are not
+        // captured: close() only restores settings on frames that own the connection.
+        state.entityCacheMap = outer.entityCacheMap;
+        Long innerRequested = state.timeoutSeconds == null ? null : deadlineFromNow(state.timeoutSeconds);
+        if (outer.deadlineNanos == null && innerRequested == null) {
+            // Keep any deadline already set when the frame began.
+        } else if (outer.deadlineNanos == null) {
+            state.deadlineNanos = innerRequested;
+        } else if (innerRequested == null) {
+            state.deadlineNanos = outer.deadlineNanos;
+        } else {
+            state.deadlineNanos = Math.min(outer.deadlineNanos, innerRequested);
         }
+        state.connection = connection;
     }
 }

--- a/storm-core/src/main/java/st/orm/core/spi/WeakInterner.java
+++ b/storm-core/src/main/java/st/orm/core/spi/WeakInterner.java
@@ -47,21 +47,21 @@ import st.orm.Ref;
 public final class WeakInterner {
 
     /** Map for non-entity objects, using object equality for lookup. Keys are held weakly. */
-    private final Map<Object, WeakReference<Object>> map;
+    private Map<Object, WeakReference<Object>> map;
 
     /** Queue for tracking garbage-collected entities to enable lazy cleanup of {@link #entityMap}. */
-    private final ReferenceQueue<Entity<?>> queue;
+    private ReferenceQueue<Entity<?>> queue;
 
     /** Map for entities, using {@link Ref} (primary key) for efficient lookup. Keys are held strongly. */
-    private final Map<Ref<?>, RefWeakReference> entityMap;
+    private Map<Ref<?>, RefWeakReference> entityMap;
 
     /**
      * Creates a new weak interner.
+     *
+     * <p>The internal structures are initialized lazily: an interner is created per query, and queries without
+     * record or entity results never intern anything.</p>
      */
     public WeakInterner() {
-        map = new WeakHashMap<>();
-        queue = new ReferenceQueue<>();
-        entityMap = new HashMap<>();
     }
 
     /**
@@ -97,6 +97,9 @@ public final class WeakInterner {
      * @return the cached entity, or {@code null} if not found or already garbage collected.
      */
     public <E extends Entity<?>> E get(@Nonnull Class<E> entityType, @Nonnull Object pk) {
+        if (entityMap == null) {
+            return null;
+        }
         drainQueue();
         Ref<?> ref = Ref.of(entityType, pk);
         WeakReference<Entity<?>> existing = entityMap.get(ref);
@@ -121,7 +124,12 @@ public final class WeakInterner {
      * @return the canonical instance for the entity's primary key.
      */
     private <E extends Entity<?>> E internEntity(@Nonnull E entity) {
-        drainQueue();
+        if (entityMap == null) {
+            entityMap = new HashMap<>();
+            queue = new ReferenceQueue<>();
+        } else {
+            drainQueue();
+        }
         Ref<?> ref = Ref.of(entity);
         WeakReference<Entity<?>> existing = entityMap.get(ref);
         if (existing != null) {
@@ -146,6 +154,9 @@ public final class WeakInterner {
      * @throws IllegalArgumentException if an equivalent object of a different class is already interned.
      */
     private <T> T internObject(@Nonnull T object) {
+        if (map == null) {
+            map = new WeakHashMap<>();
+        }
         WeakReference<Object> existing = map.get(object);
         if (existing != null) {
             // Equivalent object found; return existing instance


### PR DESCRIPTION
Follow-up to #249 (PR #250): trims the remaining per-transaction round trips found by the statement-log audit, plus a regression fix and a small allocation saving on the read path.

## Transaction settings capture

`JdbcTransactionContext` captured and restored the connection's isolation level and read-only flag unconditionally on every transaction. On drivers that hit the server for these settings this costs two round trips per transaction — pgjdbc issues `SHOW TRANSACTION ISOLATION LEVEL` at begin and `SET SESSION CHARACTERISTICS` at close, while `BEGIN` itself is piggybacked onto the first statement and is free.

- The originals are now captured only when the transaction explicitly requests an isolation level or read-only mode, and `close()` restores only what was captured.
- Nested-savepoint and joined frames no longer capture at all: `close()` only restores settings on frames that own the connection, so those captures were dead weight (and the removal also drops a dead `try/catch` in the join path).

Measured on the #214 benchmark suite (PostgreSQL 17, same session): `updateById` 1055 → 650 µs against a raw JDBC floor of 573 µs; `batchInsert` down to 2537 µs.

## Regression fix: partial cache hits in findAllById/findAllByRef

The materialized batch variants added to `BaseRepositoryImpl` in #250 bypassed `EntityRepositoryImpl`'s cache-aware overrides, so `findAllById`/`findAllByRef` lost their REPEATABLE_READ partial-cache-hit behavior (two tests red on main). `selectByIdMaterialized`/`selectByRefMaterialized` are now `protected` and `EntityRepositoryImpl` overrides them to serve cached entities directly and query only the uncached remainder, sharing a `partitionByCache` helper.

## WeakInterner lazy initialization

A `WeakInterner` is created per query, but queries without record or entity results never intern anything. The internal maps and reference queue are now initialized on first use; `get()` short-circuits to `null` when nothing has been interned.

## Notes

No behavioral change for transactions that set an isolation level or read-only mode: they capture and restore exactly as before. Full suites green: storm-core 2263, storm-kotlin 1627, storm-java21 517.