### PR TITLE
feat: ship GraalVM reachability metadata and Spring AOT hints

### DIFF
--- a/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/proxy-config.json
+++ b/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/proxy-config.json
@@ -1,0 +1,26 @@
+[
+  {
+    "condition": { "typeReachable": "st.orm.core.template.impl.PreparedStatementTemplateImpl" },
+    "interfaces": ["java.sql.PreparedStatement"]
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.template.impl.MonitoredResource" },
+    "interfaces": ["st.orm.core.template.PreparedQuery", "st.orm.core.template.Query"]
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.template.impl.MonitoredResource" },
+    "interfaces": ["java.util.stream.BaseStream", "java.util.stream.Stream"]
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.template.impl.MonitoredResource" },
+    "interfaces": ["java.util.stream.BaseStream", "java.util.stream.IntStream"]
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.template.impl.MonitoredResource" },
+    "interfaces": ["java.util.stream.BaseStream", "java.util.stream.LongStream"]
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.template.impl.MonitoredResource" },
+    "interfaces": ["java.util.stream.BaseStream", "java.util.stream.DoubleStream"]
+  }
+]

--- a/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/reflect-config.json
+++ b/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/reflect-config.json
@@ -1,0 +1,54 @@
+[
+  {
+    "condition": { "typeReachable": "st.orm.MetamodelHelper" },
+    "name": "st.orm.core.template.impl.MetamodelFactory",
+    "allPublicMethods": true
+  },
+  {
+    "condition": { "typeReachable": "st.orm.EntityHelper" },
+    "name": "st.orm.core.spi.Providers",
+    "allPublicMethods": true
+  },
+  {
+    "condition": { "typeReachable": "st.orm.EntityHelper" },
+    "name": "st.orm.core.spi.ORMReflection",
+    "allPublicMethods": true
+  },
+  {
+    "condition": { "typeReachable": "st.orm.CursorHelper" },
+    "name": "st.orm.core.spi.CursorFactory",
+    "allPublicMethods": true
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.spi.Nullability" },
+    "name": "org.jspecify.annotations.NullMarked"
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.spi.Nullability" },
+    "name": "org.jspecify.annotations.NullUnmarked"
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.spi.Nullability" },
+    "name": "javax.annotation.Nonnull"
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.spi.Nullability" },
+    "name": "javax.annotation.Nullable"
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.spi.Nullability" },
+    "name": "jakarta.annotation.Nonnull"
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.spi.Nullability" },
+    "name": "jakarta.annotation.Nullable"
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.spi.Nullability" },
+    "name": "kotlin.Metadata"
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.template.impl.ObjectMapperFactory" },
+    "name": "kotlin.Metadata"
+  }
+]

--- a/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/resource-config.json
+++ b/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/resource-config.json
@@ -1,0 +1,10 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "condition": { "typeReachable": "st.orm.core.spi.TypeDiscovery" },
+        "pattern": "\\QMETA-INF/storm/\\E.*"
+      }
+    ]
+  }
+}

--- a/storm-foundation/src/main/resources/META-INF/native-image/st.orm/storm-foundation/reflect-config.json
+++ b/storm-foundation/src/main/resources/META-INF/native-image/st.orm/storm-foundation/reflect-config.json
@@ -1,0 +1,17 @@
+[
+  {
+    "condition": { "typeReachable": "st.orm.Page" },
+    "name": "st.orm.Page",
+    "allPublicMethods": true
+  },
+  {
+    "condition": { "typeReachable": "st.orm.Pageable" },
+    "name": "st.orm.Pageable",
+    "allPublicMethods": true
+  },
+  {
+    "condition": { "typeReachable": "st.orm.Window" },
+    "name": "st.orm.Window",
+    "allPublicMethods": true
+  }
+]

