### PR TITLE
feat: generate record deconstructors alongside instantiators

### DIFF
--- a/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
@@ -564,6 +564,26 @@ public final class WriteSetImpl implements WriteSet {
         Object newInstance(@Nonnull Object[] args) {
             return instantiator != null ? instantiator.instantiate(args) : recordType.newInstance(args);
         }
+
+        /**
+         * Reads the record's component values in declaration order, through the generated deconstructor when the
+         * metamodel registered one, so rebuilds run as generated code on both sides of the round trip.
+         */
+        @SuppressWarnings("unchecked")
+        Object[] deconstruct(@Nonnull Object record) {
+            if (instantiator != null) {
+                Object[] args = ((Instantiator<Object>) instantiator).deconstruct(record);
+                if (args != null) {
+                    return args;
+                }
+            }
+            List<RecordField> fields = recordType.fields();
+            Object[] args = new Object[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                args[i] = REFLECTION.invoke(fields.get(i), record);
+            }
+            return args;
+        }
     }
 
     private static final ClassValue<RebuildType> REBUILD_TYPES = new ClassValue<>() {
@@ -584,11 +604,7 @@ public final class WriteSetImpl implements WriteSet {
      */
     private Object withComponent(@Nonnull Object record, @Nonnull int[] path, int depth, @Nullable Object newValue) {
         RebuildType rebuildType = REBUILD_TYPES.get(record.getClass());
-        List<RecordField> fields = rebuildType.recordType().fields();
-        Object[] args = new Object[fields.size()];
-        for (int i = 0; i < fields.size(); i++) {
-            args[i] = REFLECTION.invoke(fields.get(i), record);
-        }
+        Object[] args = rebuildType.deconstruct(record);
         int index = path[depth];
         args[index] = depth == path.length - 1
                 ? newValue

--- a/storm-foundation/src/main/java/st/orm/mapping/Instantiator.java
+++ b/storm-foundation/src/main/java/st/orm/mapping/Instantiator.java
@@ -16,6 +16,7 @@
 package st.orm.mapping;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 
 /**
  * Constructs record instances without reflection.
@@ -51,4 +52,24 @@ public interface Instantiator<T> {
      * @return the constructed instance.
      */
     T instantiate(@Nonnull Object[] args);
+
+    /**
+     * Deconstructs the given instance into its canonical constructor arguments, in declaration order.
+     *
+     * <p>Generated instantiators override this to read the components directly, completing the reflection-free
+     * round trip for record rebuilds: component reads run as generated code, matching {@link #instantiate} on the
+     * construction side. The returned array is freshly allocated; callers may modify it and pass it to
+     * {@link #instantiate} to build an adjusted copy of the instance.</p>
+     *
+     * <p>The default returns {@code null}, signalling that no generated deconstructor is available; callers fall
+     * back to reflective component access.</p>
+     *
+     * @param instance the instance to deconstruct.
+     * @return the component values in declaration order, or {@code null} when not supported.
+     * @since 1.13
+     */
+    @Nullable
+    default Object[] deconstruct(@Nonnull T instance) {
+        return null;
+    }
 }

--- a/storm-metamodel-ksp/src/main/kotlin/st/orm/metamodel/MetamodelProcessor.kt
+++ b/storm-metamodel-ksp/src/main/kotlin/st/orm/metamodel/MetamodelProcessor.kt
@@ -991,6 +991,8 @@ class MetamodelProcessor(
         val arguments = primaryConstructor.parameters.mapIndexed { index, parameter ->
             "        args[$index] as ${getKotlinValueTypeName(parameter.type, packageName)}"
         }.joinToString(",\n")
+        val componentNames = primaryConstructor.parameters.map { it.name?.asString() ?: return }
+        val components = componentNames.joinToString(",\n") { "        instance.`$it`" }
         val containingFile = classDeclaration.containingFile
         val deps = if (containingFile != null) Dependencies(true, containingFile) else Dependencies(false)
         val file = codeGenerator.createNewFile(
@@ -1015,6 +1017,10 @@ class MetamodelProcessor(
                 |    @Suppress("UNCHECKED_CAST")
                 |    override fun instantiate(args: Array<Any?>): $className = $className(
                 |$arguments
+                |    )
+                |
+                |    override fun deconstruct(instance: $className): Array<Any?> = arrayOf(
+                |$components
                 |    )
                 |}
                 """.trimMargin(),

--- a/storm-metamodel-processor/src/main/java/st/orm/metamodel/MetamodelProcessor.java
+++ b/storm-metamodel-processor/src/main/java/st/orm/metamodel/MetamodelProcessor.java
@@ -906,10 +906,13 @@ public final class MetamodelProcessor extends AbstractProcessor {
         String instantiatorName = recordName + "Instantiator";
         var parameters = constructor.getParameters();
         StringBuilder arguments = new StringBuilder();
+        StringBuilder components = new StringBuilder();
         for (int i = 0; i < parameters.size(); i++) {
             String castType = getBoxedTypeName(parameters.get(i).asType().toString().replaceAll("@\\S+\\s+", ""));
             arguments.append(arguments.isEmpty() ? "" : ",\n")
                     .append("                (").append(castType).append(") args[").append(i).append("]");
+            components.append(components.isEmpty() ? "" : ",\n")
+                    .append("                instance.").append(parameters.get(i).getSimpleName()).append("()");
         }
         try {
             JavaFileObject fileObject = processingEnv.getFiler()
@@ -919,7 +922,7 @@ public final class MetamodelProcessor extends AbstractProcessor {
                     %simport javax.annotation.processing.Generated;
 
                     /**
-                     * Instantiator for %s; constructs instances without reflection.
+                     * Instantiator for %s; constructs and deconstructs instances without reflection.
                      */
                     @Generated("%s")
                     public final class %s implements st.orm.mapping.Instantiator<%s> {
@@ -936,6 +939,13 @@ public final class MetamodelProcessor extends AbstractProcessor {
                     %s
                             );
                         }
+
+                        @Override
+                        public Object[] deconstruct(%s instance) {
+                            return new Object[] {
+                    %s
+                            };
+                        }
                     }""",
                         (packageName.isEmpty() ? "" : "package " + packageName + ";\n\n"),
                         recordName,
@@ -946,7 +956,9 @@ public final class MetamodelProcessor extends AbstractProcessor {
                         recordName,
                         recordName,
                         recordName,
-                        arguments
+                        arguments,
+                        recordName,
+                        components
                 ));
             }
             generatedInstantiators.add((packageName.isEmpty() ? "" : packageName + ".") + instantiatorName);


### PR DESCRIPTION
Closes #295

## What

The metamodel generators emit an `Instantiator` per record type, so record construction runs as generated code — but reading a record's components back out still went through reflective accessors. This completes the pair:

- **`Instantiator#deconstruct(T)`** — returns the canonical constructor arguments in declaration order as a freshly allocated array the caller may adjust and pass back to `instantiate`. The default returns `null` ("no generated deconstructor"), so instantiators generated before this change and types without generated support keep working unchanged through the reflective fallback.
- **Both generators emit it**: the Java annotation processor reads the record accessors, the KSP processor reads the data-class properties (backtick-quoted, so any property name works).
- **Write-set rebuilds use it**: key propagation and generated-key assignment (`withComponent`) now run the full deconstruct → adjust → instantiate round trip as generated code.

## Why

- **Native images**: component reads as generated code are closed-world analyzable — no accessor reachability metadata to register, and no method-handle machinery in the write path.
- **Cold start**: generated reads start at full speed; the reflective path costs several hundred µs per write-set operation until the JIT catches up, which matters for short-lived processes.
- Warmed-JIT throughput is unchanged (measured); this is stated in #295 so it is not mistaken for a performance item.

## Testing

- storm-core: **2307** green after a clean rebuild — 45 test records regenerate with deconstructors and the write-set integration tests exercise the generated round trip.
- storm-h2: **158** green (write-set suite included).
- KSP verified end to end: the Kotlin benchmark project regenerates its instantiators with deconstructors, compiles, and runs the write-set graph insert with its key-count guards passing.
- Full reactor test-compile.
