### PR TITLE
fix(website): complete HTML attribute escaping in the editor component

### DIFF
--- a/website/src/components/tutorial/tutorialTheme.js
+++ b/website/src/components/tutorial/tutorialTheme.js
@@ -122,7 +122,7 @@ export function editor({file, tag, code, sql, copy, variants}) {
           const paneCopy = v.copy || (copy === true ? toPlain(v.code) : null);
           return `<div class="codearea varpane${i === selectedIdx ? ' on' : ''}"${
             paneCopy ? ` data-copy="${esc(paneCopy).replace(/"/g, '&quot;')}"` : ''
-          }${v.tag ? ` data-tag="${esc(v.tag)}"` : ''}${v.file ? ` data-file="${esc(v.file)}"` : ''}>${pane(v.code)}</div>`;
+          }${v.tag ? ` data-tag="${esc(v.tag).replace(/"/g, '&quot;')}"` : ''}${v.file ? ` data-file="${esc(v.file).replace(/"/g, '&quot;')}"` : ''}>${pane(v.code)}</div>`;
         })
         .join('')
     : `<div class="codearea">${pane(code)}</div>`;


### PR DESCRIPTION
Resolves the two CodeQL `js/incomplete-html-attribute-sanitization` alerts (medium) in `website/src/components/tutorial/tutorialTheme.js`.

The per-variant `data-tag` and `data-file` attributes on code blocks were built with `esc()`, which escapes `&`, `<`, `>` but not the `"` that delimits the attribute. Escape `"` to `&quot;`, matching the adjacent `data-copy` attribute.

In practice these values are static (`Kotlin`/`Java`, filenames), so there is no exploitable injection; this completes the sanitization pattern and clears the alerts.