--- a/storm-spring/src/main/java/st/orm/spring/impl/StormRuntimeHints.java
+++ b/storm-spring/src/main/java/st/orm/spring/impl/StormRuntimeHints.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.aop.SpringProxy;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.core.DecoratingProxy;
+
+/**
+ * Registers the reachability metadata a Storm application needs to run as a GraalVM native image.
+ *
+ * <p>Row construction goes through the instantiators the metamodel processor generates at compile time, so
+ * constructing entities and projections needs no reflection hints. What remains is registered here, driven
+ * by the type index the metamodel processor writes to {@code META-INF/storm/}, so applications get their
+ * types registered during Spring AOT processing without writing hints themselves:</p>
+ *
+ * <ul>
+ *   <li><strong>Data types</strong>: Storm reads each entity's and projection's constructor parameters,
+ *       accessors and annotations once to build its model.</li>
+ *   <li><strong>Generated metamodels</strong>: {@code MetamodelFactory} looks up the generated
+ *       {@code <Type>Metamodel} companion by name and walks its public fields; without the hint the lookup
+ *       silently falls back to the slower runtime-built metamodel.</li>
+ *   <li><strong>Converters</strong>: converter implementations are instantiated through their declared
+ *       constructor.</li>
+ *   <li><strong>Repositories</strong>: Storm implements repository interfaces as JDK dynamic proxies, and
+ *       {@link RepositoryProxyingPostProcessor} wraps each repository bean in a Spring AOP proxy, which is
+ *       a JDK proxy as well. A native image only supports proxies whose exact ordered interface list is
+ *       registered ahead of time, so both shapes are registered per repository. Kotlin repositories
+ *       additionally dispatch default methods through the compiler-generated {@code $DefaultImpls}
+ *       class, which is looked up and invoked reflectively.</li>
+ * </ul>
+ *
+ * <p>Hints may reference generated companions that do not exist for a given type (for example
+ * {@code $DefaultImpls} for Java repositories); the native image builder skips metadata entries it cannot
+ * resolve.</p>
+ *
+ * <p>The application independent shapes (the stream and prepared query guarding proxies, the JDBC statement
+ * proxy, and the type index resources) ship as static reachability metadata in the storm-core and
+ * storm-foundation jars and need no registration here.</p>
+ *
+ * @since 1.13
+ */
+public class StormRuntimeHints implements RuntimeHintsRegistrar {
+
+    private static final String INDEX_DIRECTORY = "META-INF/storm/";
+    private static final String DATA_INDEX = INDEX_DIRECTORY + "st.orm.Data.idx";
+    private static final String CONVERTER_INDEX = INDEX_DIRECTORY + "st.orm.Converter.idx";
+    private static final String REPOSITORY_INDEX = INDEX_DIRECTORY + "st.orm.repository.Repository.idx";
+
+    @Override
+    public void registerHints(@Nonnull RuntimeHints hints, @Nullable ClassLoader classLoader) {
+        ClassLoader loader = classLoader == null ? StormRuntimeHints.class.getClassLoader() : classLoader;
+        for (String typeName : readIndex(loader, DATA_INDEX)) {
+            hints.reflection().registerType(TypeReference.of(typeName),
+                    MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                    MemberCategory.INVOKE_PUBLIC_METHODS);
+            hints.reflection().registerType(TypeReference.of(typeName + "Metamodel"),
+                    MemberCategory.PUBLIC_FIELDS,
+                    MemberCategory.INVOKE_PUBLIC_METHODS);
+            hints.reflection().registerType(TypeReference.of(typeName + "NullableMetamodel"),
+                    MemberCategory.PUBLIC_FIELDS,
+                    MemberCategory.INVOKE_PUBLIC_METHODS);
+        }
+        for (String typeName : readIndex(loader, CONVERTER_INDEX)) {
+            hints.reflection().registerType(TypeReference.of(typeName),
+                    MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+        }
+        for (String typeName : readIndex(loader, REPOSITORY_INDEX)) {
+            TypeReference repository = TypeReference.of(typeName);
+            hints.proxies().registerJdkProxy(repository);
+            hints.proxies().registerJdkProxy(repository,
+                    TypeReference.of(Serializable.class),
+                    TypeReference.of(SpringProxy.class),
+                    TypeReference.of(Advised.class),
+                    TypeReference.of(DecoratingProxy.class));
+            hints.reflection().registerType(TypeReference.of(typeName + "$DefaultImpls"),
+                    MemberCategory.INVOKE_DECLARED_METHODS,
+                    MemberCategory.INVOKE_PUBLIC_METHODS);
+        }
+    }
+
+    private static List<String> readIndex(@Nonnull ClassLoader loader, @Nonnull String resourceName) {
+        Set<String> typeNames = new LinkedHashSet<>();
+        try {
+            Enumeration<URL> resources = loader.getResources(resourceName);
+            while (resources.hasMoreElements()) {
+                URL url = resources.nextElement();
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), UTF_8))) {
+                    reader.lines()
+                            .map(String::trim)
+                            .filter(line -> !line.isEmpty())
+                            .forEach(typeNames::add);
+                }
+            }
+        } catch (IOException ignore) {
+            // No index available; nothing to register.
+        }
+        return List.copyOf(typeNames);
+    }
+}

--- a/storm-spring/src/main/resources/META-INF/spring/aot.factories
+++ b/storm-spring/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar=\
+st.orm.spring.impl.StormRuntimeHints

