### PR TITLE
feat: declare configuration-cache compatibility for the Gradle plugin

### DIFF
--- a/storm-gradle-plugin/build.gradle.kts
+++ b/storm-gradle-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.plugin.compatibility.compatibility
+
 plugins {
     `java-gradle-plugin`
     id("com.gradle.plugin-publish") version "2.1.1"
@@ -88,6 +90,13 @@ gradlePlugin {
                 "metamodel generation (KSP or annotation processor), Kotlin compiler-plugin variant " +
                 "selection, and Java preview flags."
             tags = listOf("orm", "sql", "database", "persistence", "kotlin", "ksp")
+            // Backed by ConfigurationCacheFunctionalTest and the smoke tests, which build with
+            // --configuration-cache on both language paths.
+            compatibility {
+                features {
+                    configurationCache = true
+                }
+            }
         }
     }
 }

--- a/storm-gradle-plugin/src/functionalTest/java/st/orm/gradle/ConfigurationCacheFunctionalTest.java
+++ b/storm-gradle-plugin/src/functionalTest/java/st/orm/gradle/ConfigurationCacheFunctionalTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.gradle;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Builds with {@code --configuration-cache} on both language paths, backing the compatibility declared in
+ * the plugin metadata. Configuration-cache problems fail the build by default, so a successful first run
+ * proves the plugin's configuration-time wiring is clean, and the second run proves the serialized task
+ * graph round-trips: it must reuse the entry and replay the dump captured at configuration time.
+ */
+public class ConfigurationCacheFunctionalTest {
+
+    @TempDir
+    Path projectDir;
+
+    private GradleRunner runner() {
+        return GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withArguments("stormDump", "--configuration-cache");
+    }
+
+    @Test
+    public void javaPathStoresAndReusesTheConfigurationCache() throws Exception {
+        FunctionalTestSupport.writeProject(projectDir, """
+                plugins {
+                    java
+                    id("st.orm")
+                }
+                """);
+        var first = runner().build();
+        assertTrue(first.getOutput().contains("Configuration cache entry stored."), first.getOutput());
+        assertTrue(first.getOutput().contains("DEP implementation st.orm:storm-bom:"));
+        assertTrue(first.getOutput().contains("DEP implementation st.orm:storm-java21:"));
+        assertTrue(first.getOutput().contains("DEP annotationProcessor st.orm:storm-metamodel-processor:"));
+        assertTrue(first.getOutput().contains("--enable-preview"), "Expected --enable-preview on the Java path.");
+        var second = runner().build();
+        assertTrue(second.getOutput().contains("Reusing configuration cache."), second.getOutput());
+        assertTrue(second.getOutput().contains("DEP implementation st.orm:storm-java21:"),
+                "The cached run must replay the dependencies captured at configuration time.");
+        assertTrue(second.getOutput().contains("--enable-preview"),
+                "The cached run must replay the preview flags captured at configuration time.");
+    }
+
+    @Test
+    public void kotlinPathStoresAndReusesTheConfigurationCache() throws Exception {
+        FunctionalTestSupport.writeProject(projectDir, """
+                plugins {
+                    id("org.jetbrains.kotlin.jvm") version "2.4.0"
+                    id("com.google.devtools.ksp") version "2.3.10"
+                    id("st.orm")
+                }
+                """);
+        var first = runner().build();
+        assertTrue(first.getOutput().contains("Configuration cache entry stored."), first.getOutput());
+        assertTrue(first.getOutput().contains("DEP implementation st.orm:storm-kotlin:"));
+        assertTrue(first.getOutput().contains("DEP ksp st.orm:storm-metamodel-ksp:"));
+        assertTrue(first.getOutput().contains("DEP kotlinCompilerPluginClasspath st.orm:storm-compiler-plugin-"));
+        var second = runner().build();
+        assertTrue(second.getOutput().contains("Reusing configuration cache."), second.getOutput());
+        assertTrue(second.getOutput().contains("DEP implementation st.orm:storm-kotlin:"),
+                "The cached run must replay the dependencies captured at configuration time.");
+    }
+}

