### PR TITLE
feat: AOT-compatible repository scanning for GraalVM native images

### DIFF
--- a/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/proxy-config.json
+++ b/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/proxy-config.json
@@ -13,6 +13,10 @@
   },
   {
     "condition": { "typeReachable": "st.orm.core.template.impl.MonitoredResource" },
+    "interfaces": ["java.io.Serializable", "java.util.stream.BaseStream", "java.util.stream.Stream"]
+  },
+  {
+    "condition": { "typeReachable": "st.orm.core.template.impl.MonitoredResource" },
     "interfaces": ["java.util.stream.BaseStream", "java.util.stream.IntStream"]
   },
   {

--- a/storm-kotlin-spring/src/main/kotlin/st/orm/spring/kotlin/RepositoryBeanFactoryPostProcessor.kt
+++ b/storm-kotlin-spring/src/main/kotlin/st/orm/spring/kotlin/RepositoryBeanFactoryPostProcessor.kt
@@ -15,13 +15,12 @@
  */
 package st.orm.spring.kotlin
 
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.stereotype.Component
 import st.orm.repository.EntityRepository
 import st.orm.repository.ProjectionRepository
 import st.orm.repository.Repository
 import st.orm.spring.AbstractRepositoryBeanFactoryPostProcessor
-import st.orm.template.ORMTemplate
+import st.orm.spring.AbstractRepositoryFactoryBean
 
 /**
  * BeanFactoryPostProcessor that scans base packages for Repository interfaces and registers them as beans.
@@ -48,18 +47,5 @@ open class RepositoryBeanFactoryPostProcessor(
 
     override fun getExcludedRepositoryTypes(): Set<Class<*>> = setOf(Repository::class.java, EntityRepository::class.java, ProjectionRepository::class.java)
 
-    override fun createRepository(beanFactory: ConfigurableListableBeanFactory, repositoryType: Class<*>): Any {
-        val orm = getBeanORMTemplate(beanFactory)
-        @Suppress("UNCHECKED_CAST")
-        return orm.repository((repositoryType as Class<Repository>).kotlin)
-    }
-
-    private fun getBeanORMTemplate(beanFactory: ConfigurableListableBeanFactory): ORMTemplate {
-        val beanName = getOrmTemplateBeanName()
-        return if (beanName != null) {
-            beanFactory.getBean(beanName, ORMTemplate::class.java)
-        } else {
-            beanFactory.getBean(ORMTemplate::class.java)
-        }
-    }
+    override fun getRepositoryFactoryBeanClass(): Class<out AbstractRepositoryFactoryBean<*>> = RepositoryFactoryBean::class.java
 }

--- a/storm-kotlin-spring/src/main/kotlin/st/orm/spring/kotlin/RepositoryFactoryBean.kt
+++ b/storm-kotlin-spring/src/main/kotlin/st/orm/spring/kotlin/RepositoryFactoryBean.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring.kotlin
+
+import st.orm.repository.Repository
+import st.orm.spring.AbstractRepositoryFactoryBean
+import st.orm.template.ORMTemplate
+
+/**
+ * FactoryBean that produces a Storm repository through the Kotlin API's template.
+ *
+ * @since 1.13
+ */
+open class RepositoryFactoryBean<R : Repository>(
+    repositoryType: Class<R>,
+    ormTemplateBeanName: String?,
+) : AbstractRepositoryFactoryBean<R>(repositoryType, ormTemplateBeanName) {
+
+    override fun createRepository(repositoryType: Class<R>): R = getOrmTemplate(ORMTemplate::class.java).repository(repositoryType.kotlin)
+}

--- a/storm-spring/pom.xml
+++ b/storm-spring/pom.xml
@@ -144,6 +144,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
             <scope>test</scope>

--- a/storm-spring/src/main/java/st/orm/spring/AbstractRepositoryBeanFactoryPostProcessor.java
+++ b/storm-spring/src/main/java/st/orm/spring/AbstractRepositoryBeanFactoryPostProcessor.java
@@ -21,23 +21,27 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aot.AotDetector;
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.DependencyDescriptor;
+import org.springframework.beans.factory.support.AutowireCandidateQualifier;
 import org.springframework.beans.factory.support.AutowireCandidateResolver;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.core.io.ResourceLoader;
@@ -89,11 +93,12 @@ public abstract class AbstractRepositoryBeanFactoryPostProcessor
     protected abstract Set<Class<?>> getExcludedRepositoryTypes();
 
     /**
-     * Creates the repository proxy for the given interface through the stack's template API, honoring
-     * {@link #getOrmTemplateBeanName()}.
+     * The stack's repository FactoryBean; one bean definition of this type is registered per discovered
+     * repository interface, honoring {@link #getOrmTemplateBeanName()}.
+     *
+     * @since 1.13
      */
-    protected abstract Object createRepository(@Nonnull ConfigurableListableBeanFactory beanFactory,
-                                               @Nonnull Class<?> repositoryType);
+    protected abstract Class<? extends AbstractRepositoryFactoryBean<?>> getRepositoryFactoryBeanClass();
 
     @Override
     public void setResourceLoader(@Nonnull ResourceLoader resourceLoader) {
@@ -102,6 +107,11 @@ public abstract class AbstractRepositoryBeanFactoryPostProcessor
 
     @Override
     public void postProcessBeanFactory(@Nonnull ConfigurableListableBeanFactory beanFactory) {
+        if (AotDetector.useGeneratedArtifacts()) {
+            // The repository bean definitions registered by this post-processor were turned into generated
+            // code during AOT processing; scanning again would re-register them over the generated ones.
+            return;
+        }
         String[] bases = getRepositoryBasePackages();
         if (bases == null || bases.length == 0) {
             return;
@@ -138,25 +148,35 @@ public abstract class AbstractRepositoryBeanFactoryPostProcessor
                 .filter(type -> !hasNoRepositoryBeanAnnotation(type))
                 .distinct()
                 .collect(Collectors.toList());
-        registerRepositories(registry, beanFactory, repositoryTypes.stream());
+        registerRepositories(registry, repositoryTypes.stream());
         RepositoryAutowireCandidateResolver.register(beanFactory);
     }
 
     private void registerRepositories(
             BeanDefinitionRegistry registry,
-            ConfigurableListableBeanFactory beanFactory,
             Stream<Class<?>> repositories
     ) {
         repositories.forEach(type -> {
-            @SuppressWarnings("unchecked")
-            Class<Object> repositoryType = (Class<Object>) type;
-            Supplier<Object> supplier = () -> createRepository(beanFactory, repositoryType);
-            var definition = BeanDefinitionBuilder.genericBeanDefinition(repositoryType, supplier).getBeanDefinition();
+            // A FactoryBean definition carrying the repository interface as a constructor argument, rather
+            // than an instance supplier: suppliers cannot be processed by Spring AOT into generated code,
+            // which would make scanned repositories unavailable in GraalVM native images.
+            var definition = (RootBeanDefinition) BeanDefinitionBuilder
+                    .rootBeanDefinition(getRepositoryFactoryBeanClass())
+                    .addConstructorArgValue(type)
+                    .addConstructorArgValue(getOrmTemplateBeanName())
+                    .getBeanDefinition();
+            // Expose the produced type without instantiating the FactoryBean.
+            definition.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, type);
+            // The attribute is not carried into AOT-generated registrations; the target type is, and it
+            // binds the FactoryBean's generic to the repository interface so the repository can still be
+            // autowired by type in a native image.
+            definition.setTargetType(ResolvableType.forClassWithGenerics(getRepositoryFactoryBeanClass(), type));
             definition.setAttribute("qualifier", getRepositoryPrefix());
             String prefix = getRepositoryPrefix();
             if (prefix != null && !prefix.isEmpty()) {
-                // Set the qualifier attribute to support autowiring by qualifier.
-                definition.setAttribute("qualifier", prefix);
+                // The qualifier attribute supports autowiring by qualifier on the JVM; the definition-level
+                // qualifier survives AOT processing, where attributes are not carried into generated code.
+                definition.addQualifier(new AutowireCandidateQualifier(Qualifier.class, prefix));
                 LOGGER.debug("Registering repository {} with qualifier {}.", type.getName(), prefix);
             } else {
                 LOGGER.debug("Registering repository {}.", type.getName());

--- a/storm-spring/src/main/java/st/orm/spring/AbstractRepositoryFactoryBean.java
+++ b/storm-spring/src/main/java/st/orm/spring/AbstractRepositoryFactoryBean.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring;
+
+import static java.util.Objects.requireNonNull;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * FactoryBean that produces a Storm repository for a given repository interface.
+ *
+ * <p>The scanning engine registers one bean definition of this type per discovered repository interface,
+ * carrying the interface and the optional ORMTemplate bean name as constructor arguments. Unlike an
+ * instance-supplier definition, such a definition can be processed by Spring AOT into generated code,
+ * which makes scanned repositories work in GraalVM native images.</p>
+ *
+ * <p>The Java and Kotlin Spring integrations each provide a concrete subclass binding their stack's
+ * repository creation call, mirroring the {@link AbstractRepositoryBeanFactoryPostProcessor} adapters.</p>
+ *
+ * <p>The class is generic in the repository type it produces so the bean definition's target type can
+ * bind {@code FactoryBean<R>} to the repository interface. AOT-generated registrations preserve the
+ * target type but not definition attributes, so without the generic the produced type would be unknown
+ * in a native image and the repository could not be autowired by type.</p>
+ *
+ * @param <R> the repository interface this factory produces.
+ * @since 1.13
+ */
+public abstract class AbstractRepositoryFactoryBean<R> implements FactoryBean<R>, BeanFactoryAware {
+
+    private final Class<R> repositoryType;
+    private final @Nullable String ormTemplateBeanName;
+    private BeanFactory beanFactory;
+
+    /**
+     * @param repositoryType the repository interface to produce.
+     * @param ormTemplateBeanName the ORMTemplate bean the repository binds to, or {@code null} for the
+     *                            primary template.
+     */
+    protected AbstractRepositoryFactoryBean(@Nonnull Class<R> repositoryType,
+                                            @Nullable String ormTemplateBeanName) {
+        this.repositoryType = requireNonNull(repositoryType, "repositoryType");
+        this.ormTemplateBeanName = ormTemplateBeanName;
+    }
+
+    @Override
+    public void setBeanFactory(@Nonnull BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return repositoryType;
+    }
+
+    @Override
+    public R getObject() {
+        return createRepository(repositoryType);
+    }
+
+    /**
+     * Creates the repository proxy for the given interface through the stack's template API.
+     */
+    protected abstract R createRepository(@Nonnull Class<R> repositoryType);
+
+    /**
+     * Resolves the ORMTemplate the repository binds to: the configured bean name if one was given, the
+     * primary template otherwise.
+     */
+    protected final <T> T getOrmTemplate(@Nonnull Class<T> templateType) {
+        return ormTemplateBeanName != null
+                ? beanFactory.getBean(ormTemplateBeanName, templateType)
+                : beanFactory.getBean(templateType);
+    }
+}

--- a/storm-spring/src/main/java/st/orm/spring/RepositoryBeanFactoryPostProcessor.java
+++ b/storm-spring/src/main/java/st/orm/spring/RepositoryBeanFactoryPostProcessor.java
@@ -18,12 +18,10 @@ package st.orm.spring;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.Set;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.stereotype.Component;
 import st.orm.repository.EntityRepository;
 import st.orm.repository.ProjectionRepository;
 import st.orm.repository.Repository;
-import st.orm.template.ORMTemplate;
 
 /**
  * BeanFactoryPostProcessor that scans base packages for Repository interfaces and registers them as beans.
@@ -89,15 +87,7 @@ public class RepositoryBeanFactoryPostProcessor extends AbstractRepositoryBeanFa
 
     @Override
     @SuppressWarnings("unchecked")
-    protected Object createRepository(@Nonnull ConfigurableListableBeanFactory beanFactory,
-                                      @Nonnull Class<?> repositoryType) {
-        return getBeanORMTemplate(beanFactory).repository((Class<Repository>) repositoryType);
-    }
-
-    private ORMTemplate getBeanORMTemplate(ConfigurableListableBeanFactory beanFactory) {
-        String beanName = getOrmTemplateBeanName();
-        return beanName != null
-                ? beanFactory.getBean(beanName, ORMTemplate.class)
-                : beanFactory.getBean(ORMTemplate.class);
+    protected Class<? extends AbstractRepositoryFactoryBean<?>> getRepositoryFactoryBeanClass() {
+        return (Class<? extends AbstractRepositoryFactoryBean<?>>) (Class<?>) RepositoryFactoryBean.class;
     }
 }

--- a/storm-spring/src/main/java/st/orm/spring/RepositoryFactoryBean.java
+++ b/storm-spring/src/main/java/st/orm/spring/RepositoryFactoryBean.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import st.orm.repository.Repository;
+import st.orm.template.ORMTemplate;
+
+/**
+ * FactoryBean that produces a Storm repository through the Java API's template.
+ *
+ * @since 1.13
+ */
+public class RepositoryFactoryBean<R extends Repository> extends AbstractRepositoryFactoryBean<R> {
+
+    public RepositoryFactoryBean(@Nonnull Class<R> repositoryType, @Nullable String ormTemplateBeanName) {
+        super(repositoryType, ormTemplateBeanName);
+    }
+
+    @Override
+    protected R createRepository(@Nonnull Class<R> repositoryType) {
+        return getOrmTemplate(ORMTemplate.class).repository(repositoryType);
+    }
+}

--- a/storm-spring/src/test/java/st/orm/spring/RepositoryScanningAotTest.java
+++ b/storm-spring/src/test/java/st/orm/spring/RepositoryScanningAotTest.java
@@ -1,0 +1,69 @@
+package st.orm.spring;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.generate.GeneratedFiles.Kind;
+import org.springframework.aot.test.generate.TestGenerationContext;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.context.aot.ApplicationContextAotGenerator;
+import org.springframework.context.support.GenericApplicationContext;
+
+/**
+ * Verifies that the repository bean definitions registered by the scanning post-processor can be processed
+ * by Spring AOT into generated code. Instance-supplier definitions fail this processing outright, so these
+ * tests guard the FactoryBean-based registration that native images depend on.
+ */
+public class RepositoryScanningAotTest {
+
+    private static GenericApplicationContext contextWithScanner(String repositoryPrefix) {
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBeanDefinition("repositoryScanner", BeanDefinitionBuilder
+                .genericBeanDefinition(RepositoryBeanFactoryPostProcessor.class)
+                .addConstructorArgValue(new String[] { "st.orm.spring.repository" })
+                .addConstructorArgValue(null)
+                .addConstructorArgValue(repositoryPrefix)
+                .getBeanDefinition());
+        return context;
+    }
+
+    private static String processAheadOfTime(GenericApplicationContext context) {
+        TestGenerationContext generationContext = new TestGenerationContext();
+        new ApplicationContextAotGenerator().processAheadOfTime(context, generationContext);
+        generationContext.writeGeneratedContent();
+        StringBuilder allSources = new StringBuilder();
+        generationContext.getGeneratedFiles().getGeneratedFiles(Kind.SOURCE).forEach((path, content) -> {
+            try (InputStream in = content.getInputStream()) {
+                allSources.append(new String(in.readAllBytes(), UTF_8));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+        return allSources.toString();
+    }
+
+    @Test
+    public void testAotProcessingGeneratesRepositoryRegistrations() {
+        String generatedSources = processAheadOfTime(contextWithScanner(""));
+        assertTrue(generatedSources.contains("VisitRepository"),
+                "The scanned repositories must be present in the AOT-generated registrations");
+        assertTrue(generatedSources.contains("RepositoryFactoryBean"),
+                "The repositories must be produced through the FactoryBean in generated code");
+        assertFalse(generatedSources.contains("OwnerRepository"),
+                "@NoRepositoryBean interfaces must stay excluded from the AOT-generated registrations");
+    }
+
+    @Test
+    public void testRepositoryQualifierSurvivesAotProcessing() {
+        String generatedSources = processAheadOfTime(contextWithScanner("acme"));
+        assertTrue(generatedSources.contains("AutowireCandidateQualifier"),
+                "The repository qualifier must be carried into the AOT-generated definitions");
+        assertTrue(generatedSources.contains("\"acme\""),
+                "The configured qualifier value must be carried into the AOT-generated definitions");
+    }
+}


### PR DESCRIPTION
Repository scanning registered instance-supplier bean definitions, which Spring AOT cannot process into generated code. AOT processing failed on any application that used scanning, and scanned repositories were unavailable in native images.

## Changes

**FactoryBean-based registration** (storm-spring, storm-kotlin-spring). The scanning engine registers one `RepositoryFactoryBean` definition per discovered repository interface, carrying the interface and the optional ORMTemplate bean name as constructor arguments. Constructor-argument definitions are processable by Spring AOT into generated code. Scanning backs off entirely under `AotDetector.useGeneratedArtifacts()`, since the definitions already live in the generated registrations.

**Produced type survives AOT code generation.** `FactoryBean.OBJECT_TYPE_ATTRIBUTE` is a definition attribute, and attributes are not carried into generated code, so at native runtime the produced type was unknown and no repository qualified for autowiring by type. The FactoryBean hierarchy is generic in the repository type (`AbstractRepositoryFactoryBean<R> implements FactoryBean<R>`) and the definition sets `targetType` to `RepositoryFactoryBean<TheRepository>`, which generated registrations preserve. Same pattern spring-data uses for its repository factories.

**Serializable stream proxy shape** (storm-core). The shipped proxy metadata gains `[java.io.Serializable, java.util.stream.BaseStream, java.util.stream.Stream]`, requested through the resource guard by the suspending batch-insert path.

## Verification

Verified end to end on the full IMDB example application compiled with Oracle GraalVM for JDK 25: repository scanning with no explicit bean configuration, all pages served natively, 14/14 Playwright interface tests green, and the complete dataset import (1.5M rows through suspending batch inserts) running natively in 81 seconds. Test AOT processing over the `@DataStormTest` slice passes as well.

`RepositoryScanningAotTest` covers the definitions' AOT shape; the storm-spring and storm-kotlin-spring suites pass.

Fixes #260