### PR TITLE
fix: make monitored resource proxy interface order deterministic

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/impl/MonitoredResource.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/MonitoredResource.java
@@ -15,6 +15,8 @@
  */
 package st.orm.core.template.impl;
 
+import static java.util.Comparator.comparing;
+
 import jakarta.annotation.Nonnull;
 import java.lang.ref.Cleaner;
 import java.lang.ref.Cleaner.Cleanable;
@@ -93,7 +95,12 @@ final class MonitoredResource {
         return proxy;
     }
 
-    /** Interface arrays per class; the walk is only performed once per resource type. */
+    /**
+     * Interface arrays per class; the walk is only performed once per resource type. The interfaces are
+     * sorted by name because JDK proxy classes are keyed by the ordered interface list: a stable order
+     * ensures every run requests the same proxy shape, which allows the shape to be registered as
+     * GraalVM native-image reachability metadata.
+     */
     private static final ClassValue<Class<?>[]> INTERFACES = new ClassValue<>() {
         @Override
         protected Class<?>[] computeValue(@Nonnull Class<?> clazz) {
@@ -103,7 +110,9 @@ final class MonitoredResource {
                 allInterfaces.addAll(Arrays.asList(current.getInterfaces()));
                 current = current.getSuperclass();
             }
-            return allInterfaces.toArray(new Class<?>[0]);
+            Class<?>[] interfaces = allInterfaces.toArray(new Class<?>[0]);
+            Arrays.sort(interfaces, comparing(Class::getName));
+            return interfaces;
         }
     };
 }

--- a/storm-core/src/test/java/st/orm/core/template/impl/MonitoredResourceTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/MonitoredResourceTest.java
@@ -1,0 +1,47 @@
+package st.orm.core.template.impl;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.BaseStream;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MonitoredResource}.
+ *
+ * <p>JDK proxy classes are keyed by the ordered interface list, and the proxy shapes below are registered
+ * as GraalVM native-image reachability metadata. These tests pin the exact shapes so a change in interface
+ * order fails here instead of at runtime in a native image.</p>
+ */
+public class MonitoredResourceTest {
+
+    @Test
+    public void testStreamProxyShapeIsDeterministic() {
+        try (Stream<String> stream = MonitoredResource.wrap(Stream.of("a", "b"))) {
+            assertArrayEquals(new Class<?>[] { BaseStream.class, Stream.class },
+                    stream.getClass().getInterfaces(),
+                    "Stream proxy must implement [BaseStream, Stream] in that order");
+        }
+    }
+
+    @Test
+    public void testDerivedIntStreamProxyShapeIsDeterministic() {
+        try (Stream<String> stream = MonitoredResource.wrap(Stream.of("a", "b"))) {
+            try (IntStream mapped = stream.mapToInt(String::length)) {
+                assertArrayEquals(new Class<?>[] { BaseStream.class, IntStream.class },
+                        mapped.getClass().getInterfaces(),
+                        "Derived IntStream proxy must implement [BaseStream, IntStream] in that order");
+            }
+        }
+    }
+
+    @Test
+    public void testProxyDelegatesStreamOperations() {
+        try (Stream<String> stream = MonitoredResource.wrap(Stream.of("a", "b"))) {
+            assertEquals(List.of("A", "B"), stream.map(String::toUpperCase).toList());
+        }
+    }
+}


### PR DESCRIPTION
`MonitoredResource` collected the proxy interfaces into a `HashSet`, so the order passed to `Proxy.newProxyInstance` depended on identity hash codes and could differ between runs. JDK proxy classes are keyed by the ordered interface list, and a GraalVM native image can only instantiate proxy shapes whose exact ordered interface list was registered at build time, so the shape has to be stable.

The interfaces are now sorted by class name before the proxy is built, which yields `[BaseStream, Stream]` for result streams and `[BaseStream, IntStream]` for derived primitive streams. New tests pin these exact shapes so a reordering fails in CI instead of at runtime in a native image, and cover delegation through the proxy.

This is a prerequisite for the static proxy metadata proposed in #261.

Fixes #262