--- a/storm-gradle-plugin/src/functionalTest/java/st/orm/gradle/FunctionalTestSupport.java
+++ b/storm-gradle-plugin/src/functionalTest/java/st/orm/gradle/FunctionalTestSupport.java
@@ -22,7 +22,9 @@ import java.nio.file.Path;
 /**
  * Helpers for TestKit projects. The generated build script registers a {@code stormDump} task that queries
  * the declared dependencies (triggering the plugin's dependency callbacks without resolving artifacts) and
- * prints the compiler argument providers, so assertions run offline and fast.
+ * prints the compiler argument providers, so assertions run offline and fast. The dump is captured at
+ * configuration time and the task action only replays the captured lines, so the task itself is
+ * configuration-cache compatible and the same assertions hold on a cache-reusing run.
  */
 final class FunctionalTestSupport {
 
@@ -39,15 +41,18 @@ final class FunctionalTestSupport {
     static final String DUMP_TASK = """
 
             tasks.register("stormDump") {
-                doLast {
+                val lines = buildList {
                     listOf("implementation", "runtimeOnly", "annotationProcessor", "ksp", "kotlinCompilerPluginClasspath").forEach { name ->
                         configurations.findByName(name)?.incoming?.dependencies?.forEach { d ->
-                            println("DEP $name ${d.group}:${d.name}:${d.version}")
+                            add("DEP $name ${d.group}:${d.name}:${d.version}")
                         }
                     }
                     tasks.withType(JavaCompile::class).forEach { t ->
-                        println("ARGS ${t.name} " + t.options.compilerArgumentProviders.flatMap { it.asArguments() })
+                        add("ARGS ${t.name} " + t.options.compilerArgumentProviders.flatMap { it.asArguments() })
                     }
+                }
+                doLast {
+                    lines.forEach { println(it) }
                 }
             }
             """;

--- a/storm-gradle-plugin/src/functionalTest/java/st/orm/gradle/SmokeCompileTest.java
+++ b/storm-gradle-plugin/src/functionalTest/java/st/orm/gradle/SmokeCompileTest.java
@@ -25,14 +25,23 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Compiles a real Kotlin project against the locally installed Storm snapshot artifacts and asserts the
- * KSP-generated metamodel exists. Requires a prior {@code mvn install -DskipTests} of the reactor; gated
- * behind {@code -Dstorm.smoke=true}.
+ * Compiles real Kotlin and Java projects against the locally installed Storm snapshot artifacts and asserts
+ * the generated metamodel exists. Both builds run with {@code --configuration-cache} and run twice, so the
+ * full task graph (KSP respectively the annotation processor and the preview-flag argument providers) is
+ * proven to serialize and be reusable. Requires a prior {@code mvn install -DskipTests} of the reactor;
+ * gated behind {@code -Dstorm.smoke=true}.
  */
 public class SmokeCompileTest {
 
     @TempDir
     Path projectDir;
+
+    private GradleRunner runner() {
+        return GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withArguments("build", "-x", "test", "--configuration-cache");
+    }
 
     @Test
     @EnabledIfSystemProperty(named = "storm.smoke", matches = "true")
@@ -65,15 +74,55 @@ public class SmokeCompileTest {
                     val name: String,
                 ) : Entity<Int>
                 """);
-        var result = GradleRunner.create()
-                .withProjectDir(projectDir.toFile())
-                .withPluginClasspath()
-                .withArguments("build", "-x", "test")
-                .build();
+        var result = runner().build();
         assertTrue(result.getOutput().contains("BUILD SUCCESSFUL"), result.getOutput());
+        assertTrue(result.getOutput().contains("Configuration cache entry stored."), result.getOutput());
         try (var generated = Files.walk(projectDir.resolve("build/generated/ksp"))) {
             assertTrue(generated.anyMatch(path -> path.getFileName().toString().startsWith("City_")),
                     "Expected a generated City_ metamodel under build/generated/ksp.");
         }
+        var second = runner().build();
+        assertTrue(second.getOutput().contains("Reusing configuration cache."), second.getOutput());
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "storm.smoke", matches = "true")
+    public void compilesAJavaEntityAndGeneratesTheMetamodel() throws Exception {
+        Files.writeString(projectDir.resolve("settings.gradle.kts"), FunctionalTestSupport.SETTINGS);
+        Files.writeString(projectDir.resolve("build.gradle.kts"), """
+                plugins {
+                    java
+                    id("st.orm")
+                }
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                }
+                java {
+                    toolchain {
+                        languageVersion = JavaLanguageVersion.of(21)
+                    }
+                }
+                """);
+        var sourceDir = projectDir.resolve("src/main/java/demo");
+        Files.createDirectories(sourceDir);
+        Files.writeString(sourceDir.resolve("City.java"), """
+                package demo;
+
+                import st.orm.Entity;
+                import st.orm.PK;
+
+                public record City(@PK Integer id, String name) implements Entity<Integer> {
+                }
+                """);
+        var result = runner().build();
+        assertTrue(result.getOutput().contains("BUILD SUCCESSFUL"), result.getOutput());
+        assertTrue(result.getOutput().contains("Configuration cache entry stored."), result.getOutput());
+        try (var generated = Files.walk(projectDir.resolve("build/generated/sources/annotationProcessor"))) {
+            assertTrue(generated.anyMatch(path -> path.getFileName().toString().startsWith("City_")),
+                    "Expected a generated City_ metamodel under build/generated/sources/annotationProcessor.");
+        }
+        var second = runner().build();
+        assertTrue(second.getOutput().contains("Reusing configuration cache."), second.getOutput());
     }
 }


### PR DESCRIPTION
Declares Gradle Configuration cache compatibility for the `st.orm` plugin, backed by functional-test coverage rather than a bare flag.

## What changed

- **Plugin metadata** (`build.gradle.kts`): `compatibility { features { configurationCache = true } }` on the plugin declaration. This writes `compatibility.feature.configuration-cache=DECLARED_SUPPORTED` into `META-INF/gradle-plugins/st.orm.properties`, which the Plugin Portal reads on publish. In Kotlin DSL the block is an extension function from `org.gradle.plugin:compatibility-plugin` (auto-applied by plugin-publish 2.1.x) and needs an explicit `import org.gradle.plugin.compatibility.compatibility`.
- **`ConfigurationCacheFunctionalTest`** (new): builds with `--configuration-cache` on both language paths. Configuration-cache problems fail the build by default on Gradle 9, so a green first run proves the plugin's configuration-time wiring is clean; the second run must reuse the entry and replay the dependency dump captured at configuration time.
- **`SmokeCompileTest`**: the real compiles against the locally installed snapshots now run with `--configuration-cache`, twice each, so the full task graph (KSP respectively the annotation processor and the preview-flag argument providers) is proven to serialize and be reusable. A Java-path smoke test joins the existing Kotlin one: a `record` entity compiled with the metamodel annotation processor and `--enable-preview`, asserting the generated `City_` metamodel.
- **`FunctionalTestSupport`**: the `stormDump` helper task previously read `configurations` and `tasks` inside `doLast`; it now captures the dump at configuration time and the action only replays strings, making the helper itself configuration-cache compatible.

`StormPlugin` needed no changes: all of its wiring (dependency callbacks, `afterEvaluate` validations, Kotlin version detection) runs at configuration time, and `PreviewArgs` only carries a serializable `Provider`.

## Verification

`./gradlew build -Dstorm.smoke=true` (the CI invocation) is green: 16 functional tests including both new configuration-cache tests and both smoke compiles with store + reuse. The built jar's plugin descriptor contains `compatibility.feature.configuration-cache=DECLARED_SUPPORTED`.

The remaining acceptance criterion, the Portal dropping its "consider declaring compatibility" suggestion, can only be observed on the next publish; the descriptor change rides along with whichever version is uploaded next.

Fixes #248