### PR TITLE
feat: GraalVM native image support for Ktor and plain JVM applications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <kotlin.coroutines.version>1.9.0</kotlin.coroutines.version>
         <kotlinx.serialization.version>1.7.3</kotlinx.serialization.version>
         <ktor.version>3.2.3</ktor.version>
+        <graalvm.version>24.2.2</graalvm.version>
         <micrometer.version>1.15.4</micrometer.version>
         <micrometer-tracing.version>1.5.4</micrometer-tracing.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -80,6 +81,13 @@
                 <groupId>org.jetbrains</groupId>
                 <artifactId>annotations</artifactId>
                 <version>24.0.1</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <!-- Build-time API for GraalVM native-image features; never loaded at runtime. -->
+                <groupId>org.graalvm.sdk</groupId>
+                <artifactId>nativeimage</artifactId>
+                <version>${graalvm.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -83,10 +83,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <!-- Build-time API for the GraalVM native-image feature; never loaded at runtime. -->
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>nativeimage</artifactId>
-            <version>24.2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -83,6 +83,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <!-- Build-time API for the GraalVM native-image feature; never loaded at runtime. -->
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <version>24.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>

--- a/storm-core/src/main/java/module-info.java
+++ b/storm-core/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module storm.core {
     requires java.management;
     requires java.sql;
     requires static jakarta.persistence;
+    requires static org.graalvm.nativeimage;
     requires jakarta.annotation;
     requires java.compiler;
     requires storm.foundation;

--- a/storm-core/src/main/java/st/orm/core/graal/StormFeature.java
+++ b/storm-core/src/main/java/st/orm/core/graal/StormFeature.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.graal;
+
+import jakarta.annotation.Nonnull;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeProxyCreation;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+import st.orm.core.spi.TypeDiscovery;
+
+/**
+ * GraalVM native-image feature that registers the application's Storm types, driven by the compile-time
+ * type index the metamodel processor writes to {@code META-INF/storm/}.
+ *
+ * <p>Spring applications receive these registrations through the Spring AOT hints in storm-spring. This
+ * feature provides the equivalent for applications without an AOT phase, such as Ktor services and plain
+ * JVM applications. It activates automatically through this jar's {@code native-image.properties}
+ * whenever storm-core is on the image classpath, so no configuration is needed.</p>
+ *
+ * <p>Per Data type (including compound primary keys and inline components, resolved through
+ * {@link TypeDiscovery#getDataTypesWithComponents()}), the declared constructors and public methods are
+ * registered for reflection (model introspection), along with the generated metamodel companion classes.
+ * Per repository interface, the JDK proxy shape Storm creates behind {@code ORMTemplate.repository(..)}
+ * is registered, along with the Kotlin {@code $DefaultImpls} class that carries default method bodies.
+ * Converters are registered for reflective construction.</p>
+ *
+ * @since 1.13
+ */
+public final class StormFeature implements Feature {
+
+    @Override
+    public String getDescription() {
+        return "Registers Storm entities, converters, and repositories from the compile-time type index.";
+    }
+
+    @Override
+    public void beforeAnalysis(@Nonnull BeforeAnalysisAccess access) {
+        int dataTypes = 0;
+        for (Class<?> type : TypeDiscovery.getDataTypes()) {
+            registerDataType(access, type);
+            for (Class<?> componentType : TypeDiscovery.getComponentTypes(type)) {
+                registerDataType(access, componentType);
+            }
+            dataTypes++;
+        }
+        int converterTypes = 0;
+        for (Class<?> type : TypeDiscovery.getConverterTypes()) {
+            RuntimeReflection.register(type);
+            RuntimeReflection.register(type.getDeclaredConstructors());
+            converterTypes++;
+        }
+        int repositoryTypes = 0;
+        for (Class<?> type : TypeDiscovery.getRepositoryTypes()) {
+            RuntimeProxyCreation.register(type);
+            Class<?> defaultImplementations = access.findClassByName(type.getName() + "$DefaultImpls");
+            if (defaultImplementations != null) {
+                RuntimeReflection.register(defaultImplementations);
+                RuntimeReflection.register(defaultImplementations.getDeclaredMethods());
+            }
+            repositoryTypes++;
+        }
+        System.out.printf(
+                "Storm: registered %d data types, %d converters, and %d repositories from the type index.%n",
+                dataTypes, converterTypes, repositoryTypes);
+    }
+
+    private static void registerDataType(@Nonnull BeforeAnalysisAccess access, @Nonnull Class<?> type) {
+        RuntimeReflection.register(type);
+        RuntimeReflection.register(type.getDeclaredConstructors());
+        RuntimeReflection.register(type.getMethods());
+        // The declared fields include the static Companion instance, which kotlinx.serialization
+        // reads reflectively when it resolves a serializer at runtime.
+        RuntimeReflection.register(type.getDeclaredFields());
+        registerMetamodel(access, type.getName() + "Metamodel");
+        registerMetamodel(access, type.getName() + "NullableMetamodel");
+        // kotlinx.serialization resolves serializers reflectively through the generated companions.
+        registerCompanion(access, type.getName() + "$serializer");
+        registerCompanion(access, type.getName() + "$Companion");
+    }
+
+    private static void registerCompanion(@Nonnull BeforeAnalysisAccess access, @Nonnull String className) {
+        Class<?> companion = access.findClassByName(className);
+        if (companion == null) {
+            return;
+        }
+        RuntimeReflection.register(companion);
+        RuntimeReflection.register(companion.getDeclaredConstructors());
+        RuntimeReflection.register(companion.getMethods());
+        RuntimeReflection.register(companion.getFields());
+    }
+
+    private static void registerMetamodel(@Nonnull BeforeAnalysisAccess access, @Nonnull String className) {
+        Class<?> metamodel = access.findClassByName(className);
+        if (metamodel == null) {
+            return;
+        }
+        RuntimeReflection.register(metamodel);
+        RuntimeReflection.register(metamodel.getFields());
+        RuntimeReflection.register(metamodel.getMethods());
+    }
+}

--- a/storm-core/src/main/java/st/orm/core/spi/TypeDiscovery.java
+++ b/storm-core/src/main/java/st/orm/core/spi/TypeDiscovery.java
@@ -19,6 +19,11 @@ import jakarta.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.net.URL;
 import java.util.*;
 import st.orm.Converter;
@@ -63,6 +68,79 @@ public final class TypeDiscovery {
      */
     public static List<Class<?>> getRepositoryTypes() {
         return loadClasses(REPOSITORY_TYPE);
+    }
+
+    /**
+     * Returns the component types of the given Data type: compound primary keys and inline components
+     * are plain records or data classes that do not appear in the type index themselves, yet they are
+     * introspected the same way as the Data types that carry them. The constructor parameters are
+     * walked recursively; JDK, Kotlin, Jakarta, and Storm types are left out, as their metadata is
+     * covered elsewhere.
+     *
+     * <p>Native-image support builds on this closure: the GraalVM feature and the Spring AOT hints
+     * register these types for reflection alongside the indexed Data types.</p>
+     *
+     * @param type the Data type whose components to resolve.
+     * @return the transitive application-domain component types, excluding the given type itself.
+     * @since 1.13
+     */
+    public static List<Class<?>> getComponentTypes(@Nonnull Class<?> type) {
+        Set<Class<?>> components = new LinkedHashSet<>();
+        collectComponents(type, components);
+        components.remove(type);
+        return List.copyOf(components);
+    }
+
+    private static void collectComponents(@Nonnull Class<?> type, @Nonnull Set<Class<?>> visited) {
+        if (!visited.add(type)) {
+            return;
+        }
+        for (Constructor<?> constructor : type.getDeclaredConstructors()) {
+            for (Type parameterType : constructor.getGenericParameterTypes()) {
+                collectFromType(parameterType, visited);
+            }
+        }
+    }
+
+    /**
+     * Follows a generic constructor parameter type into the application types it mentions: the raw
+     * class itself, and the type arguments of parameterized types such as {@code List<Photo>}, whose
+     * elements are introspected during serialization even though the raw type is a platform type.
+     */
+    private static void collectFromType(@Nonnull Type genericType, @Nonnull Set<Class<?>> visited) {
+        if (genericType instanceof Class<?> cls) {
+            if (isApplicationType(cls)) {
+                collectComponents(cls, visited);
+            }
+        } else if (genericType instanceof ParameterizedType parameterizedType) {
+            collectFromType(parameterizedType.getRawType(), visited);
+            for (Type typeArgument : parameterizedType.getActualTypeArguments()) {
+                collectFromType(typeArgument, visited);
+            }
+        } else if (genericType instanceof WildcardType wildcardType) {
+            for (Type bound : wildcardType.getUpperBounds()) {
+                collectFromType(bound, visited);
+            }
+        } else if (genericType instanceof GenericArrayType genericArrayType) {
+            collectFromType(genericArrayType.getGenericComponentType(), visited);
+        }
+    }
+
+    /**
+     * Whether the type belongs to the application domain rather than to the JDK or the Kotlin runtime,
+     * whose types are covered by their own metadata. Framework types that appear as constructor
+     * parameters, such as {@code Ref}, are interfaces without constructors, so including them is
+     * harmless and keeps the filter from accidentally excluding application packages.
+     */
+    private static boolean isApplicationType(@Nonnull Class<?> type) {
+        if (type.isPrimitive() || type.isArray()) {
+            return false;
+        }
+        String name = type.getName();
+        return !name.startsWith("java.")
+                && !name.startsWith("javax.")
+                && !name.startsWith("jakarta.")
+                && !name.startsWith("kotlin");
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/native-image.properties
+++ b/storm-core/src/main/resources/META-INF/native-image/st.orm/storm-core/native-image.properties
@@ -1,0 +1,1 @@
+Args = --features=st.orm.core.graal.StormFeature

--- a/storm-core/src/test/java/st/orm/core/spi/TypeDiscoveryComponentTest.java
+++ b/storm-core/src/test/java/st/orm/core/spi/TypeDiscoveryComponentTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The component closure backs the native-image registrations: compound primary keys, inline
+ * components, and types reached through generic constructor signatures are introspected like the
+ * Data types that carry them, while JDK and Kotlin platform types are covered by their own metadata.
+ */
+class TypeDiscoveryComponentTest {
+
+    record CityPk(String countryCode, int cityCode) {
+    }
+
+    record Photo(String url) {
+    }
+
+    record Landmark(String name, Photo photo) {
+    }
+
+    record City(CityPk id, String name, BigDecimal area, List<Photo> photos,
+                Map<String, List<Landmark>> landmarksByDistrict) {
+    }
+
+    @Test
+    void componentClosureContainsCompoundKeyAndGenericArguments() {
+        List<Class<?>> components = TypeDiscovery.getComponentTypes(City.class);
+        assertTrue(components.contains(CityPk.class), "compound primary key");
+        assertTrue(components.contains(Photo.class), "generic type argument");
+        assertTrue(components.contains(Landmark.class), "nested generic type argument");
+    }
+
+    @Test
+    void componentClosureWalksComponentsRecursively() {
+        List<Class<?>> components = TypeDiscovery.getComponentTypes(Landmark.class);
+        assertEquals(List.of(Photo.class), components);
+    }
+
+    @Test
+    void componentClosureExcludesTheTypeItselfAndPlatformTypes() {
+        List<Class<?>> components = TypeDiscovery.getComponentTypes(City.class);
+        assertFalse(components.contains(City.class), "the type itself");
+        assertFalse(components.contains(String.class), "JDK value type");
+        assertFalse(components.contains(BigDecimal.class), "JDK value type");
+        assertFalse(components.contains(List.class), "JDK collection type");
+        assertFalse(components.contains(Map.class), "JDK collection type");
+    }
+
+    @Test
+    void componentClosureOfALeafTypeIsEmpty() {
+        assertEquals(List.of(), TypeDiscovery.getComponentTypes(Photo.class));
+    }
+}

--- a/storm-spring/src/main/java/st/orm/spring/impl/StormRuntimeHints.java
+++ b/storm-spring/src/main/java/st/orm/spring/impl/StormRuntimeHints.java
@@ -35,6 +35,7 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.core.DecoratingProxy;
+import st.orm.core.spi.TypeDiscovery;
 
 /**
  * Registers the reachability metadata a Storm application needs to run as a GraalVM native image.
@@ -81,15 +82,18 @@ public class StormRuntimeHints implements RuntimeHintsRegistrar {
     public void registerHints(@Nonnull RuntimeHints hints, @Nullable ClassLoader classLoader) {
         ClassLoader loader = classLoader == null ? StormRuntimeHints.class.getClassLoader() : classLoader;
         for (String typeName : readIndex(loader, DATA_INDEX)) {
-            hints.reflection().registerType(TypeReference.of(typeName),
-                    MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
-                    MemberCategory.INVOKE_PUBLIC_METHODS);
-            hints.reflection().registerType(TypeReference.of(typeName + "Metamodel"),
-                    MemberCategory.PUBLIC_FIELDS,
-                    MemberCategory.INVOKE_PUBLIC_METHODS);
-            hints.reflection().registerType(TypeReference.of(typeName + "NullableMetamodel"),
-                    MemberCategory.PUBLIC_FIELDS,
-                    MemberCategory.INVOKE_PUBLIC_METHODS);
+            registerDataType(hints, typeName);
+            // Compound primary keys and inline components are introspected like the Data types that
+            // carry them but do not appear in the index themselves; resolve them through the shared
+            // closure when the type is loadable.
+            try {
+                Class<?> type = Class.forName(typeName, false, loader);
+                for (Class<?> componentType : TypeDiscovery.getComponentTypes(type)) {
+                    registerDataType(hints, componentType.getName());
+                }
+            } catch (Throwable ignore) {
+                // Entries that do not load still get their hints registered by name above.
+            }
         }
         for (String typeName : readIndex(loader, CONVERTER_INDEX)) {
             hints.reflection().registerType(TypeReference.of(typeName),
@@ -107,6 +111,29 @@ public class StormRuntimeHints implements RuntimeHintsRegistrar {
                     MemberCategory.INVOKE_DECLARED_METHODS,
                     MemberCategory.INVOKE_PUBLIC_METHODS);
         }
+    }
+
+    private static void registerDataType(@Nonnull RuntimeHints hints, @Nonnull String typeName) {
+        // The declared fields include the static Companion instance, which kotlinx.serialization
+        // reads reflectively when it resolves a serializer at runtime.
+        hints.reflection().registerType(TypeReference.of(typeName),
+                MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                MemberCategory.INVOKE_PUBLIC_METHODS,
+                MemberCategory.DECLARED_FIELDS);
+        hints.reflection().registerType(TypeReference.of(typeName + "Metamodel"),
+                MemberCategory.PUBLIC_FIELDS,
+                MemberCategory.INVOKE_PUBLIC_METHODS);
+        hints.reflection().registerType(TypeReference.of(typeName + "NullableMetamodel"),
+                MemberCategory.PUBLIC_FIELDS,
+                MemberCategory.INVOKE_PUBLIC_METHODS);
+        // kotlinx.serialization resolves serializers reflectively through the generated companions.
+        hints.reflection().registerType(TypeReference.of(typeName + "$serializer"),
+                MemberCategory.PUBLIC_FIELDS,
+                MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                MemberCategory.INVOKE_PUBLIC_METHODS);
+        hints.reflection().registerType(TypeReference.of(typeName + "$Companion"),
+                MemberCategory.PUBLIC_FIELDS,
+                MemberCategory.INVOKE_PUBLIC_METHODS);
     }
 
     private static List<String> readIndex(@Nonnull ClassLoader loader, @Nonnull String resourceName) {


### PR DESCRIPTION
Spring applications get the application's entities and repositories registered for native images through the Spring AOT hints in storm-spring (#265). Applications without an AOT phase, such as Ktor services and plain JVM applications, had no equivalent: a native image failed at startup even though the Ktor plugin already discovers repositories through the compile-time type index.

## Changes

**GraalVM feature in storm-core.** `StormFeature` reads the type index at image build time and registers what the Spring AOT hints register: Data types (constructors, methods, fields, metamodel companions), converters, and repository proxy shapes with the Kotlin `$DefaultImpls` classes. It activates through the jar's `native-image.properties` whenever storm-core is on the image classpath, so no configuration is needed; in Spring builds it layers harmlessly with the AOT hints. The `org.graalvm.sdk:nativeimage` API is provided-scope; the class never loads outside an image build. The build prints one line, e.g. `Storm: registered 11 data types, 0 converters, and 11 repositories from the type index.`

**Component closure in `TypeDiscovery.getComponentTypes`**, shared by the feature and the Spring AOT hints, and covered by `TypeDiscoveryComponentTest`:
- Compound primary keys and inline components (e.g. `MovieGenrePk`) are introspected like the Data types that carry them but do not appear in the index; constructor parameters are walked recursively. Previously, Spring applications had to register such classes by hand.
- Generic signatures contribute their type arguments: a `@Json photos: List<Photo>` column reaches `Photo` even though the raw type is a platform type.
- Declared fields and the kotlinx.serialization companions (`$serializer`, `$Companion`) are registered, so runtime serializer lookup for JSON columns works natively.

The domain filter excludes JDK/Kotlin/Jakarta packages only; an earlier `st.orm.` exclusion would have silently dropped application packages like the examples' `st.orm.demo`.

## Verification

**Ktor**: the full IMDB Ktor example (CIO engine) compiled with Oracle GraalVM for JDK 25, with zero Storm-specific configuration in the application. All pages and JSON APIs served natively, all 14 Playwright interface tests green, and on an empty database the Flyway migration plus the complete dataset import (1.5M rows through suspending batch inserts) ran natively in 83 seconds. Startup reports 0.129 seconds including schema validation of all 11 entities.

**Spring regression**: the IMDB Spring Boot example rebuilt against these changes passes all 14 Playwright interface tests, with the feature active alongside the AOT hints.

The storm-core and storm-spring suites pass, including the new component closure test.

Fixes #266