### PR TITLE
perf: reduce allocation in expression binding and template parsing

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/TemplateBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/TemplateBuilder.java
@@ -56,24 +56,7 @@ public interface TemplateBuilder {
      * @return a List of fragments between each NUL delimiter.
      */
     private static List<String> parseFragments(String raw) {
-        List<String> fragments = new ArrayList<>();
-        StringBuilder cur = new StringBuilder();
-        for (int i = 0; i < raw.length(); i++) {
-            char c = raw.charAt(i);
-            if (c == '\\' && i + 1 < raw.length() && raw.charAt(i + 1) == '0') {
-                // Escaped null sequence.
-                cur.append('\0');
-                i++;
-            } else if (c == '\0') {
-                // Delimiter: end fragment.
-                fragments.add(cur.toString());
-                cur.setLength(0);
-            } else {
-                cur.append(c);
-            }
-        }
-        fragments.add(cur.toString());
-        return fragments;
+        return TemplateFragments.parse(raw);
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/TemplateFragments.java
+++ b/storm-core/src/main/java/st/orm/core/template/TemplateFragments.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.template;
+
+import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import st.orm.core.template.impl.SegmentedLruCache;
+
+/**
+ * Parses raw template strings into fragment lists.
+ *
+ * <p>Fragment lists are a pure function of the raw template, and interpolated values travel separately as
+ * {@code \0} placeholders, so the cache key space is bounded by the distinct template shapes of the application.
+ * Cached lists are immutable and shared.</p>
+ */
+final class TemplateFragments {
+
+    private static final SegmentedLruCache<String, List<String>> CACHE = new SegmentedLruCache<>(1024);
+
+    private TemplateFragments() {
+    }
+
+    /**
+     * Parses the given string into template fragments, splitting on unescaped NULs (\0)
+     * and turning "\\0" into a real NUL within fragments.
+     *
+     * @param raw the raw string with '\0' delimiters and '\\0' escapes.
+     * @return an immutable list of fragments between each NUL delimiter.
+     */
+    static List<String> parse(@Nonnull String raw) {
+        var cached = CACHE.get(raw);
+        if (cached != null) {
+            return cached;
+        }
+        List<String> fragments = new ArrayList<>();
+        StringBuilder cur = new StringBuilder();
+        for (int i = 0; i < raw.length(); i++) {
+            char c = raw.charAt(i);
+            if (c == '\\' && i + 1 < raw.length() && raw.charAt(i + 1) == '0') {
+                // Escaped null sequence.
+                cur.append('\0');
+                i++;
+            } else if (c == '\0') {
+                // Delimiter: end fragment.
+                fragments.add(cur.toString());
+                cur.setLength(0);
+            } else {
+                cur.append(c);
+            }
+        }
+        fragments.add(cur.toString());
+        var result = List.copyOf(fragments);
+        CACHE.put(raw, result);
+        return result;
+    }
+}

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryModelImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryModelImpl.java
@@ -30,7 +30,9 @@ import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.SequencedMap;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 import st.orm.BindVars;
 import st.orm.Data;
@@ -415,44 +417,95 @@ final class QueryModelImpl implements QueryModel {
      * @param binder    the binder collecting parameter values.
      * @throws SqlTemplateException if binding fails or versioning rules are violated.
      */
+    /**
+     * Collects the column values of an object expression. Single-column expressions, the vast majority, bind their
+     * one value straight from the first-column slots; the name-keyed map is materialized only when a second column
+     * appears, since only multi-column expressions need it.
+     */
+    private static final class ObjectExpressionValues implements BiConsumer<Column, Object> {
+        private Column firstColumn;
+        private Object firstValue;
+        private SequencedMap<String, Object> map;
+        private int size;
+
+        void reset() {
+            firstColumn = null;
+            firstValue = null;
+            map = null;
+            size = 0;
+        }
+
+        @Override
+        public void accept(Column column, Object value) {
+            if (size++ == 0) {
+                firstColumn = column;
+                firstValue = value;
+                return;
+            }
+            if (map == null) {
+                map = new LinkedHashMap<>();
+                map.put(firstColumn.name(), firstValue);
+            }
+            map.put(column.name(), value);
+        }
+
+        /** Hands off the collected values as a map; ownership transfers to the caller. */
+        SequencedMap<String, Object> toMap() {
+            if (map == null) {
+                map = new LinkedHashMap<>();
+                if (size == 1) {
+                    map.put(firstColumn.name(), firstValue);
+                }
+            }
+            return map;
+        }
+    }
+
     private void bindObjectExpression(@Nonnull Metamodel<?, ?> metamodel,
                                       @Nonnull Operator operator,
                                       @Nonnull Object object,
                                       @Nonnull TemplateBinder binder) throws SqlTemplateException {
         var model = getModel(metamodel);
-        List<SequencedMap<String, Object>> multiValues = new ArrayList<>();
+        List<SequencedMap<String, Object>> multiValues = null;
+        var values = new ObjectExpressionValues();
         for (var o : getObjectIterable(object)) {
-            //noinspection DuplicatedCode
-            SequencedMap<String, Object> valueMap = new LinkedHashMap<>();
             var derivedObject = switch (o) {
                 case Ref<?> ref -> ref.id();
                 case Data data -> data;
                 case Object it -> it;
             };
+            values.reset();
             //noinspection unchecked
-            model.forEachValue((Metamodel<Data, ?>) metamodel, derivedObject,
-                    (k, v) -> valueMap.put(k.name(), v));
+            model.forEachValue((Metamodel<Data, ?>) metamodel, derivedObject, values);
             if (binder.isVersionAware()) {
                 if (o instanceof Data data) {
-                    var versionColumn = model.declaredColumns().stream()
-                            .filter(Column::version)
-                            .findFirst()
-                            .orElseThrow();
-                    model.forEachValue(List.of(versionColumn), data,
-                            (k, v) -> valueMap.put(k.name(), v));
+                    model.forEachValue(List.of(versionColumn(model)), data, values);
                 } else {
                     throw new SqlTemplateException("Data object expected for version-aware statement. When using optimistic locking, the WHERE clause value must be a Data instance that contains the version field.");
                 }
             }
-            if (multiValues.isEmpty() && valueMap.size() == 1) {
-                binder.bindParameter(valueMap.values().iterator().next());
+            if ((multiValues == null || multiValues.isEmpty()) && values.size == 1) {
+                binder.bindParameter(values.firstValue);
             } else {
-                multiValues.add(valueMap);
+                if (multiValues == null) {
+                    multiValues = new ArrayList<>();
+                }
+                multiValues.add(values.toMap());
             }
         }
-        if (!multiValues.isEmpty()) {
+        if (multiValues != null && !multiValues.isEmpty()) {
             bindMultiValues(operator, multiValues, binder);
         }
+    }
+
+    /** Returns the version column of the given model. */
+    private static Column versionColumn(@Nonnull Model<?, ?> model) {
+        for (var column : model.declaredColumns()) {
+            if (column.version()) {
+                return column;
+            }
+        }
+        throw new NoSuchElementException("No value present");
     }
 
     /**


### PR DESCRIPTION
Part of #294 (the issue stays open for the remaining tail).

## What

Follow-up to #296, targeting the two allocation sites JFR ranked highest after that merge.

**Expression binding.** `bindObjectExpression` allocated an `ArrayList` plus a name-keyed `LinkedHashMap` for every bound value, although single-column expressions, the vast majority, only need the one value. A reusable collector binds the scalar directly and materializes the map only when a second column appears (only multi-column expressions need it); the multi-values list is likewise created on demand. Version-aware binding locates the version column with a plain loop.

**Template fragment parsing.** Fragment lists are a pure function of the raw template string; interpolated values travel separately as `\0` placeholders, so the key space is bounded by the application's distinct template shapes. Parsed fragments are now cached in a bounded LRU (shared immutable lists), in a package-private helper so nothing leaks into the `TemplateBuilder` interface surface.

## Measured effect

JMH allocation profiler, per operation:

| workload | before this PR | after | cumulative vs pre-#296 |
|---|---|---|---|
| singleRowById | 6,944 B | 6,546 B | −38% |
| updateById | 12,548 B | 11,606 B | −45% |
| multiStatement | 12,486 B | 11,586 B | −44% |
| dynamic | 23,299 B | 22,249 B | −17% |

Precise counters on the by-id build phase: 4,131 → 3,693 B/op; the dynamically assembled projection's build: 6,682 → 5,796 B/op.

## Testing

All suites green against their real databases: storm-core **2307** · H2 **158** · SQLite **131** · PostgreSQL **178** · MySQL **175** · MariaDB **158**, plus a full reactor test-compile. No API changes; binding semantics (including version-aware error paths and null-value comparison) are unchanged.
