### PR TITLE
feat(website): give tag chips a metallic finish and drop the benchmarks CTA

### DIFF
--- a/website/src/components/tutorial/tutorialTheme.js
+++ b/website/src/components/tutorial/tutorialTheme.js
@@ -472,11 +472,13 @@ export const TUT_CSS = `
   .storm-tut .tuthero{max-width:1080px;margin:0 auto;padding:64px 24px 6px}
   .storm-tut .tuthero .sub{color:var(--muted);font-size:17.5px;line-height:1.66;margin:20px 0 0;max-width:700px}
   .storm-tut .catnav{display:flex;gap:10px;margin-top:28px;flex-wrap:wrap}
-  .storm-tut .catnav a{font-family:var(--mono);font-size:12.5px;color:#b1b5da;border:1px solid rgba(129,140,248,.20);border-radius:999px;padding:8px 16px;transition:.16s;background:rgba(129,140,248,.07);cursor:pointer}
-  .storm-tut .catnav a:hover{color:#e9eaf7;border-color:rgba(129,140,248,.45);background:rgba(129,140,248,.13)}
-  .storm-tut .catnav a.on{color:#0a0a0f;background:var(--accent);border-color:var(--accent);font-weight:600}
+  .storm-tut .catnav a{font-family:var(--mono);font-size:12.5px;color:#b1b5da;border:1px solid transparent;border-radius:999px;padding:8px 16px;transition:color .16s ease,box-shadow .16s ease;cursor:pointer;
+    background:linear-gradient(#10101a,#10101a) padding-box,linear-gradient(150deg,#4a4e74 0%,#3c3e62 22%,#2d2e47 46%,#27273d 54%,#383a62 74%,#454877 92%,#313352 100%) border-box}
+  .storm-tut .catnav a:hover{color:#e9eaf7;box-shadow:0 0 9px rgba(129,140,248,.12)}
+  .storm-tut .catnav a.on{color:#d8cdff;font-weight:600;box-shadow:0 0 9px rgba(129,140,248,.12);
+    background:linear-gradient(#211d44,#211d44) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
   .storm-tut .catnav a b{color:rgba(178,182,220,.55);font-weight:500;margin-left:7px}
-  .storm-tut .catnav a.on b{color:rgba(10,10,15,.55)}
+  .storm-tut .catnav a.on b{color:rgba(215,220,255,.5)}
   .storm-tut .shead{max-width:1080px;margin:0 auto;padding:52px 24px 0;font-family:var(--mono);font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--text);scroll-margin-top:86px}
   .storm-tut .shead .mark{color:var(--accent);margin-right:10px}
   .storm-tut .shead .sdesc{display:block;margin-top:9px;font-family:var(--sans);font-size:14.5px;letter-spacing:0;text-transform:none;color:var(--muted);line-height:1.6}

--- a/website/src/pages/benchmarks.js
+++ b/website/src/pages/benchmarks.js
@@ -926,10 +926,6 @@ const BM_CSS = `
   .bm-limits{border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:12px;background:var(--panel-2);padding:16px 20px;margin:8px 0 24px}
   .storm-tut .art .bm-limits h3{margin:0 0 6px;font-size:15px}
   .bm-limits p{margin:0;color:var(--muted);font-size:13.5px;line-height:1.6}
