### PR TITLE
docs: use the Gradle plugin for setup across docs and site

### DIFF
--- a/docs/api-kotlin.md
+++ b/docs/api-kotlin.md
@@ -86,7 +86,7 @@ There are two ways to configure metamodel generation for Kotlin projects, depend
 - **Gradle with KSP:** Use `storm-metamodel-ksp`, which is a Kotlin Symbol Processing plugin.
 - **Maven with kapt:** Use `storm-metamodel-processor`, which is a standard Java annotation processor invoked through kapt.
 
-Both generate the same metamodel classes; they are different build tool integrations.
+Both generate the same metamodel classes; they are different build tool integrations. The [Storm Gradle plugin](installation.md#gradle-plugin-recommended) wires the KSP path for you; the setup below is for Maven and for Gradle users who configure it explicitly.
 
 **Gradle (Kotlin DSL) with KSP:**
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -349,7 +349,7 @@ try (var stream = userRepository.select().getResultStream()) {
 
 **Fix:**
 
-For **Kotlin with Gradle**, add the KSP plugin and processor dependency:
+For **Kotlin with Gradle**, the simplest fix is to apply the [Storm Gradle plugin](installation.md#gradle-plugin-recommended), which wires the KSP processor automatically. If you configure it manually, add the KSP plugin and processor dependency:
 
 ```kotlin
 plugins {

--- a/docs/graalvm.md
+++ b/docs/graalvm.md
@@ -54,7 +54,7 @@ Add the GraalVM build plugin next to the Storm plugin and compile:
 plugins {
     id("org.springframework.boot") version "4.1.0"
     id("org.graalvm.buildtools.native") version "0.11.1"
-    id("st.orm") version "1.13.0"
+    id("st.orm") version "@@STORM_VERSION@@"
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -144,18 +144,16 @@ This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) 
 
 ## Quick Start
 
-Storm provides a Bill of Materials (BOM) for centralized version management. Import the BOM once and omit version numbers from individual Storm dependencies.
+The Storm Gradle plugin sets up a Kotlin project in one line: it imports the BOM, adds the core dependencies, and wires the metamodel processor and Kotlin compiler plugin. Maven users import the BOM once and omit version numbers from individual Storm dependencies.
 
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin (Gradle)" default>
 
 ```kotlin
-dependencies {
-    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
-    implementation("st.orm:storm-kotlin")
-    runtimeOnly("st.orm:storm-core")
-    // Use storm-compiler-plugin-2.0 for Kotlin 2.0.x, -2.1 for 2.1.x, etc.
-    kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
+plugins {
+    kotlin("jvm") version "2.4.0"
+    id("com.google.devtools.ksp") version "2.3.10"
+    id("st.orm") version "@@STORM_VERSION@@"
 }
 ```
 

--- a/docs/ktor-integration.md
+++ b/docs/ktor-integration.md
@@ -9,17 +9,17 @@ The integration follows Ktor's plugin-based architecture. You `install(Storm)` l
 
 ## Installation
 
-Add the Storm Ktor module alongside your core Storm dependencies:
+Apply the Storm Gradle plugin, then add the Ktor module alongside it. The plugin imports the BOM and wires the core dependencies, metamodel processor, and Kotlin compiler plugin, so the Ktor setup only adds the module itself, a connection pool, and a dialect:
 
 ```kotlin
-dependencies {
-    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
+plugins {
+    kotlin("jvm") version "2.4.0"
+    id("com.google.devtools.ksp") version "2.3.10"
+    id("st.orm") version "@@STORM_VERSION@@"
+}
 
-    implementation("st.orm:storm-kotlin")
+dependencies {
     implementation("st.orm:storm-ktor")
-    runtimeOnly("st.orm:storm-core")
-    ksp("st.orm:storm-metamodel-ksp")
-    kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
 
     // Connection pooling (recommended)
     implementation("com.zaxxer:HikariCP:6.2.1")
@@ -32,6 +32,8 @@ dependencies {
     testImplementation("com.h2database:h2")
 }
 ```
+
+See [Installation](installation.md#gradle-plugin-recommended) for the plugin's `storm { }` options and the manual setup if you prefer explicit configuration.
 
 Storm integrates with Ktor's built-in dependency injection out of the box (see [Dependency Injection](#dependency-injection)); if your project uses [Koin](https://insert-koin.io/) instead, see [Using with Koin](#using-with-koin).
 

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -41,6 +41,8 @@ The metamodel is **optional**. Storm works without it using SQL Templates or str
 
 The generator scans your entity classes and creates corresponding metamodel classes (e.g., `User_` for `User`) in the same package.
 
+The [Storm Gradle plugin](installation.md#gradle-plugin-recommended) configures this generator for you, so if you apply it you can skip the manual setup below. The configuration here is for Maven and for Gradle users who prefer explicit setup.
+
 ### Gradle (Kotlin with KSP)
 
 ```kotlin

--- a/docs/string-templates.md
+++ b/docs/string-templates.md
@@ -58,6 +58,8 @@ Add the Storm compiler plugin to your Kotlin compiler configuration. The plugin 
 
 The artifact version matches the Storm version (e.g., `@@STORM_VERSION@@`).
 
+The [Storm Gradle plugin](installation.md#gradle-plugin-recommended) selects and applies the matching variant automatically, so if you apply it you can skip this step. The setup below is for Maven and for Gradle users who configure it explicitly.
+
 <Tabs groupId="build">
 <TabItem value="gradle" label="Gradle (Kotlin DSL)" default>
 

--- a/website/src/pages/quickstart.js
+++ b/website/src/pages/quickstart.js
@@ -32,20 +32,16 @@ function buildBody(version) {
 
   // One install snippet per supported Kotlin line (KOTLIN_VARIANTS in the
   // shared theme), switchable in the editor title bar.
-  const installFor = ({kotlin, ksp, plugin}) =>
+  const installFor = ({kotlin, ksp}) =>
     C('// build.gradle.kts\n') +
     F('plugins') + P(' {\n') +
     P('    ') + F('kotlin') + P('(') + S('"jvm"') + P(') version ') + S(`"${kotlin}"`) + P('\n') +
     P('    ') + F('id') + P('(') + S('"com.google.devtools.ksp"') + P(') version ') + S(`"${ksp}"`) + P('\n') +
+    P('    ') + F('id') + P('(') + S('"st.orm"') + P(') version ') + S(`"${version}"`) + P('\n') +
     P('}\n\n') +
     F('dependencies') + P(' {\n') +
-    P('    ') + F('implementation') + P('(') + F('platform') + P('(') + S(`"st.orm:storm-bom:${version}"`) + P('))\n') +
-    P('    ') + F('implementation') + P('(') + S('"st.orm:storm-kotlin"') + P(')\n') +
-    P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-core"') + P(')\n') +
     P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-h2"') + P(')          ') + C('// zero-setup in-memory database\n') +
     P('    ') + F('runtimeOnly') + P('(') + S('"com.h2database:h2:2.2.224"') + P(')\n') +
-    P('    ') + F('ksp') + P('(') + S('"st.orm:storm-metamodel-ksp"') + P(')\n') +
-    P('    ') + F('kotlinCompilerPluginClasspath') + P('(') + S(`"st.orm:storm-compiler-plugin-${plugin}"`) + P(')\n') +
     P('}');
 
   const entity =
@@ -126,14 +122,14 @@ ${navHtml('')}
   <div class="meta"><span>Kotlin</span><span>~5 min</span><span>JDK 21+</span></div>
 
   <h2><span class="hno">1</span>Set up</h2>
-  <p>Add the Storm modules to your build. This is the full Kotlin set for a runnable project on an in-memory H2 database; the BOM keeps the versions aligned.</p>
+  <p>Apply the Storm Gradle plugin. It imports the BOM and wires the core dependencies, the metamodel processor, and the Kotlin compiler plugin, so all that is left for a runnable project is an in-memory H2 database.</p>
   ${editor({
     file: 'build.gradle.kts',
     tag: 'Gradle · Kotlin DSL',
     copy: true,
     variants: KOTLIN_VARIANTS.map((v) => ({label: v.label, code: installFor(v), selected: v.selected})),
   })}
-  <p>The <code>ksp</code> dependency generates the type-safe metamodel (<code>Movie_</code>), and the compiler plugin makes SQL templates injection-safe by default. On a real database, swap <code>storm-h2</code> for your dialect and add its JDBC driver. See the <a class="tlink" href="/docs/installation">installation guide</a> for all options.</p>
+  <p>The plugin generates the type-safe metamodel (<code>Movie_</code>) through KSP and makes SQL templates injection-safe by default through the compiler plugin, with no extra dependencies to declare. On a real database, swap <code>storm-h2</code> for your dialect and add its JDBC driver. See the <a class="tlink" href="/docs/installation">installation guide</a> for all options.</p>
   <p>Working with an AI coding assistant? One command, run from the root of your project's workspace, installs Storm-aware rules and skills for it (Claude, Cursor, Copilot, Windsurf, Codex) and sets up a schema-aware MCP server, so the entities and queries it generates match your real schema.</p>
   ${editor({file: 'terminal', tag: 'shell', code: cli, copy: cliCommand})}
 

--- a/website/src/pages/tutorials/build-a-rest-api.js
+++ b/website/src/pages/tutorials/build-a-rest-api.js
@@ -23,22 +23,18 @@ const DESC =
   'routes, and assert the SQL with a test.';
 
 function buildBody(version) {
-  const gradleFor = ({kotlin, ksp, plugin}) =>
+  const gradleFor = ({kotlin, ksp}) =>
     C('// build.gradle.kts\n') +
     F('plugins') + P(' {\n') +
     P('    ') + F('kotlin') + P('(') + S('"jvm"') + P(') version ') + S(`"${kotlin}"`) + P('\n') +
     P('    ') + F('id') + P('(') + S('"io.ktor.plugin"') + P(') version ') + S('"3.0.3"') + P('\n') +
     P('    ') + F('id') + P('(') + S('"com.google.devtools.ksp"') + P(') version ') + S(`"${ksp}"`) + P('\n') +
+    P('    ') + F('id') + P('(') + S('"st.orm"') + P(') version ') + S(`"${version}"`) + P('\n') +
     P('}\n\n') +
     F('dependencies') + P(' {\n') +
-    P('    ') + F('implementation') + P('(') + F('platform') + P('(') + S(`"st.orm:storm-bom:${version}"`) + P('))\n') +
-    P('    ') + F('implementation') + P('(') + S('"st.orm:storm-kotlin"') + P(')\n') +
     P('    ') + F('implementation') + P('(') + S('"st.orm:storm-ktor"') + P(')\n') +
-    P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-core"') + P(')\n') +
     P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-h2"') + P(')\n') +
-    P('    ') + F('runtimeOnly') + P('(') + S('"com.h2database:h2:2.2.224"') + P(')\n') +
-    P('    ') + F('ksp') + P('(') + S('"st.orm:storm-metamodel-ksp"') + P(')\n') +
-    P('    ') + F('kotlinCompilerPluginClasspath') + P('(') + S(`"st.orm:storm-compiler-plugin-${plugin}"`) + P(')\n\n') +
+    P('    ') + F('runtimeOnly') + P('(') + S('"com.h2database:h2:2.2.224"') + P(')\n\n') +
     P('    ') + F('implementation') + P('(') + S('"io.ktor:ktor-server-netty"') + P(')\n') +
     P('    ') + F('implementation') + P('(') + S('"io.ktor:ktor-server-content-negotiation"') + P(')\n') +
     P('    ') + F('implementation') + P('(') + S('"io.ktor:ktor-serialization-jackson"') + P(')\n') +
@@ -201,7 +197,7 @@ ${navHtml('tutorials')}
   <div class="note">New to Storm? The <a href="/quickstart">five-minute quickstart</a> covers just install, entity, and query. This tutorial builds the whole app around them.</div>
 
   <h2><span class="hno">1</span>Create the project</h2>
-  <p>Start a plain Kotlin/Gradle project and add Ktor and Storm. The Ktor plugin manages the Ktor artifact versions, and the Storm BOM manages Storm's, so most dependencies need no version. We use H2 so there is nothing to install.</p>
+  <p>Start a plain Kotlin/Gradle project and add Ktor and Storm. The Ktor plugin manages the Ktor artifact versions, and the Storm Gradle plugin imports Storm's BOM and wires the metamodel processor and compiler plugin, so most dependencies need no version. We use H2 so there is nothing to install.</p>
   ${editor({
     file: 'build.gradle.kts',
     tag: 'Gradle · Kotlin DSL',

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -18,7 +18,7 @@
 > GitHub: https://github.com/storm-orm/storm-framework
 > License: Apache 2.0
 
-# Generated: 2026-07-15T11:26:56Z
+# Generated: 2026-07-19T07:40:11Z
 
 ========================================
 ## Source: index.md
@@ -156,17 +156,15 @@ This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) 
 
 ## Quick Start
 
-Storm provides a Bill of Materials (BOM) for centralized version management. Import the BOM once and omit version numbers from individual Storm dependencies.
+The Storm Gradle plugin sets up a Kotlin project in one line: it imports the BOM, adds the core dependencies, and wires the metamodel processor and Kotlin compiler plugin. Maven users import the BOM once and omit version numbers from individual Storm dependencies.
 
 [Kotlin (Gradle)]
 
 ```kotlin
-dependencies {
-    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
-    implementation("st.orm:storm-kotlin")
-    runtimeOnly("st.orm:storm-core")
-    // Use storm-compiler-plugin-2.0 for Kotlin 2.0.x, -2.1 for 2.1.x, etc.
-    kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
+plugins {
+    kotlin("jvm") version "2.4.0"
+    id("com.google.devtools.ksp") version "2.3.10"
+    id("st.orm") version "@@STORM_VERSION@@"
 }
 ```
 
@@ -4904,6 +4902,8 @@ The metamodel is **optional**. Storm works without it using SQL Templates or str
 - **Java projects** use an annotation processor
 
 The generator scans your entity classes and creates corresponding metamodel classes (e.g., `User_` for `User`) in the same package.
+
+The [Storm Gradle plugin](installation.md#gradle-plugin-recommended) configures this generator for you, so if you apply it you can skip the manual setup below. The configuration here is for Maven and for Gradle users who prefer explicit setup.
 
 ### Gradle (Kotlin with KSP)
 
@@ -12880,6 +12880,8 @@ Add the Storm compiler plugin to your Kotlin compiler configuration. The plugin 
 
 The artifact version matches the Storm version (e.g., `@@STORM_VERSION@@`).
 
+The [Storm Gradle plugin](installation.md#gradle-plugin-recommended) selects and applies the matching variant automatically, so if you apply it you can skip this step. The setup below is for Maven and for Gradle users who configure it explicitly.
+
 [Gradle (Kotlin DSL)]
 
 ```kotlin
@@ -16774,7 +16776,7 @@ try (var stream = userRepository.select().getResultStream()) {
 
 **Fix:**
 
-For **Kotlin with Gradle**, add the KSP plugin and processor dependency:
+For **Kotlin with Gradle**, the simplest fix is to apply the [Storm Gradle plugin](installation.md#gradle-plugin-recommended), which wires the KSP processor automatically. If you configure it manually, add the KSP plugin and processor dependency:
 
 ```kotlin
 plugins {
@@ -19929,7 +19931,7 @@ There are two ways to configure metamodel generation for Kotlin projects, depend
 - **Gradle with KSP:** Use `storm-metamodel-ksp`, which is a Kotlin Symbol Processing plugin.
 - **Maven with kapt:** Use `storm-metamodel-processor`, which is a standard Java annotation processor invoked through kapt.
 
-Both generate the same metamodel classes; they are different build tool integrations.
+Both generate the same metamodel classes; they are different build tool integrations. The [Storm Gradle plugin](installation.md#gradle-plugin-recommended) wires the KSP path for you; the setup below is for Maven and for Gradle users who configure it explicitly.
 
 **Gradle (Kotlin DSL) with KSP:**
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -240,13 +240,12 @@ val cityName = user.city.fetch().name  // Fetches when needed
 
 ### Dependencies (BOM)
 
-Kotlin (Gradle):
+Kotlin (Gradle) — apply the Storm plugin (id "st.orm", Gradle 8.5+). It imports the BOM and adds storm-kotlin, storm-core, the KSP metamodel processor, and the compiler plugin, so no Storm dependencies are declared by hand:
 ```kotlin
-dependencies {
-    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
-    implementation("st.orm:storm-kotlin")
-    runtimeOnly("st.orm:storm-core")
-    kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
+plugins {
+    kotlin("jvm") version "2.4.0"
+    id("com.google.devtools.ksp") version "2.3.10"
+    id("st.orm") version "@@STORM_VERSION@@"
 }
 ```
 
@@ -278,13 +277,16 @@ Java (Maven):
 
 ### Spring Boot Starter
 
-Kotlin (Gradle):
+Kotlin (Gradle) — apply the Storm plugin, then add the starter:
 ```kotlin
+plugins {
+    kotlin("jvm") version "2.4.0"
+    id("com.google.devtools.ksp") version "2.3.10"
+    id("st.orm") version "@@STORM_VERSION@@"
+}
+
 dependencies {
-    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
     implementation("st.orm:storm-kotlin-spring-boot-starter")
-    runtimeOnly("st.orm:storm-core")
-    kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
 }
 ```
 
@@ -298,14 +300,16 @@ Java (Maven):
 
 ### Ktor Integration
 
-Kotlin (Gradle):
+Kotlin (Gradle) — apply the Storm plugin, then add the Ktor module:
 ```kotlin
+plugins {
+    kotlin("jvm") version "2.4.0"
+    id("com.google.devtools.ksp") version "2.3.10"
+    id("st.orm") version "@@STORM_VERSION@@"
+}
+
 dependencies {
-    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
-    implementation("st.orm:storm-kotlin")
     implementation("st.orm:storm-ktor")
-    runtimeOnly("st.orm:storm-core")
-    kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
 }
 ```
 
@@ -317,6 +321,7 @@ Ktor: storm-ktor, storm-ktor-test
 JSON: storm-jackson2, storm-jackson3, storm-kotlinx-serialization
 Dialects: storm-postgresql, storm-mysql, storm-mariadb, storm-oracle, storm-mssqlserver
 Build: storm-bom, storm-compiler-plugin-2.0, storm-compiler-plugin-2.1
+Gradle plugin: id "st.orm" (Gradle Plugin Portal) — one-line setup for Kotlin/Java, imports the BOM and wires metamodel + compiler plugin
 Metamodel: storm-metamodel-processor (Java), storm-metamodel-ksp (Kotlin)
 Testing: storm-test, storm-h2 (test runtime), com.h2database:h2 (test runtime — required, storm-h2 declares it as provided)
 Validation: storm-kotlin-validator

--- a/website/static/skills/storm-setup.md
+++ b/website/static/skills/storm-setup.md
@@ -14,15 +14,29 @@ Before suggesting dependencies, read the project's build file (pom.xml, build.gr
 
 ### Kotlin (Gradle) - Recommended
 
-**Important:** The KSP plugin version must match the project's Kotlin version — it is always `<kotlin-version>-<ksp-release>`. Declare it in `plugins { }`:
+Prefer the Storm Gradle plugin (`id("st.orm")`, Gradle 8.5+). It imports the BOM, adds `storm-kotlin` and `storm-core`, wires the KSP metamodel processor, and selects the Storm compiler-plugin variant matching the project's Kotlin version. Apply it alongside the Kotlin and KSP plugins:
+
 ```kotlin
 plugins {
     kotlin("jvm") version "<kotlin-version>"
     id("com.google.devtools.ksp") version "<kotlin-version>-<ksp-release>"  // e.g., 2.0.21-1.0.28 for Kotlin 2.0.21
+    id("st.orm") version "@@STORM_VERSION@@"
 }
 ```
 
-In Gradle, a `platform()` BOM only applies to the configuration where it's declared. The `ksp` and `kotlinCompilerPluginClasspath` configurations are separate — they do NOT inherit the BOM from `implementation`. You must apply the BOM to each configuration that needs it:
+**Important:** The KSP plugin version must match the project's Kotlin version — it is always `<kotlin-version>-<ksp-release>`. KSP stays in `plugins { }` because its version is paired to Kotlin; if it is missing, the build fails with the exact line to add. The `st.orm` plugin version drives all Storm coordinates, so no BOM or per-module versions are needed — add only the extra modules the project needs, without versions:
+
+```kotlin
+dependencies {
+    runtimeOnly("st.orm:storm-postgresql")   // your dialect
+}
+```
+
+The `storm { }` extension covers overrides (`metamodel`, `compilerPlugin`, `compilerPluginVariant`, `javaPreview`).
+
+#### Manual Gradle setup (explicit configuration)
+
+If the project cannot apply the plugin, configure the modules by hand. In Gradle, a `platform()` BOM only applies to the configuration where it's declared. The `ksp` and `kotlinCompilerPluginClasspath` configurations are separate — they do NOT inherit the BOM from `implementation`. Apply the BOM to each configuration that needs it:
 
 ```kotlin
 dependencies {


### PR DESCRIPTION
Now that the `st.orm` Gradle plugin is published to the Gradle Plugin Portal, the docs and site should teach setup through the plugin rather than the manual BOM + KSP + compiler-plugin wiring.

## What changed

**Switched to the plugin block** (the primary Gradle setup on each page):
- `docs/index.md` Quick Start (Kotlin tab)
- `docs/ktor-integration.md` Installation
- `website/src/pages/quickstart.js` and `website/src/pages/tutorials/build-a-rest-api.js` install snippets
- `website/static/skills/storm-setup.md` recommended path, with the manual setup kept as a fallback subsection
- `website/static/llms.txt` Kotlin/Gradle blocks, plus the plugin added to the module list

**Kept the manual mechanism, added a pointer to the plugin** (these pages document KSP / compiler-plugin internals, so the manual config stays relevant):
- `docs/metamodel.md`, `docs/api-kotlin.md`, `docs/string-templates.md`, `docs/error-handling.md`

**Version placeholder fix:**
- `docs/graalvm.md` had a literal plugin version; replaced with `@@STORM_VERSION@@` so it tracks the release like every other snippet.

`website/static/llms-full.txt` is regenerated from `docs/` via `generate-llms-full.sh`.

`installation.md` already led with the plugin and keeps its manual section by design, so it is unchanged. The README already leads with the plugin and its literal versions are synced to the tag by `release.yml`.

## Verification

`npm run build` in `website/` succeeds; the new cross-links to `installation.md#gradle-plugin-recommended` all resolve, and the `@@STORM_VERSION@@` placeholder renders as the current released version. Remaining broken-link warnings are pre-existing (Dokka API pages and frozen `versioned_docs` snapshots).