### PR TITLE
feat: add insertAndFetchIds and upsertAndFetchIds to WriteSet

### DIFF
--- a/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
@@ -91,6 +91,13 @@ public final class WriteSetImpl implements WriteSet {
     }
 
     @Override
+    @Nonnull
+    public <ID> List<ID> insertAndFetchIds(@Nonnull Iterable<? extends Entity<ID>> entities) {
+        Execution execution = executeOrdered(entities, Action.INSERT, true);
+        return fetchIds(execution);
+    }
+
+    @Override
     public void upsert(@Nonnull Iterable<? extends Entity<?>> entities) {
         executeOrdered(entities, Action.UPSERT, false);
     }
@@ -620,6 +627,18 @@ public final class WriteSetImpl implements WriteSet {
     //
     // Fetch support.
     //
+
+    /** Reports the primary keys of the passed entities from the persisted view, in input order. */
+    @SuppressWarnings("unchecked")
+    @Nonnull
+    private <ID> List<ID> fetchIds(@Nonnull Execution execution) {
+        List<ID> result = new ArrayList<>(execution.inputs().size());
+        for (Object input : execution.inputs()) {
+            Object persisted = requireNonNull(execution.persistedView().get(input), "persisted view");
+            result.add((ID) ((Entity<?>) persisted).id());
+        }
+        return result;
+    }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Nonnull

--- a/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
@@ -110,6 +110,13 @@ public final class WriteSetImpl implements WriteSet {
     }
 
     @Override
+    @Nonnull
+    public <ID> List<ID> upsertAndFetchIds(@Nonnull Iterable<? extends Entity<ID>> entities) {
+        Execution execution = executeOrdered(entities, Action.UPSERT, true);
+        return fetchIds(execution);
+    }
+
+    @Override
     public void update(@Nonnull Iterable<? extends Entity<?>> entities) {
         executeUpdate(entities);
     }

--- a/storm-core/src/test/java/st/orm/core/WriteSetIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/WriteSetIntegrationTest.java
@@ -113,6 +113,50 @@ public class WriteSetIntegrationTest {
     }
 
     @Test
+    public void testInsertAndFetchIdsReturnsKeysInInputOrder() {
+        var orm = orm();
+        var owner = newOwner("Ids", "Order");
+        var pet = Pet.builder().name("Keys").birthDate(LocalDate.of(2022, 4, 4)).type(dogType()).owner(owner).build();
+        var first = new Visit(LocalDate.of(2026, 3, 3), "Ids first", pet);
+        var second = new Visit(LocalDate.of(2026, 3, 4), "Ids second", pet);
+        List<String> statements = new ArrayList<>();
+        List<Integer> ids = SqlInterceptor.observe(
+                sql -> statements.add(sql.statement().toUpperCase()),
+                () -> orm.writeSet().insertAndFetchIds(List.of(first, second)));
+        assertEquals(2, ids.size());
+        // The keys come from the insert itself; no row is re-read.
+        assertTrue(statements.stream().noneMatch(statement -> statement.startsWith("SELECT")));
+        var visits = orm.entity(Visit.class);
+        assertEquals("Ids first", visits.getById(ids.get(0)).description());
+        assertEquals("Ids second", visits.getById(ids.get(1)).description());
+    }
+
+    @Test
+    public void testInsertAndFetchIdsReportsExplicitMembersOnly() {
+        var orm = orm();
+        var owner = newOwner("Ids", "Closure");
+        var pet = Pet.builder().name("Hidden").birthDate(LocalDate.of(2021, 5, 5)).type(dogType()).owner(owner).build();
+        var visit = new Visit(LocalDate.of(2026, 4, 4), "Ids closure", pet);
+        // Only the visit is passed; pet and owner join via the insertion closure but are not reported.
+        List<Integer> ids = orm.writeSet().insertAndFetchIds(List.of(visit));
+        assertEquals(1, ids.size());
+        var fetched = orm.entity(Visit.class).getById(ids.getFirst());
+        assertEquals("Ids closure", fetched.description());
+        assertEquals("Hidden", fetched.pet().name());
+        assertNotEquals(0, fetched.pet().id());
+    }
+
+    @Test
+    public void testInsertAndFetchIdSingleEntity() {
+        var orm = orm();
+        var owner = newOwner("Ids", "Single");
+        var pet = Pet.builder().name("Solo").birthDate(LocalDate.of(2020, 6, 6)).type(dogType()).owner(owner).build();
+        var visit = new Visit(LocalDate.of(2026, 5, 5), "Ids single", pet);
+        Integer id = orm.writeSet().insertAndFetchId(visit);
+        assertEquals("Ids single", orm.entity(Visit.class).getById(id).description());
+    }
+
+    @Test
     public void testInsertAndFetchReturnsInputOrder() {
         var orm = orm();
         var owner = newOwner("Fetch", "Order");

--- a/storm-core/src/test/java/st/orm/core/WriteSetIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/WriteSetIntegrationTest.java
@@ -157,6 +157,31 @@ public class WriteSetIntegrationTest {
     }
 
     @Test
+    public void testUpsertAndFetchIdsUnsavedRequiresDialectSupport() {
+        var orm = orm();
+        var owner = newOwner("UpsertIds", "Dialect");
+        var pet = Pet.builder().name("NoDialect").birthDate(LocalDate.of(2022, 7, 7)).type(dogType()).owner(owner).build();
+        var visit = new Visit(LocalDate.of(2026, 6, 6), "UpsertIds dialect", pet);
+        // An unsaved explicit member needs a real upsert, which the default dialect lacks; the ids
+        // variant reports it the same way upsertAndFetch does. The PostgreSQL module covers the
+        // insert path and the mixed batch against a dialect with upsert support.
+        assertThrows(PersistenceException.class, () -> orm.writeSet().upsertAndFetchIds(List.of(visit)));
+    }
+
+    @Test
+    public void testUpsertAndFetchIdsUpdatesExistingEntity() {
+        var orm = orm();
+        var owner = newOwner("UpsertIds", "Update");
+        var pet = Pet.builder().name("Known").birthDate(LocalDate.of(2021, 8, 8)).type(dogType()).owner(owner).build();
+        var visit = orm.writeSet().insertAndFetch(new Visit(LocalDate.of(2026, 7, 7), "Before amend", pet));
+        // The visit carries its key: the upsert takes the update path and reports that same key.
+        var amended = visit.toBuilder().description("After amend").build();
+        Integer id = orm.writeSet().upsertAndFetchId(amended);
+        assertEquals(visit.id(), id);
+        assertEquals("After amend", orm.entity(Visit.class).getById(id).description());
+    }
+
+    @Test
     public void testInsertAndFetchReturnsInputOrder() {
         var orm = orm();
         var owner = newOwner("Fetch", "Order");

--- a/storm-foundation/src/main/java/st/orm/WriteSet.java
+++ b/storm-foundation/src/main/java/st/orm/WriteSet.java
@@ -295,6 +295,39 @@ public interface WriteSet {
     }
 
     /**
+     * Upserts like {@link #upsert(Iterable)} and returns the primary keys of the explicit members, in input order.
+     *
+     * <p>For inserted rows the generated key is reported; for updated rows the key the entity carries. The rows are
+     * not re-read, so database-applied defaults and version columns are not reflected; use
+     * {@link #upsertAndFetch(Iterable)} when that state is needed. Discovered members are written but not
+     * reported.</p>
+     *
+     * <p>The batch is homogeneous in its id type; entity types may differ as long as they share it. For batches
+     * that mix id types, use {@link #upsertAndFetch(Iterable)}, where each returned entity carries its own id.</p>
+     *
+     * @param entities the entities to upsert; may span multiple entity types sharing the id type.
+     * @return the primary keys of the explicit members in input order.
+     * @throws PersistenceException if the dependencies contain a cycle that cannot be ordered, if an unsaved entity
+     * is referenced through a non-insertable foreign key component, or if the upsert fails.
+     */
+    @Nonnull
+    <ID> List<ID> upsertAndFetchIds(@Nonnull Iterable<? extends Entity<ID>> entities);
+
+    /**
+     * Upserts the given entity and its insertion closure and returns its primary key; see
+     * {@link #upsertAndFetchIds(Iterable)}.
+     *
+     * @param entity the entity to upsert.
+     * @return the primary key of the upserted entity.
+     * @throws PersistenceException if the dependencies contain a cycle that cannot be ordered, if an unsaved entity
+     * is referenced through a non-insertable foreign key component, or if the upsert fails.
+     */
+    @Nonnull
+    default <ID> ID upsertAndFetchId(@Nonnull Entity<ID> entity) {
+        return upsertAndFetchIds(List.of(entity)).getFirst();
+    }
+
+    /**
      * Removes the given entities, children before parents.
      *
      * <p>Only the explicit members are removed; referenced entities are never removed implicitly. Dependencies

--- a/storm-foundation/src/main/java/st/orm/WriteSet.java
+++ b/storm-foundation/src/main/java/st/orm/WriteSet.java
@@ -156,6 +156,39 @@ public interface WriteSet {
     }
 
     /**
+     * Inserts like {@link #insert(Iterable)} and returns the primary keys of the explicit members, in input order.
+     *
+     * <p>The keys are taken from the insert itself: generated keys as reported by the database, or the keys the
+     * entities carry when the primary key is not generated. The rows are not re-read, so database-applied defaults
+     * and version columns are not reflected; use {@link #insertAndFetch(Iterable)} when that state is needed.
+     * Discovered members are inserted but not reported.</p>
+     *
+     * <p>The batch is homogeneous in its id type; entity types may differ as long as they share it. For batches
+     * that mix id types, use {@link #insertAndFetch(Iterable)}, where each returned entity carries its own id.</p>
+     *
+     * @param entities the entities to insert; may span multiple entity types sharing the id type.
+     * @return the primary keys of the explicit members in input order.
+     * @throws PersistenceException if the dependencies contain a cycle that cannot be ordered, if an unsaved entity
+     * is referenced through a non-insertable foreign key component, or if the insert fails.
+     */
+    @Nonnull
+    <ID> List<ID> insertAndFetchIds(@Nonnull Iterable<? extends Entity<ID>> entities);
+
+    /**
+     * Inserts the given entity and its insertion closure and returns its primary key; see
+     * {@link #insertAndFetchIds(Iterable)}.
+     *
+     * @param entity the entity to insert.
+     * @return the primary key of the inserted entity.
+     * @throws PersistenceException if the dependencies contain a cycle that cannot be ordered, if an unsaved entity
+     * is referenced through a non-insertable foreign key component, or if the insert fails.
+     */
+    @Nonnull
+    default <ID> ID insertAndFetchId(@Nonnull Entity<ID> entity) {
+        return insertAndFetchIds(List.of(entity)).getFirst();
+    }
+
+    /**
      * Updates the given entities, grouped by type.
      *
      * <p>Per-row semantics are identical to the per-repository update, including transaction-scoped dirty checking:

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
@@ -462,6 +462,27 @@ public class PostgreSQLEntityRepositoryTest {
     }
 
     @Test
+    public void testWriteSetUpsertAndFetchIdsCoversBothPaths() {
+        var orm = PreparedStatementTemplate.ORM(dataSource);
+        var repo = orm.entity(Owner.class);
+        var template = repo.getById(1);
+        // Insert path: id 0 is the default value, so the upsert inserts and reports the generated key.
+        var fresh = template.toBuilder().id(0).firstName("WriteSetIds").build();
+        Integer freshId = orm.writeSet().upsertAndFetchId(fresh);
+        assertFalse(freshId == 0 || freshId.equals(template.id()));
+        assertEquals("WriteSetIds", repo.getById(freshId).firstName());
+        // Mixed batch: the persisted row takes the update path, the new row the insert path, ids in input order.
+        var amended = repo.getById(freshId).toBuilder().lastName("Amended").build();
+        var second = template.toBuilder().id(0).firstName("WriteSetIds2").build();
+        List<Integer> ids = orm.writeSet().upsertAndFetchIds(List.of(amended, second));
+        assertEquals(2, ids.size());
+        assertEquals(freshId, ids.get(0));
+        assertFalse(ids.get(1) == 0 || ids.get(1).equals(freshId));
+        assertEquals("Amended", repo.getById(ids.get(0)).lastName());
+        assertEquals("WriteSetIds2", repo.getById(ids.get(1)).firstName());
+    }
+
+    @Test
     public void testUpsertAndFetchInlineVersion() {
         String expectedSql = """
                 UPDATE owner


### PR DESCRIPTION
## Summary

`WriteSet` offers `insert(...)`/`upsert(...)` returning `void` and `insertAndFetch(...)`/`upsertAndFetch(...)`, which re-read the persisted rows. There is no way to obtain just the keys, even though the execution already collects every key in its persisted view for foreign-key propagation. The repository layer establishes the vocabulary for this middle tier: `insert` / `insertAndFetchId(s)` / `insertAndFetch`; this change completes the same triads on the write set.

```java
<ID> List<ID> insertAndFetchIds(@Nonnull Iterable<? extends Entity<ID>> entities);
<ID> ID insertAndFetchId(@Nonnull Entity<ID> entity);    // default method
<ID> List<ID> upsertAndFetchIds(@Nonnull Iterable<? extends Entity<ID>> entities);
<ID> ID upsertAndFetchId(@Nonnull Entity<ID> entity);    // default method
```

- The keys are reported from the persisted view in input order; no row is re-read. For upserts, inserted rows report the generated key and updated rows the key they carry. The `AndFetch` forms keep their stronger contract (database-applied defaults and version columns) unchanged.
- The generic bound makes the id type flow from `Entity<ID>`: a homogeneous batch (`List<Visit>`) infers a fully typed `List<Long>`, and a batch that mixes id types does not compile. A positional list of mixed-type ids has no useful static type; mixed batches keep using the `AndFetch` forms, where each returned entity carries its own id.
- Discovered members are written but not reported, matching the explicit-members contract of the `AndFetch` forms.
- Kotlin needs no mirror: the generic methods flow through the foundation interface with full inference.

## Testing

- `WriteSetIntegrationTest` (H2, 31/31): insert keys in input order with a `SqlInterceptor` assertion that no SELECT is issued; closure-discovered members excluded; single-entity forms; the keyed upsert update path; and dialect parity, verifying the unsaved upsert path reports missing dialect support the same way `upsertAndFetch` does.
- `PostgreSQLEntityRepositoryTest` (Testcontainers, 80/80): both upsert paths against a real upsert dialect, in one mixed batch, with input-order ids: the persisted row updates and reports its carried key, the unsaved row inserts and reports its generated key.

Fixes #302