-  .bm-cta{border:1px solid var(--border);border-radius:16px;background:var(--panel);padding:30px 32px;margin:46px 0 10px}
-  .storm-tut .art .bm-cta h2{margin:0 0 8px}
-  .bm-cta p{margin:0;color:var(--muted);max-width:640px}
-  .bm-cta .getit{margin-top:20px}
 `;
 
 // One workload: Storm's implementation shows by default; the other six are a
@@ -1122,14 +1118,6 @@ ${charts}
     <a class="btn" href="https://github.com/storm-orm/storm-benchmarks" target="_blank" rel="noopener">View on GitHub →</a>
   </div>
 
-  <div class="bm-cta">
-    <h2>See how the API feels</h2>
-    <p>Performance matters most when the programming model also fits your application. Explore the Storm documentation or build the example application yourself.</p>
-    <div class="getit">
-      <a class="btn primary" href="/quickstart">Get started</a>
-      <a class="btn" href="https://github.com/storm-orm/storm-benchmarks" target="_blank" rel="noopener">View benchmark source</a>
-    </div>
-  </div>
 </div>
 
 ${FOOT_HTML}

--- a/website/src/pages/blog/index.js
+++ b/website/src/pages/blog/index.js
@@ -137,11 +137,13 @@ const filterBar = `
 
 const BLOG_FILTER_CSS = `
   .storm-tut .bfilters{display:flex;gap:12px;flex-wrap:wrap;margin-top:28px}
-  .storm-tut .bchip{font-family:var(--mono);font-size:12.5px;color:#b1b5da;border:1px solid rgba(129,140,248,.20);border-radius:999px;padding:8px 16px;background:rgba(129,140,248,.07);cursor:pointer;transition:.16s;line-height:1}
-  .storm-tut .bchip:hover{color:#e9eaf7;border-color:rgba(129,140,248,.45);background:rgba(129,140,248,.13)}
-  .storm-tut .bchip.on{color:#0a0a0f;background:var(--accent);border-color:var(--accent);font-weight:600}
+  .storm-tut .bchip{font-family:var(--mono);font-size:12.5px;color:#b1b5da;border:1px solid transparent;border-radius:999px;padding:8px 16px;cursor:pointer;transition:color .16s ease,box-shadow .16s ease;line-height:1;
+    background:linear-gradient(#10101a,#10101a) padding-box,linear-gradient(150deg,#4a4e74 0%,#3c3e62 22%,#2d2e47 46%,#27273d 54%,#383a62 74%,#454877 92%,#313352 100%) border-box}
+  .storm-tut .bchip:hover{color:#e9eaf7;box-shadow:0 0 9px rgba(129,140,248,.12)}
+  .storm-tut .bchip.on{color:#d8cdff;font-weight:600;box-shadow:0 0 9px rgba(129,140,248,.12);
+    background:linear-gradient(#211d44,#211d44) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
   .storm-tut .bchip b{color:rgba(178,182,220,.55);font-weight:500;margin-left:7px}
-  .storm-tut .bchip.on b{color:rgba(10,10,15,.55)}
+  .storm-tut .bchip.on b{color:rgba(215,220,255,.5)}
 `;
 
 // Wires the filter chips: clicking one highlights it and shows only the cards

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -52,9 +52,11 @@ const CSS = `
   .storm-home .grad{background:linear-gradient(100deg,#a78bfa,#818cf8 50%,#7dd3fc);-webkit-background-clip:text;background-clip:text;color:transparent}
   .storm-home .vs-chips{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:18px}
   .storm-home .vs-label{font-size:12.5px;color:var(--faint);margin-right:2px}
-  .storm-home .vs-chips button{font-family:var(--mono);font-size:11.5px;color:var(--faint);border:1px solid var(--border-soft);background:none;border-radius:999px;padding:6px 12px;cursor:pointer;transition:all .15s ease}
-  .storm-home .vs-chips button:hover{color:var(--muted);border-color:var(--border)}
-  .storm-home .vs-chips button.on{color:#feeeb0;border-color:rgba(251,191,36,.65);background:rgba(251,191,36,.14);box-shadow:0 0 14px rgba(251,191,36,.18);font-weight:700}
+  .storm-home .vs-chips button{font-family:var(--mono);font-size:11.5px;color:var(--faint);border:1px solid transparent;border-radius:999px;padding:6px 12px;cursor:pointer;transition:color .15s ease,box-shadow .15s ease;
+    background:linear-gradient(var(--bg),var(--bg)) padding-box,linear-gradient(150deg,#5c5233 0%,#4a4026 22%,#382e15 46%,#2e2610 54%,#443a22 74%,#574d31 92%,#3c3319 100%) border-box}
+  .storm-home .vs-chips button:hover{color:var(--muted);box-shadow:0 0 6px rgba(251,191,36,.05)}
+  .storm-home .vs-chips button.on{color:#feeeb0;font-weight:700;box-shadow:0 0 8px rgba(251,191,36,.09);
+    background:linear-gradient(#1c1608,#1c1608) padding-box,linear-gradient(150deg,#ad9b63 0%,#8a6e30 22%,#6a531b 48%,#5f4c18 54%,#8a7030 74%,#ab965c 92%,#715e24 100%) border-box}
   .storm-home .vs-bench{margin-left:auto;font-size:12.5px;font-weight:600;color:#fbbf24;text-decoration:none;white-space:nowrap}
   .storm-home .vs-bench:hover{text-decoration:underline;color:#feeeb0}
   .storm-home .card.bcard{padding:18px 22px}
@@ -186,10 +188,12 @@ const CSS = `
   .storm-home .statusbar .right{color:var(--faint);letter-spacing:.05em}
 
   .storm-home .scenes{display:flex;gap:8px;margin-top:22px;flex-wrap:wrap}
