### PR TITLE
perf: emit multi-row VALUES for keyless batch inserts; write-set rebuilds via generated instantiators

### DIFF
--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -1320,15 +1320,44 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
      * parameter limit so that {@code rows × bound columns} never exceeds what a single statement can carry.
      */
     private int multiRowInsertChunkSize() {
+        return multiRowInsertChunkSize(false);
+    }
+
+    private int multiRowInsertChunkSize(boolean ignoreAutoGenerate) {
         int boundColumns = (int) model.declaredColumns().stream()
                 .filter(Column::insertable)
-                .filter(column -> column.generation() == NONE)
+                .filter(column -> ignoreAutoGenerate || column.generation() == NONE)
                 .count();
         if (boundColumns == 0) {
             return defaultBatchSize;
         }
         int maxRows = Math.max(1, ormTemplate.dialect().maxBindParameters() / boundColumns);
         return Math.min(defaultBatchSize, maxRows);
+    }
+
+    /**
+     * Inserts a batch using a single multi-row {@code INSERT INTO t (...) VALUES (...),(...)} statement without
+     * fetching generated keys, avoiding the per-row statements of {@code executeBatch} on dialects that support the
+     * multi-row form.
+     */
+    private void insertMultiRow(@Nonnull List<E> batch, boolean ignoreAutoGenerate) {
+        if (batch.isEmpty()) {
+            return;
+        }
+        List<E> transformed = batch.stream()
+                .map(this::fireBeforeInsert)
+                .map(e -> validateInsert(e, ignoreAutoGenerate))
+                .toList();
+        var query = ormTemplate.query(raw("""
+                INSERT INTO \0
+                VALUES \0""",
+                Templates.insert(model.type(), ignoreAutoGenerate),
+                Templates.values(transformed, ignoreAutoGenerate))).managed();
+        if (query.executeUpdate() != transformed.size()) {
+            throw new PersistenceException("Multi-row insert of %s failed. The number of affected rows does not match the batch size."
+                    .formatted(model.type().getSimpleName()));
+        }
+        transformed.forEach(this::fireAfterInsert);
     }
 
     /**
@@ -1707,6 +1736,13 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
                 insertJoinedBatch(transformed);
                 transformed.forEach(this::fireAfterInsert);
             });
+            return;
+        }
+        if (supportsMultiRowInsert()) {
+            // A dialect that can return keys from a multi-row insert necessarily supports the statement form; the
+            // keyless path reuses that capability rather than introducing a separate one.
+            int chunkSize = Math.min(batchSize, multiRowInsertChunkSize(ignoreAutoGenerate));
+            chunked(entities, chunkSize).forEach(batch -> insertMultiRow(batch, ignoreAutoGenerate));
             return;
         }
         try (var query = prepareInsertQuery(ignoreAutoGenerate)) {

--- a/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
@@ -41,10 +41,12 @@ import st.orm.Ref;
 import st.orm.WriteSet;
 import st.orm.core.repository.EntityRepository;
 import st.orm.core.repository.RepositoryLookup;
+import st.orm.core.spi.Instantiators;
 import st.orm.core.spi.ORMReflection;
 import st.orm.core.spi.Providers;
 import st.orm.core.template.Column;
 import st.orm.core.template.Model;
+import st.orm.mapping.Instantiator;
 import st.orm.mapping.RecordField;
 import st.orm.mapping.RecordType;
 
@@ -554,6 +556,26 @@ public final class WriteSetImpl implements WriteSet {
     }
 
     /**
+     * Rebuild metadata per record class: the record type with its canonical constructor made accessible once, and
+     * the generated metamodel instantiator when one is registered, so rebuilds construct through generated code
+     * rather than reflection.
+     */
+    private record RebuildType(@Nonnull RecordType recordType, @Nullable Instantiator<?> instantiator) {
+        Object newInstance(@Nonnull Object[] args) {
+            return instantiator != null ? instantiator.instantiate(args) : recordType.newInstance(args);
+        }
+    }
+
+    private static final ClassValue<RebuildType> REBUILD_TYPES = new ClassValue<>() {
+        @Override
+        protected RebuildType computeValue(Class<?> type) {
+            RecordType recordType = REFLECTION.getRecordType(type);
+            recordType.constructor().trySetAccessible();
+            return new RebuildType(recordType, Instantiators.find(type));
+        }
+    };
+
+    /**
      * Rebuilds the record with the component at the given path replaced, reconstructing nested records as needed.
      *
      * <p>Intermediate components along the path are never {@code null} here: a dependency is only recorded when
@@ -561,18 +583,17 @@ public final class WriteSetImpl implements WriteSet {
      * immutable.</p>
      */
     private Object withComponent(@Nonnull Object record, @Nonnull int[] path, int depth, @Nullable Object newValue) {
-        RecordType recordType = REFLECTION.getRecordType(record.getClass());
-        List<RecordField> fields = recordType.fields();
+        RebuildType rebuildType = REBUILD_TYPES.get(record.getClass());
+        List<RecordField> fields = rebuildType.recordType().fields();
         Object[] args = new Object[fields.size()];
         for (int i = 0; i < fields.size(); i++) {
-            args[i] = REFLECTION.getRecordValue(record, i);
+            args[i] = REFLECTION.invoke(fields.get(i), record);
         }
         int index = path[depth];
         args[index] = depth == path.length - 1
                 ? newValue
                 : withComponent(args[index], path, depth + 1, newValue);
-        recordType.constructor().setAccessible(true);
-        return recordType.newInstance(args);
+        return rebuildType.newInstance(args);
     }
 
     /** Rebuilds the entity with the given primary key. */