--- a/storm-spring/src/test/java/st/orm/spring/impl/StormRuntimeHintsTest.java
+++ b/storm-spring/src/test/java/st/orm/spring/impl/StormRuntimeHintsTest.java
@@ -1,0 +1,125 @@
+package st.orm.spring.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeHint;
+import org.springframework.aot.hint.TypeReference;
+
+/**
+ * Tests for {@link StormRuntimeHints}.
+ *
+ * <p>The index files are served from a temporary directory through an isolated class loader, so the hints
+ * observed here come exclusively from the fixtures and the referenced type names never have to exist as
+ * classes.</p>
+ */
+public class StormRuntimeHintsTest {
+
+    @TempDir
+    Path indexDirectory;
+
+    private ClassLoader classLoaderWithIndex(String indexName, String content) throws Exception {
+        Path indexFile = indexDirectory.resolve("META-INF/storm/" + indexName);
+        Files.createDirectories(indexFile.getParent());
+        Files.writeString(indexFile, content);
+        return new URLClassLoader(new URL[] { indexDirectory.toUri().toURL() }, null);
+    }
+
+    private static RuntimeHints registerHints(ClassLoader loader) {
+        RuntimeHints hints = new RuntimeHints();
+        new StormRuntimeHints().registerHints(hints, loader);
+        return hints;
+    }
+
+    @Test
+    public void testDataTypesAreRegisteredForIntrospectionAndInvocation() throws Exception {
+        ClassLoader loader = classLoaderWithIndex("st.orm.Data.idx", "com.example.City\ncom.example.Pet\n");
+        RuntimeHints hints = registerHints(loader);
+        TypeHint cityHint = hints.reflection().getTypeHint(TypeReference.of("com.example.City"));
+        assertNotNull(cityHint, "Data type from the index must be registered");
+        assertTrue(cityHint.getMemberCategories().contains(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS));
+        assertTrue(cityHint.getMemberCategories().contains(MemberCategory.INVOKE_PUBLIC_METHODS));
+        assertNotNull(hints.reflection().getTypeHint(TypeReference.of("com.example.Pet")));
+    }
+
+    @Test
+    public void testGeneratedMetamodelCompanionsAreRegistered() throws Exception {
+        ClassLoader loader = classLoaderWithIndex("st.orm.Data.idx", "com.example.City\n");
+        RuntimeHints hints = registerHints(loader);
+        TypeHint metamodelHint = hints.reflection().getTypeHint(TypeReference.of("com.example.CityMetamodel"));
+        assertNotNull(metamodelHint, "Generated metamodel companion must be registered");
+        assertTrue(metamodelHint.getMemberCategories().contains(MemberCategory.PUBLIC_FIELDS));
+        assertTrue(metamodelHint.getMemberCategories().contains(MemberCategory.INVOKE_PUBLIC_METHODS));
+        assertNotNull(hints.reflection().getTypeHint(TypeReference.of("com.example.CityNullableMetamodel")),
+                "Nullable metamodel companion must be registered");
+    }
+
+    @Test
+    public void testKotlinDefaultImplsAreRegisteredPerRepository() throws Exception {
+        ClassLoader loader = classLoaderWithIndex("st.orm.repository.Repository.idx", "com.example.CityRepository\n");
+        RuntimeHints hints = registerHints(loader);
+        TypeHint defaultImplsHint = hints.reflection()
+                .getTypeHint(TypeReference.of("com.example.CityRepository$DefaultImpls"));
+        assertNotNull(defaultImplsHint, "Kotlin DefaultImpls companion must be registered");
+        assertTrue(defaultImplsHint.getMemberCategories().contains(MemberCategory.INVOKE_DECLARED_METHODS));
+        assertTrue(defaultImplsHint.getMemberCategories().contains(MemberCategory.INVOKE_PUBLIC_METHODS));
+    }
+
+    @Test
+    public void testConverterTypesAreRegisteredForConstructionOnly() throws Exception {
+        ClassLoader loader = classLoaderWithIndex("st.orm.Converter.idx", "com.example.MoneyConverter\n");
+        RuntimeHints hints = registerHints(loader);
+        TypeHint converterHint = hints.reflection().getTypeHint(TypeReference.of("com.example.MoneyConverter"));
+        assertNotNull(converterHint, "Converter type from the index must be registered");
+        assertTrue(converterHint.getMemberCategories().contains(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS));
+        assertFalse(converterHint.getMemberCategories().contains(MemberCategory.INVOKE_PUBLIC_METHODS));
+    }
+
+    @Test
+    public void testRepositoriesAreRegisteredInBothProxyShapes() throws Exception {
+        ClassLoader loader = classLoaderWithIndex("st.orm.repository.Repository.idx", "com.example.CityRepository\n");
+        RuntimeHints hints = registerHints(loader);
+        List<List<String>> proxyShapes = hints.proxies().jdkProxyHints()
+                .map(proxyHint -> proxyHint.getProxiedInterfaces().stream()
+                        .map(TypeReference::getCanonicalName)
+                        .toList())
+                .toList();
+        assertTrue(proxyShapes.contains(List.of("com.example.CityRepository")),
+                "Storm's own repository proxy shape must be registered");
+        assertTrue(proxyShapes.contains(List.of(
+                        "com.example.CityRepository",
+                        "java.io.Serializable",
+                        "org.springframework.aop.SpringProxy",
+                        "org.springframework.aop.framework.Advised",
+                        "org.springframework.core.DecoratingProxy")),
+                "The Spring AOP wrapper shape must be registered with the exact interface order");
+    }
+
+    @Test
+    public void testDuplicateIndexEntriesAreRegisteredOnce() throws Exception {
+        ClassLoader loader = classLoaderWithIndex("st.orm.repository.Repository.idx",
+                "com.example.CityRepository\ncom.example.CityRepository\n");
+        RuntimeHints hints = registerHints(loader);
+        assertEquals(2, hints.proxies().jdkProxyHints().count(),
+                "One repository must produce exactly two proxy shapes");
+    }
+
+    @Test
+    public void testMissingIndexRegistersNothing() throws Exception {
+        ClassLoader loader = new URLClassLoader(new URL[] { indexDirectory.toUri().toURL() }, null);
+        RuntimeHints hints = registerHints(loader);
+        assertEquals(0, hints.reflection().typeHints().count());
+        assertEquals(0, hints.proxies().jdkProxyHints().count());
+    }
+}


