### PR TITLE
feat(website): refine the selected pill highlight

### DIFF
--- a/website/src/components/tutorial/tutorialTheme.js
+++ b/website/src/components/tutorial/tutorialTheme.js
@@ -475,8 +475,8 @@ export const TUT_CSS = `
   .storm-tut .catnav a{font-family:var(--mono);font-size:12.5px;color:#b1b5da;border:1px solid transparent;border-radius:999px;padding:8px 16px;transition:color .16s ease,box-shadow .16s ease;cursor:pointer;
     background:linear-gradient(#10101a,#10101a) padding-box,linear-gradient(150deg,#4a4e74 0%,#3c3e62 22%,#2d2e47 46%,#27273d 54%,#383a62 74%,#454877 92%,#313352 100%) border-box}
   .storm-tut .catnav a:hover{color:#e9eaf7;box-shadow:0 0 9px rgba(129,140,248,.12)}
-  .storm-tut .catnav a.on{color:#d8cdff;font-weight:600;box-shadow:0 0 9px rgba(129,140,248,.12);
-    background:linear-gradient(#211d44,#211d44) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
+  .storm-tut .catnav a.on{color:#f2ecff;font-weight:600;box-shadow:0 0 9px rgba(129,140,248,.12);
+    background:linear-gradient(#131028,#131028) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
   .storm-tut .catnav a b{color:rgba(178,182,220,.55);font-weight:500;margin-left:7px}
   .storm-tut .catnav a.on b{color:rgba(215,220,255,.5)}
   .storm-tut .shead{max-width:1080px;margin:0 auto;padding:52px 24px 0;font-family:var(--mono);font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--text);scroll-margin-top:86px}

--- a/website/src/pages/blog/index.js
+++ b/website/src/pages/blog/index.js
@@ -140,8 +140,8 @@ const BLOG_FILTER_CSS = `
   .storm-tut .bchip{font-family:var(--mono);font-size:12.5px;color:#b1b5da;border:1px solid transparent;border-radius:999px;padding:8px 16px;cursor:pointer;transition:color .16s ease,box-shadow .16s ease;line-height:1;
     background:linear-gradient(#10101a,#10101a) padding-box,linear-gradient(150deg,#4a4e74 0%,#3c3e62 22%,#2d2e47 46%,#27273d 54%,#383a62 74%,#454877 92%,#313352 100%) border-box}
   .storm-tut .bchip:hover{color:#e9eaf7;box-shadow:0 0 9px rgba(129,140,248,.12)}
-  .storm-tut .bchip.on{color:#d8cdff;font-weight:600;box-shadow:0 0 9px rgba(129,140,248,.12);
-    background:linear-gradient(#211d44,#211d44) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
+  .storm-tut .bchip.on{color:#f2ecff;font-weight:600;box-shadow:0 0 9px rgba(129,140,248,.12);
+    background:linear-gradient(#131028,#131028) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
   .storm-tut .bchip b{color:rgba(178,182,220,.55);font-weight:500;margin-left:7px}
   .storm-tut .bchip.on b{color:rgba(215,220,255,.5)}
 `;

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -192,8 +192,8 @@ const CSS = `
     border-radius:999px;padding:5px 13px;transition:color .2s ease,box-shadow .2s ease;cursor:pointer;
     background:linear-gradient(var(--bg),var(--bg)) padding-box,linear-gradient(150deg,#4a4e74 0%,#3c3e62 22%,#2d2e47 46%,#27273d 54%,#383a62 74%,#454877 92%,#313352 100%) border-box}
   .storm-home .scenes .s:hover{color:var(--muted);box-shadow:0 0 8px rgba(129,140,248,.10)}
-  .storm-home .scenes .s.on{color:#d8cdff;box-shadow:0 0 10px rgba(129,140,248,.14);
-    background:linear-gradient(#211d44,#211d44) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
+  .storm-home .scenes .s.on{color:#f2ecff;box-shadow:0 0 10px rgba(129,140,248,.14);
+    background:linear-gradient(#131028,#131028) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
 
   .storm-home .code-k{color:var(--kw)}.storm-home .code-t{color:var(--type)}.storm-home .code-s{color:var(--str)}.storm-home .code-c{color:var(--com)}
   .storm-home .code-f{color:var(--fn)}.storm-home .code-n{color:var(--num)}.storm-home .code-a{color:var(--anno)}.storm-home .code-pl{color:var(--plain)}.storm-home .code-m{color:var(--muted)}


### PR DESCRIPTION
Follow-up to #284.

Tunes the selected (`.on`) state of the tag/category pills so the active
pill reads more clearly:

- **Quieter fill.** The selected fill drops from `#211d44` to a darker `#131028`, so it lifts only slightly from the resting state (closer to the gold chips' restraint).
- **Brighter label.** The selected label goes from `#d8cdff` to `#f2ecff` (near-white with a faint lavender tint) so it stands out against the subtler fill.

Applied consistently to the homepage scene selector, the blog category chips, and the tutorial category nav.

## Verifying

- Homepage: scene selector pills under the code editor
- `/blog`: click a category filter chip
- `/tutorials`: the category nav chips