### PR TITLE
fix(ktor): eagerly resolve DI registrations to avoid shutdown warnings

### DIFF
--- a/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
@@ -195,15 +195,27 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
     // exactly one database, so `val visits: VisitRepository by dependencies` works regardless of the database.
     // Repositories created lazily after installation are not added to the container.
     if (pluginConfig.registerDependencies) {
+        val providedKeys = mutableListOf<DependencyKey>()
         application.dependencies {
             provide<ORMTemplate> { ormTemplate }
         }
-        application.registerRepositories(repositoryRegistry)
+        providedKeys += DependencyKey<ORMTemplate>()
+        providedKeys += application.registerRepositories(repositoryRegistry)
         for ((name, template) in namedTemplates) {
             application.dependencies {
                 provide<ORMTemplate>(name) { template }
             }
-            application.registerRepositories(namedRegistries.getValue(name))
+            providedKeys += DependencyKey<ORMTemplate>(name)
+            providedKeys += application.registerRepositories(namedRegistries.getValue(name))
+        }
+        // The container resolves dependencies lazily; a declaration nobody resolves keeps an unfinished
+        // deferred that the container cancels at shutdown, logging a spurious "Exception during cleanup"
+        // warning for the key and each of its covariant supertype keys. Resolving every provided key once
+        // at startup completes those deferreds. The instances already exist, so this creates nothing.
+        application.monitor.subscribe(ApplicationStarted) {
+            for (providedKey in providedKeys) {
+                application.dependencies.getBlocking<Any?>(providedKey)
+            }
         }
     }
 
@@ -299,13 +311,19 @@ private fun Application.resolveObservationConvention(): ObservationConvention<st
 
 /**
  * Registers every repository of the given registry in the dependency container, each under its own interface type.
+ *
+ * @return the keys the repositories are registered under.
  */
-private fun Application.registerRepositories(registry: RepositoryRegistry) {
+private fun Application.registerRepositories(registry: RepositoryRegistry): List<DependencyKey> {
+    val registeredKeys = mutableListOf<DependencyKey>()
     registry.forEach { type, instance ->
+        val key = DependencyKey(TypeInfo(type, type.starProjectedType))
         dependencies {
-            set(DependencyKey(TypeInfo(type, type.starProjectedType))) { instance }
+            set(key) { instance }
         }
+        registeredKeys += key
     }
+    return registeredKeys
 }
 
 /**

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormDependencyInjectionTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormDependencyInjectionTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.ktor.server.application.install
 import io.ktor.server.plugins.di.DependencyKey
 import io.ktor.server.plugins.di.dependencies
+import io.ktor.server.plugins.di.getBlocking
 import io.ktor.server.testing.testApplication
 import io.ktor.util.reflect.TypeInfo
 import org.junit.jupiter.api.Test
@@ -124,6 +125,7 @@ class StormDependencyInjectionTest {
                     }
                     val injectedOrm: ORMTemplate by dependencies
                     injectedOrm.shouldNotBeNull()
+                    dependencies.getBlocking<String>(DependencyKey<String>("greeting")) shouldBe "hello"
                 }
             }
         } finally {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormObservabilityTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormObservabilityTest.kt
@@ -4,10 +4,13 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
+import io.ktor.server.plugins.di.DependencyKey
 import io.ktor.server.plugins.di.dependencies
+import io.ktor.server.plugins.di.getBlocking
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
@@ -170,6 +173,7 @@ class StormObservabilityTest {
         }
         val dataSource = createTestDataSource("storm-explicit-observer", "/schema.sql")
         try {
+            var registryFromContainer: ObservationRegistry? = null
             testApplication {
                 application {
                     dependencies {
@@ -179,6 +183,7 @@ class StormObservabilityTest {
                         this.dataSource = dataSource
                         queryObserver = explicitObserver
                     }
+                    registryFromContainer = dependencies.getBlocking(DependencyKey<ObservationRegistry>())
                     routing {
                         get("/pets") {
                             call.respondText(repository<PetRepository>().findAll().size.toString())
@@ -188,6 +193,8 @@ class StormObservabilityTest {
                 client.get("/pets").status shouldBe HttpStatusCode.OK
                 observedExecutions.get() shouldBeGreaterThan 0
                 TestObservationRegistryAssert.assertThat(observationRegistry).doesNotHaveAnyObservation()
+                // The registry remains resolvable from the container; the plugin just leaves it unbound.
+                registryFromContainer shouldBeSameInstanceAs observationRegistry
             }
         } finally {
             dataSource.close()


### PR DESCRIPTION
## Problem

Ktor test runs (and production shutdowns) log a wall of warnings when an application using the Storm plugin stops:

```
WARN io.ktor.test - Exception during cleanup for st.orm.template.QueryTemplate; continuing
kotlinx.coroutines.JobCancellationException: Job was cancelled
```

The dependency container resolves lazily, and on `ApplicationStopped` it cancels its coroutine scope before walking the registered keys for cleanup. Any declaration nobody resolved during the run still has an unstarted deferred, which the cancelled scope completes exceptionally, so the cleanup pass logs a warning with a full stack trace. Type covariance multiplies the noise: `provide<ORMTemplate>` also registers keys for `QueryTemplate`, `SubqueryTemplate`, and `RepositoryLookup` plus nullable variants, and every repository registration fans out the same way. A typical test application warned on ~18 keys per shutdown.

## Fix

The plugin now collects every key it registers (primary template, named database templates, and all repositories) and resolves each of them once on `ApplicationStarted`. The instances already exist at that point, so this creates nothing; it only completes the container's deferreds. Covariant keys delegate to the origin registration's cached deferred, so resolving the origin key covers the whole fan-out.

Two tests provided dependencies they never resolved, producing the same warning for their own keys; they now resolve and assert them, which also strengthens what they verify.

## Remaining noise

With two or more repositories registered, Ktor 3.2.x still logs two short warnings per shutdown for `st.orm.repository.Repository` and `Repository?`: the shared marker interface is an ambiguous covariant key, and the container's cleanup pass logs its `AmbiguousDependencyException`. Resolving that ambiguity to an arbitrary repository would trade correct fail-fast behavior for silence, so it is left as is. Ktor 3.3.0 runs cleanup before cancelling the scope and 3.4.3+ skips ambiguous keys entirely, but Ktor 3.3+ ships Kotlin 2.2/2.3 metadata that the Kotlin 2.0.21 toolchain cannot read, so adopting it is a separate toolchain decision.

## Verification

`mvn test -pl storm-ktor,storm-ktor-test` on this branch: 61 tests pass, and the cleanup warnings for Storm-registered keys are gone from the logs.