-  .storm-home .scenes .s{font-family:var(--mono);font-size:11.5px;color:var(--faint);border:1px solid var(--border-soft);
-    border-radius:999px;padding:5px 13px;transition:.2s;cursor:pointer}
-  .storm-home .scenes .s:hover{color:var(--muted);border-color:var(--border)}
-  .storm-home .scenes .s.on{color:var(--accent);border-color:rgba(129,140,248,.4);background:rgba(129,140,248,.08)}
+  .storm-home .scenes .s{font-family:var(--mono);font-size:11.5px;color:var(--faint);border:1px solid transparent;
+    border-radius:999px;padding:5px 13px;transition:color .2s ease,box-shadow .2s ease;cursor:pointer;
+    background:linear-gradient(var(--bg),var(--bg)) padding-box,linear-gradient(150deg,#4a4e74 0%,#3c3e62 22%,#2d2e47 46%,#27273d 54%,#383a62 74%,#454877 92%,#313352 100%) border-box}
+  .storm-home .scenes .s:hover{color:var(--muted);box-shadow:0 0 8px rgba(129,140,248,.10)}
+  .storm-home .scenes .s.on{color:#d8cdff;box-shadow:0 0 10px rgba(129,140,248,.14);
+    background:linear-gradient(#211d44,#211d44) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
 
   .storm-home .code-k{color:var(--kw)}.storm-home .code-t{color:var(--type)}.storm-home .code-s{color:var(--str)}.storm-home .code-c{color:var(--com)}
   .storm-home .code-f{color:var(--fn)}.storm-home .code-n{color:var(--num)}.storm-home .code-a{color:var(--anno)}.storm-home .code-pl{color:var(--plain)}.storm-home .code-m{color:var(--muted)}
@@ -198,7 +202,10 @@ const CSS = `
   .storm-home .dbstrip{padding:30px 0}
   .storm-home .db-label{text-align:center;font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--faint);margin-bottom:18px}
   .storm-home .dbs{display:flex;flex-wrap:wrap;gap:10px;justify-content:center}
-  .storm-home .dbs span{font-family:var(--mono);font-size:13px;color:var(--muted);background:var(--panel-2);border:1px solid var(--border-soft);border-radius:8px;padding:7px 14px}
+  .storm-home .dbs span{font-family:var(--mono);font-size:13px;color:var(--muted);border:1px solid transparent;border-radius:8px;padding:7px 14px;
+    background:linear-gradient(var(--panel-2),var(--panel-2)) padding-box,linear-gradient(150deg,#5c6069 0%,#474b53 24%,#33363d 48%,#2c2f36 54%,#42464e 74%,#565a62 92%,#383b43 100%) border-box;
+    transition:box-shadow .18s ease,color .18s ease}
+  .storm-home .dbs span:hover{color:var(--text);box-shadow:0 0 7px rgba(214,219,229,.05)}
   .storm-home .strips{display:flex;flex-wrap:wrap;justify-content:center;align-items:flex-start;gap:34px 64px}
   .storm-home .strip-col{display:flex;flex-direction:column;align-items:center}
   .storm-home .three{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}


### PR DESCRIPTION
## Summary

- **Metallic tag chips.** The pill/tag chips across the site now use a subtle low-contrast gradient border instead of the previous flat borders: silver for the database list, gold for the benchmark comparison chips, and indigo for the scene selector plus the blog and tutorial category pills.
- **Consistent selected state.** The selected (`.on`) pill lights up with a brighter gradient border, a soft tinted fill and a lighter label rather than a flat solid fill, so the active state reads the same way across every chip group.
- **Benchmarks page.** Removed the "See how the API feels" block at the foot of the benchmarks page along with its now-unused `.bm-cta` styles.

## Files

- `website/src/pages/index.js` — database (silver) and benchmark (gold) chips, scene selector pills
- `website/src/pages/blog/index.js` — blog category pills
- `website/src/components/tutorial/tutorialTheme.js` — tutorial category pills
- `website/src/pages/benchmarks.js` — CTA removal

## Verifying

- Homepage: the database strip, the "Benchmark against" chips, and the scene selector under the code editor
- `/blog`: the category filter chips (select one to see the highlight)
- `/tutorials`: the category nav chips
- `/benchmarks`: the closing CTA block is gone