### PR DESCRIPTION
Compiling a Storm application to a GraalVM native image currently requires the application to register all reachability metadata by hand. Everything that needs registering is either fixed or derivable from the type index the metamodel processor writes to `META-INF/storm/`, so Storm now ships it.

## Static metadata (storm-core, storm-foundation)

JSON under `META-INF/native-image/st.orm/<artifact>/`, picked up automatically by every native-image build, with or without Spring. All entries are `typeReachable`-conditioned.

- **proxy-config**: `[PreparedStatement]` (connection release on the DataSource path), `[PreparedQuery, Query]` (the prepared query guarding proxy; sorted order per #263), and `[BaseStream, Stream]` with the `IntStream`/`LongStream`/`DoubleStream` variants (result stream guarding proxies).
- **resource-config**: the `META-INF/storm/*` type index, read at runtime by `TypeDiscovery` for schema validation, record validation, converter discovery, and repository discovery in storm-ktor.
- **reflect-config (storm-core)**: the foundation-to-core bridges (`MetamodelHelper`, `EntityHelper`, `CursorHelper` reach `MetamodelFactory`, `Providers`, `ORMReflection`, `CursorFactory` through `Class.forName` and reflective invocation), and the nullability marker annotations that `Nullability` and `ObjectMapperFactory` load by name. The annotation entries are correctness-critical: the lookup falls back to null on failure, which would silently change null-marked semantics in a native image.
- **reflect-config (storm-foundation)**: public-method reflection for `st.orm.Page`, `st.orm.Pageable` and `st.orm.Window`, which template engines and SpEL reach reflectively.

## Spring AOT hints (storm-spring)

`StormRuntimeHints`, registered through `META-INF/spring/aot.factories`, runs during AOT processing of every Spring Boot application without requiring `@ImportRuntimeHints` in user code. Driven by the compile-time index:

- Reflection for every type in `st.orm.Data.idx` (declared constructors, public methods) and its generated `<Type>Metamodel`/`<Type>NullableMetamodel` companions (public fields, public methods), which `MetamodelFactory` looks up by name and would otherwise silently replace with the slower runtime-built metamodel.
- Declared constructors for every type in `st.orm.Converter.idx`.
- Both JDK proxy shapes for every interface in `st.orm.repository.Repository.idx`: `[Repo]` for Storm's own proxy and `[Repo, Serializable, SpringProxy, Advised, DecoratingProxy]` for the Spring AOP wrapper, plus the Kotlin `$DefaultImpls` companion used for default method dispatch.

storm-kotlin-spring inherits the registrar through its storm-spring dependency. Row construction needs no hints: it goes through the generated instantiators, which native-image discovers via its built-in ServiceLoader support. Enum columns need no hints either, verified with a native probe: `getEnumConstants()` and `Enum.valueOf` work on any reachable enum class, and model enums are always reachable through the record signature.

## Out of scope

- Repository scanning under Spring AOT (#260): native applications still need to exclude the scanning auto-configuration and register repositories as plain `@Bean` methods until that lands.
- Per-application metadata for non-Spring stacks (storm-ktor, plain JVM): follow-up in which the metamodel processors emit the JSON into the application's own `META-INF/native-image`.

Fixes #261