--- a/storm-core/src/main/java/st/orm/core/template/impl/ORMTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/ORMTemplateImpl.java
@@ -41,9 +41,11 @@ import st.orm.EntityCallback;
 import st.orm.PersistenceException;
 import st.orm.Projection;
 import st.orm.StormConfig;
+import st.orm.WriteSet;
 import st.orm.core.repository.EntityRepository;
 import st.orm.core.repository.ProjectionRepository;
 import st.orm.core.repository.Repository;
+import st.orm.core.repository.impl.WriteSetImpl;
 import st.orm.core.spi.ORMReflection;
 import st.orm.core.spi.Provider;
 import st.orm.core.spi.Providers;
@@ -61,6 +63,7 @@ public final class ORMTemplateImpl extends QueryTemplateImpl implements ORMTempl
     private final Predicate<? super Provider> providerFilter;
     private final StormConfig config;
     private final List<EntityCallback<?>> entityCallbacks;
+    private volatile WriteSet writeSet;
 
     public ORMTemplateImpl(@Nonnull QueryFactory factory,
                            @Nonnull ModelBuilder modelBuilder,
@@ -89,6 +92,24 @@ public final class ORMTemplateImpl extends QueryTemplateImpl implements ORMTempl
     @Override
     public StormConfig config() {
         return config;
+    }
+
+    /**
+     * Returns the write set bound to this template.
+     *
+     * <p>The instance is cached so its per-type metadata (FK edges, key carriers) is discovered once per template
+     * rather than on every {@code writeSet()} call. The write set itself is stateless per operation, so sharing one
+     * instance is safe.</p>
+     */
+    @Override
+    public WriteSet writeSet() {
+        WriteSet result = writeSet;
+        if (result == null) {
+            // Benign race: two threads may briefly build separate instances; both are correct and the field settles.
+            result = new WriteSetImpl(this);
+            writeSet = result;
+        }
+        return result;
     }
 
     @Override

--- a/storm-h2/src/test/java/st/orm/spi/h2/H2EntityRepositoryTest.java
+++ b/storm-h2/src/test/java/st/orm/spi/h2/H2EntityRepositoryTest.java
@@ -746,7 +746,7 @@ public class H2EntityRepositoryTest {
     public void testInsertWithSequenceIgnoreAutoGenerateBatch() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Pet.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -754,7 +754,7 @@ public class H2EntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -780,7 +780,7 @@ public class H2EntityRepositoryTest {
     public void testInsertWithSequenceIgnoreAutoGenerateStream() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Pet.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -788,7 +788,7 @@ public class H2EntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1120,7 +1120,7 @@ public class H2EntityRepositoryTest {
     public void testInsertWithSequenceEmptyIgnoreAutoGenerateBatch() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(PetSequenceEmpty.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1128,7 +1128,7 @@ public class H2EntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1154,7 +1154,7 @@ public class H2EntityRepositoryTest {
     public void testInsertWithSequenceEmptyIgnoreAutoGenerateStream() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(PetSequenceEmpty.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1162,7 +1162,7 @@ public class H2EntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBEntityRepositoryTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBEntityRepositoryTest.java
@@ -999,7 +999,7 @@ public class MariaDBEntityRepositoryTest {
     public void testInsertWithSequenceIgnoreAutoGenerateBatch() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Pet.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1007,7 +1007,7 @@ public class MariaDBEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1033,7 +1033,7 @@ public class MariaDBEntityRepositoryTest {
     public void testInsertWithSequenceIgnoreAutoGenerateStream() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Pet.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1041,7 +1041,7 @@ public class MariaDBEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1554,7 +1554,7 @@ public class MariaDBEntityRepositoryTest {
     public void testInsertWithSequenceEmptyIgnoreAutoGenerateBatch() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(PetSequenceEmpty.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1562,7 +1562,7 @@ public class MariaDBEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1588,7 +1588,7 @@ public class MariaDBEntityRepositoryTest {
     public void testInsertWithSequenceEmptyIgnoreAutoGenerateStream() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(PetSequenceEmpty.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1596,7 +1596,7 @@ public class MariaDBEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);

--- a/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLEntityRepositoryTest.java
+++ b/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLEntityRepositoryTest.java
@@ -1110,7 +1110,7 @@ public class MySQLEntityRepositoryTest {
     public void testInsertWithSequenceIgnoreAutoGenerateBatch() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Pet.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1118,7 +1118,7 @@ public class MySQLEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1144,7 +1144,7 @@ public class MySQLEntityRepositoryTest {
     public void testInsertWithSequenceIgnoreAutoGenerateStream() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Pet.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1152,7 +1152,7 @@ public class MySQLEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1360,7 +1360,7 @@ public class MySQLEntityRepositoryTest {
     public void testInsertWithSequenceEmptyIgnoreAutoGenerateBatch() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(PetSequenceEmpty.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1368,7 +1368,7 @@ public class MySQLEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1394,7 +1394,7 @@ public class MySQLEntityRepositoryTest {
     public void testInsertWithSequenceEmptyIgnoreAutoGenerateStream() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(PetSequenceEmpty.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1402,7 +1402,7 @@ public class MySQLEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
@@ -995,7 +995,7 @@ public class PostgreSQLEntityRepositoryTest {
     public void testInsertWithSequenceIgnoreAutoGenerateBatch() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Pet.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1003,7 +1003,7 @@ public class PostgreSQLEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1029,7 +1029,7 @@ public class PostgreSQLEntityRepositoryTest {
     public void testInsertWithSequenceIgnoreAutoGenerateStream() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Pet.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1037,7 +1037,7 @@ public class PostgreSQLEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1550,7 +1550,7 @@ public class PostgreSQLEntityRepositoryTest {
     public void testInsertWithSequenceEmptyIgnoreAutoGenerateBatch() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(PetSequenceEmpty.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1558,7 +1558,7 @@ public class PostgreSQLEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);
@@ -1584,7 +1584,7 @@ public class PostgreSQLEntityRepositoryTest {
     public void testInsertWithSequenceEmptyIgnoreAutoGenerateStream() {
         String expectedSql = """
                 INSERT INTO pet (id, name, birth_date, type_id, owner_id)
-                VALUES (?, ?, ?, ?, ?)""";
+                VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(PetSequenceEmpty.class);
         var first = new AtomicBoolean(false);
         observe(sql -> {
@@ -1592,7 +1592,7 @@ public class PostgreSQLEntityRepositoryTest {
                 assertEquals(expectedSql, sql.statement());
                 assertEquals(sql.generatedKeys(), List.of());
                 assertFalse(sql.versionAware());
-                assertTrue(sql.bindVariables().isPresent());
+                assertTrue(sql.bindVariables().isEmpty());
             }
         }, () -> {
             var ids = List.of(100, 101);


### PR DESCRIPTION
Closes #292

## What

Two write-path follow-ups to #290/#291.

**Keyless multi-row inserts.** Batch inserts that do not fetch generated keys still issued a JDBC `executeBatch` of single-row inserts; only the key-fetching path used the multi-row form. On dialects with a multi-row key-fetch capability, keyless batch inserts (including the `ignoreAutoGenerate` variants) now emit one multi-row statement per chunk, bounded by the dialect's bind-parameter limit. Write sets benefit on every level whose keys no dependent consumes: writing 20 dependent rows through `writeSet().insert(...)` drops by roughly the same margin the key-fetching path gained in #291 (~240 µs per 20-row level in local profiling).

No new dialect API: the keyless path reuses the existing capability check, since a dialect that returns keys from a multi-row insert necessarily supports the statement form. A dialect that supports multi-row `VALUES` without either key-fetch mechanism (SQL Server, capped at 1000 row constructors) would need its own capability plus a row-constructor bound; that seam is best designed when that dialect is actually enabled.

**Write-set rebuilds through generated instantiators.** Key propagation and generated-key assignment rebuilt records reflectively, calling `setAccessible` on the canonical constructor for every rebuild. Rebuilds now construct through the metamodel-generated `Instantiator` when one is registered (the same generated code the read path uses since #253), falling back to the record constructor made accessible once per class, and read components through the already-resolved record fields. The template also caches its `WriteSet` instance so per-type metadata (FK edges, key carriers) is discovered once per template rather than on every `writeSet()` call. Warmed-JIT impact is neutral; the wins are cold start, short-lived processes, and native images.

## Testing

All suites green against their real databases:

- storm-core: **2307** · H2: **158** · PostgreSQL: **178** · MySQL: **175** · MariaDB: **158** · SQLite: **131**
- The 16 updated test expectations are the intended shape change: `ignoreAutoGenerate` batch/stream inserts now assert the multi-row statement with inline parameters instead of the single-row reusable-bind form.
