### PR TITLE
docs: explain why the LIMIT clause is inlined as a literal

### DIFF
--- a/storm-core/src/main/java/st/orm/core/spi/DefaultSqlDialect.java
+++ b/storm-core/src/main/java/st/orm/core/spi/DefaultSqlDialect.java
@@ -312,8 +312,9 @@ public class DefaultSqlDialect implements SqlDialect {
      */
     @Override
     public String limit(int limit) {
-        // Taking the most basic approach that is supported by most database in test (containers).
-        // For production use, ensure the right dialect is used.
+        // The limit is inlined as a literal, not bound (see SqlDialect#limit): a literal lets the planner pick an
+        // early-terminating plan for small pages, where a bound value would force a slower generic plan. Basic LIMIT
+        // syntax works on most databases in the test containers; for production, ensure the right dialect is used.
         return "LIMIT " + limit;
     }
 
@@ -326,6 +327,7 @@ public class DefaultSqlDialect implements SqlDialect {
      */
     @Override
     public String offset(int offset) {
+        // Inlined as a literal, not bound; see SqlDialect#limit for the rationale.
         return "OFFSET " + offset;
     }
 
@@ -339,8 +341,8 @@ public class DefaultSqlDialect implements SqlDialect {
      */
     @Override
     public String limit(int offset, int limit) {
-        // Taking the most basic approach that is supported by most database in test (containers).
-        // For production use, ensure the right dialect is used.
+        // Both values inlined as literals, not bound (see SqlDialect#limit). Basic LIMIT/OFFSET syntax works on most
+        // databases in the test containers; for production, ensure the right dialect is used.
         return "LIMIT %s OFFSET %s".formatted(limit, offset);
     }
 

--- a/storm-core/src/main/java/st/orm/core/template/SqlDialect.java
+++ b/storm-core/src/main/java/st/orm/core/template/SqlDialect.java
@@ -300,29 +300,41 @@ public interface SqlDialect {
     boolean applyLimitAfterSelect();
 
     /**
-     * Returns a string template for the given limit.
+     * Returns the LIMIT clause for the given limit, with the value inlined as a literal rather than bound.
+     *
+     * <p>Inlining is deliberate. A literal lets the planner see the value at plan time and choose an
+     * early-terminating plan (an index scan plus a nested loop that stops after {@code limit} rows), which is exactly
+     * what pagination wants. A bound limit forces a generic plan for an unknown row count, which is materially slower
+     * for small pages over large tables; on PostgreSQL a prepared {@code LIMIT ?} also degrades to that generic plan
+     * once it stops using a value-aware custom plan. Limits come from a small, fixed set of page sizes, so inlining
+     * them costs negligible plan-cache churn in return.</p>
      *
      * @param limit the maximum number of records to return.
-     * @return a string template for the given limit.
+     * @return the LIMIT clause with the value inlined as a literal.
      * @since 1.2
      */
     String limit(int limit);
 
     /**
-     * Returns a string template for the given offset.
+     * Returns the OFFSET clause for the given offset, with the value inlined as a literal rather than bound.
+     *
+     * <p>Inlined for the same reason as {@link #limit(int)}: a literal lets the planner account for the value at plan
+     * time, and offsets come from a small, fixed set of page positions, so inlining costs negligible plan-cache
+     * churn.</p>
      *
      * @param offset the offset.
-     * @return a string template for the given offset.
+     * @return the OFFSET clause with the value inlined as a literal.
      * @since 1.2
      */
     String offset(int offset);
 
     /**
-     * Returns a string template for the given limit and offset.
+     * Returns the combined LIMIT/OFFSET clause, with both values inlined as literals rather than bound; see
+     * {@link #limit(int)} for why.
      *
      * @param offset the offset.
      * @param limit the maximum number of records to return.
-     * @return a string template for the given limit and offset.
+     * @return the LIMIT/OFFSET clause with both values inlined as literals.
      * @since 1.2
      */
     String limit(int offset, int limit);


### PR DESCRIPTION
`SqlDialect#limit(int)` inlines the limit value as a literal rather than binding it. This documents why, so it isn't "optimized" into a bind parameter later.

A literal lets the query planner see the value at plan time and pick an early-terminating plan (index scan plus a nested loop that stops after `limit` rows) — exactly what pagination wants. A bound `LIMIT ?` forces a generic plan for an unknown row count, which is materially slower for small pages over large tables; on PostgreSQL it also degrades to that generic plan once the prepared statement stops using a value-aware custom plan. Limit values come from a small, fixed set of page sizes, so inlining them costs negligible plan-cache churn.

Comment-only; no behavior change.