### PR TITLE
fix(website): drop unweighted benchmark averages for per-workload counts

### DIFF
--- a/website/src/pages/benchmarks.js
+++ b/website/src/pages/benchmarks.js
@@ -856,18 +856,9 @@ function matrixHtml() {
     }).join('');
     return `<tr><th>${w.title}</th>${cells}</tr>`;
   }).join('\n');
-  // Average overhead over raw JDBC per library, across all workloads.
-  const avgRatio = (lib) => WORKLOADS.reduce((sum, w) => sum + w.results[lib][0] / w.results.jdbc[0], 0) / WORKLOADS.length;
-  const bestAvg = Math.min(...MATRIX_LIBS.filter((l) => l !== 'jdbc').map(avgRatio));
-  const avgCells = MATRIX_LIBS.map((lib) => {
-    if (lib === 'jdbc') return `<td class="bm-floor">baseline</td>`;
-    const avg = avgRatio(lib);
-    return `<td style="${heatStyle(avg / bestAvg)}"><b>+${Math.round((avg - 1) * 100)}%</b></td>`;
-  }).join('');
   return `<div class="bm-matrix-wrap"><table class="bm-matrix">
     <thead><tr><th></th>${head}</tr></thead>
-    <tbody>${rows}<tr class="bm-gap" aria-hidden="true"><td colspan="8"></td></tr></tbody>
-    <tfoot><tr><th>Average over JDBC</th>${avgCells}</tr></tfoot>
+    <tbody>${rows}</tbody>
   </table></div>`;
 }
 
@@ -947,13 +938,13 @@ ${navHtml('benchmarks')}
   <div class="bm-stats">
     <div class="bm-stat"><b>5 of 8</b><span>workloads where Storm is the fastest ORM.</span></div>
     <div class="bm-stat"><b>5.6%</b><span>is the most Storm trails the fastest ORM on any workload.</span></div>
-    <div class="bm-stat"><b>62% lower</b><span>overhead than jOOQ (2nd fastest ORM) relative to raw JDBC.</span></div>
+    <div class="bm-stat"><b>72% less</b><span>entity code than JPA: the five-table model is 29 lines in Storm, 105 as JPA entities.</span></div>
   </div>
 
   <h2>At a glance</h2>
   <p>Seven implementations, one database, one discipline: same schema, same data, same transaction boundaries, every score a real network round trip away from PostgreSQL. Mean latency per operation, lower is better. Cells are tinted by distance from the fastest framework in the row, green through red. Percentages are overhead over raw JDBC. Raw JDBC is the baseline.</p>
   ${matrixHtml()}
-  <p class="bm-matrix-read">Storm is the fastest framework on average across the eight workloads. On a few, another library edges it: Hibernate on the single-row lookup and the read-modify-update, jOOQ on the batch insert, where its single multi-row statement beats the batched single-row insert the others send. Even then, Storm stays within about six percent of the fastest framework. A real network round trip sits inside every score, so the pure mapping gap is larger still. Absolute times depend on the hardware they were measured on; the relative comparisons are the point.</p>
+  <p class="bm-matrix-read">On most workloads Storm is the fastest framework; where it isn't, another library edges it narrowly: Hibernate on the single-row lookup and the read-modify-update, jOOQ on the batch insert, where its single multi-row statement beats the batched single-row insert the others send. Even then, Storm stays within about six percent of the fastest framework. A real network round trip sits inside every score, so the pure mapping gap is larger still. Absolute times depend on the hardware they were measured on; the relative comparisons are the point.</p>
 
   <details class="bm-details">
     <summary>Per-workload charts: the same numbers with their reported error</summary>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -364,27 +364,27 @@ export default function Home() {
     // Pick your ORM: the feature cards show Storm-vs-X measured figures (run of 2026-07-16).
     const VS = {
       hibernate: {
-        speed: ['17%', 'faster than Hibernate', 'On average across 8 workloads.'],
+        speed: ['6 of 8', 'workloads faster than Hibernate', 'Behind only on the primary-key lookup (+1%) and read-modify-update (+1%).'],
         entities: ['72%', 'fewer entity lines', 'The five-table model: 29 lines in Storm, 105 in Hibernate.'],
         queries: ['19%', 'fewer query lines', 'All eight workloads: 100 lines in Storm, 123 in Hibernate, with no query strings.'],
       },
       jooq: {
-        speed: ['15%', 'faster than jOOQ', 'On average across 8 workloads.'],
+        speed: ['7 of 8', 'workloads faster than jOOQ', 'Behind only on the batch insert (+6%), where jOOQ sends one multi-row statement.'],
         entities: ['29 lines', 'instead of manual mapping', 'jOOQ maps results by hand into DTOs; Storm turns one 29-line model into typed rows everywhere.'],
         queries: ['24%', 'fewer query lines', 'All eight workloads: 100 lines in Storm, 131 in jOOQ, no hand-written row mapping.'],
       },
       exposed: {
-        speed: ['18%', 'faster than Exposed', 'On average across 8 workloads.'],
+        speed: ['7 of 8', 'workloads faster than Exposed', 'Behind only on read-modify-update (+1%).'],
         entities: ['43%', 'fewer entity lines', 'The five-table model: 29 lines in Storm, 51 lines of Exposed table objects and data classes.'],
         queries: ['22%', 'fewer query lines', 'All eight workloads: 100 lines in Storm, 128 in Exposed, no hand-written row mapping.'],
       },
       exposedDao: {
-        speed: ['38%', 'faster than Exposed DAO', 'On average across 8 workloads.'],
+        speed: ['8 of 8', 'workloads faster than Exposed DAO', 'Faster on every workload measured.'],
         entities: ['58%', 'fewer entity lines', 'One data class per table in Storm; Exposed DAO needs the table object, the DAO class and a DTO.'],
         queries: ['19%', 'fewer query lines', 'All eight workloads: 100 lines in Storm, 124 in Exposed DAO.'],
       },
       jimmer: {
-        speed: ['25%', 'faster than Jimmer', 'On average across 8 workloads.'],
+        speed: ['7 of 8', 'workloads faster than Jimmer', 'Faster on seven; dead even on the primary-key lookup.'],
         entities: ['47%', 'fewer entity lines', 'The five-table model: 29 lines of data classes in Storm, 55 lines of interfaces in Jimmer.'],
         queries: ['31%', 'fewer query lines', 'All eight workloads: 100 lines in Storm, 144 in Jimmer.'],
       },


### PR DESCRIPTION
## Summary

The benchmark page and homepage reported unweighted averages of per-workload overhead ratios. Averaging a ratio across workloads of very different absolute cost (an 8x-costlier join counted the same as a cheap primary-key lookup) is not meaningful, so these are replaced with per-workload counts.

- **Benchmarks page**: drop the "Average over JDBC" matrix footer, and replace the average-overhead stat card with the entity-code line count. The matrix summary no longer claims "fastest on average".
- **Homepage cards**: each now states how many of the eight workloads Storm is faster than the selected library, and by how much it trails on the rest — e.g. "6 of 8 workloads faster than Hibernate", "behind only on the primary-key lookup (+1%) and read-modify-update (+1%)" — instead of an averaged percentage. "workloads" is spelled out so the count can't be misread as a speed multiple.
