### PR TITLE
test: align test models with null-marked defaults

### DIFF
--- a/storm-h2/src/test/java/st/orm/spi/h2/H2SchemaValidatorTest.java
+++ b/storm-h2/src/test/java/st/orm/spi/h2/H2SchemaValidatorTest.java
@@ -37,19 +37,19 @@ public class H2SchemaValidatorTest {
 
     public record Vet(
             @PK Integer id,
-            String firstName,
-            String lastName
+            @Nullable String firstName,
+            @Nullable String lastName
     ) implements Entity<Integer> {}
 
     public record Address(
-            String address,
-            String city
+            @Nullable String address,
+            @Nullable String city
     ) {}
 
     public record Owner(
             @PK Integer id,
-            String firstName,
-            String lastName,
+            @Nullable String firstName,
+            @Nullable String lastName,
             Address address,
             @Nullable String telephone,
             @Nullable Integer version

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBSchemaValidatorTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBSchemaValidatorTest.java
@@ -74,19 +74,19 @@ public class MariaDBSchemaValidatorTest {
 
     public record Vet(
             @PK Integer id,
-            String firstName,
-            String lastName
+            @Nullable String firstName,
+            @Nullable String lastName
     ) implements Entity<Integer> {}
 
     public record Address(
-            String address,
-            String city
+            @Nullable String address,
+            @Nullable String city
     ) {}
 
     public record Owner(
             @PK Integer id,
-            String firstName,
-            String lastName,
+            @Nullable String firstName,
+            @Nullable String lastName,
             Address address,
             @Nullable String telephone,
             @Nullable Integer version

--- a/storm-mssqlserver/src/test/java/st/orm/spi/mssqlserver/MSSQLServerSchemaValidatorTest.java
+++ b/storm-mssqlserver/src/test/java/st/orm/spi/mssqlserver/MSSQLServerSchemaValidatorTest.java
@@ -74,19 +74,19 @@ public class MSSQLServerSchemaValidatorTest {
 
     public record Vet(
             @PK Integer id,
-            String firstName,
-            String lastName
+            @Nullable String firstName,
+            @Nullable String lastName
     ) implements Entity<Integer> {}
 
     public record Address(
-            String address,
-            String city
+            @Nullable String address,
+            @Nullable String city
     ) {}
 
     public record Owner(
             @PK Integer id,
-            String firstName,
-            String lastName,
+            @Nullable String firstName,
+            @Nullable String lastName,
             Address address,
             @Nullable String telephone,
             @Nullable Integer version

--- a/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLSchemaValidatorTest.java
+++ b/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLSchemaValidatorTest.java
@@ -73,19 +73,19 @@ public class MySQLSchemaValidatorTest {
 
     public record Vet(
             @PK Integer id,
-            String firstName,
-            String lastName
+            @Nullable String firstName,
+            @Nullable String lastName
     ) implements Entity<Integer> {}
 
     public record Address(
-            String address,
-            String city
+            @Nullable String address,
+            @Nullable String city
     ) {}
 
     public record Owner(
             @PK Integer id,
-            String firstName,
-            String lastName,
+            @Nullable String firstName,
+            @Nullable String lastName,
             Address address,
             @Nullable String telephone,
             @Nullable Integer version

--- a/storm-oracle/src/test/java/st/orm/spi/oracle/OracleSchemaValidatorTest.java
+++ b/storm-oracle/src/test/java/st/orm/spi/oracle/OracleSchemaValidatorTest.java
@@ -87,19 +87,19 @@ public class OracleSchemaValidatorTest {
 
     public record Vet(
             @PK Integer id,
-            String firstName,
-            String lastName
+            @Nullable String firstName,
+            @Nullable String lastName
     ) implements Entity<Integer> {}
 
     public record Address(
-            String address,
-            String city
+            @Nullable String address,
+            @Nullable String city
     ) {}
 
     public record Owner(
             @PK Integer id,
-            String firstName,
-            String lastName,
+            @Nullable String firstName,
+            @Nullable String lastName,
             Address address,
             @Nullable String telephone,
             @Nullable Integer version

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLSchemaValidatorTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLSchemaValidatorTest.java
@@ -74,19 +74,19 @@ public class PostgreSQLSchemaValidatorTest {
 
     public record Vet(
             @PK Integer id,
-            String firstName,
-            String lastName
+            @Nullable String firstName,
+            @Nullable String lastName
     ) implements Entity<Integer> {}
 
     public record Address(
-            String address,
-            String city
+            @Nullable String address,
+            @Nullable String city
     ) {}
 
     public record Owner(
             @PK Integer id,
-            String firstName,
-            String lastName,
+            @Nullable String firstName,
+            @Nullable String lastName,
             Address address,
             @Nullable String telephone,
             @Nullable Integer version

--- a/storm-spring/src/test/java/st/orm/spring/SpringTransactionBridgeTest.java
+++ b/storm-spring/src/test/java/st/orm/spring/SpringTransactionBridgeTest.java
@@ -23,6 +23,7 @@ import static st.orm.TransactionPropagation.REQUIRES_NEW;
 import static st.orm.template.Transactions.transaction;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import javax.sql.DataSource;
@@ -69,7 +70,7 @@ class SpringTransactionBridgeTest {
     }
 
     private void insertVisit(String description) {
-        visits.insert(new Visit(null, LocalDate.now(), description, pet, null));
+        visits.insert(new Visit(null, LocalDate.now(), description, pet, Instant.now()));
     }
 
     @Test
@@ -156,7 +157,7 @@ class SpringTransactionBridgeTest {
         EntityRepository<Visit, Integer> unbridgedVisits = unbridged.entity(Visit.class);
         PersistenceException exception = assertThrows(PersistenceException.class, () ->
                 transaction(tx -> {
-                    unbridgedVisits.insert(new Visit(null, LocalDate.now(), "never", pet, null));
+                    unbridgedVisits.insert(new Visit(null, LocalDate.now(), "never", pet, Instant.now()));
                     return null;
                 }));
         assertTrue(exception.getMessage().contains("PlatformTransactionManager supplier"));

--- a/storm-sqlite/src/test/java/st/orm/spi/sqlite/SQLiteSchemaValidatorTest.java
+++ b/storm-sqlite/src/test/java/st/orm/spi/sqlite/SQLiteSchemaValidatorTest.java
@@ -36,19 +36,19 @@ public class SQLiteSchemaValidatorTest {
 
     public record Vet(
             @PK Integer id,
-            String firstName,
-            String lastName
+            @Nullable String firstName,
+            @Nullable String lastName
     ) implements Entity<Integer> {}
 
     public record Address(
-            String address,
-            String city
+            @Nullable String address,
+            @Nullable String city
     ) {}
 
     public record Owner(
             @PK Integer id,
-            String firstName,
-            String lastName,
+            @Nullable String firstName,
+            @Nullable String lastName,
             Address address,
             @Nullable String telephone,
             @Nullable Integer version


### PR DESCRIPTION
## Summary

Follow-up to #257 (null-marked models by default). Now that record components are
non-null unless annotated, several test models that relied on implicit nullability
no longer compile/validate as intended. This aligns them with the new contract.

## Changes

- Annotate `firstName`/`lastName` on `Vet` and `Owner`, and `address`/`city` on
  `Address`, with `@Nullable` in the schema validator tests for H2, MariaDB, MySQL,
  MSSQLServer, Oracle, PostgreSQL, and SQLite.
- Pass a non-null `Instant.now()` (instead of `null`) for the `Visit` timestamp in
  `SpringTransactionBridgeTest`.

Test-only; no production code affected.