### PR TITLE
docs: cover the WriteSet id-returning methods and the kotlinx-serialization version floor

### DIFF
--- a/docs/jpa-cascades-vs-write-sets.md
+++ b/docs/jpa-cascades-vs-write-sets.md
@@ -217,6 +217,8 @@ Visit saved = orm.writeSet().insertAndFetch(visit);
 </TabItem>
 </Tabs>
 
+When only the keys are needed, `insertAndFetchIds` returns them in input order without re-reading the rows.
+
 ### `merge` with MERGE becomes `update` or `upsert`
 
 JPA's `merge` copies detached state onto a managed instance and, with `CascadeType.MERGE`, walks the associations; whether a row is inserted or updated follows from entity state. Storm splits that decision into two explicit actions: `update` for rows you know exist, and [`upsert`](upserts.md) when the database should resolve it atomically. Both write exactly the explicit members. Referenced entities provide foreign key values but are never written implicitly, and `update` rejects unsaved members instead of quietly inserting them.

--- a/docs/json.md
+++ b/docs/json.md
@@ -59,6 +59,8 @@ dependencies {
 
 Storm auto-detects the serialization library at runtime. Just add the dependency and it works.
 
+Storm compiles against kotlinx-serialization 1.7.3 and uses only its stable core API, so any 1.7.3 or newer release works: your project's dependency resolution picks the version, and Storm floats along with it.
+
 ---
 
 ## JSON Columns

--- a/docs/write-sets.md
+++ b/docs/write-sets.md
@@ -117,6 +117,27 @@ Visit fetchedVisit = orm.writeSet().insertAndFetch(visit);       // single root,
 </TabItem>
 </Tabs>
 
+`insertAndFetchIds` returns just the primary keys of the explicit members, in input order, without re-reading the rows: the keys come from the insert itself. It is the middle tier between `insert` (nothing back) and `insertAndFetch` (rows re-read with database-applied state), and the natural fit for a create endpoint that responds with ids. The batch is homogeneous in its id type; entity types may differ as long as they share it, and a batch that mixes id types keeps using `insertAndFetch`, where each returned entity carries its own id.
+
+<Tabs groupId="language">
+<TabItem value="kotlin" label="Kotlin" default>
+
+```kotlin
+val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)   // keys in input order, no re-read
+val id: Long = orm.writeSet().insertAndFetchId(visit)            // single root
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+List<Long> ids = orm.writeSet().insertAndFetchIds(visits);       // keys in input order, no re-read
+Long id = orm.writeSet().insertAndFetchId(visit);                // single root
+```
+
+</TabItem>
+</Tabs>
+
 ## Refs
 
 Foreign key fields typed as `Ref` participate through entity-wrapped refs, which carry the instance:
@@ -211,7 +232,7 @@ The unsaved entity's default id in the key component is a placeholder; the write
 The remaining actions follow the same contract, each with the ordering that suits it:
 
 - `update` groups the explicit members by type and updates them with the usual semantics, including transaction-scoped dirty checking: unchanged entities are skipped. Referenced entities are never updated implicitly: an updated `Owner` held inside a `Pet` you update is not written, it contributes only its primary key. Pass both when both changed; dirty checking skips whichever members are unchanged. Unsaved members are rejected; a row that does not exist cannot be updated.
-- `upsert` applies the per-repository upsert semantics to the explicit members and inserts the discovered members of the insertion closure, with keys propagating as for insert. Explicit membership takes precedence: a keyed entity that is both supplied and referenced by another member is upserted, and is written before the members that reference it. Whether an upsert can create a row for a member carrying a preset key follows the dialect's per-repository upsert behavior.
+- `upsert` applies the per-repository upsert semantics to the explicit members and inserts the discovered members of the insertion closure, with keys propagating as for insert. Explicit membership takes precedence: a keyed entity that is both supplied and referenced by another member is upserted, and is written before the members that reference it. Whether an upsert can create a row for a member carrying a preset key follows the dialect's per-repository upsert behavior. `upsertAndFetch` and `upsertAndFetchIds` mirror the insert-side variants: rows re-read, or just the keys.
 - `remove` deletes exactly the explicit members, children before parents. Members are correlated by entity type and primary key rather than by instance, so a member referencing another member is removed first regardless of which instance its foreign key field holds. Referenced entities are never removed implicitly.
 
 <Tabs groupId="language">

--- a/website/src/pages/tutorials/object-graphs.js
+++ b/website/src/pages/tutorials/object-graphs.js
@@ -85,9 +85,11 @@ const SQL_STORM_INSERT = [
 ].join('');
 
 const CODE_STORM_FETCH = [
-  C('// Values never mutate: fetch the persisted graph back when you need the keys\n'),
+  C('// Values never mutate: fetch the persisted graph back, or just its keys\n'),
   K('val '), P('saved: '), T('Visit'), P(' = orm.'), F('writeSet'), P('().'), F('insertAndFetch'), P('(visit)\n'),
-  C('// saved.pet.owner.id carries the generated key; visit itself is untouched'),
+  C('// saved.pet.owner.id carries the generated key; visit itself is untouched\n'), P('\n'),
+  K('val '), P('ids = orm.'), F('writeSet'), P('().'), F('insertAndFetchIds'), P('(listOf(visit))\n'),
+  C('// keys in input order, straight from the insert: no re-read'),
 ].join('');
 
 const CODE_STORM_REMOVE = [

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -18,7 +18,7 @@
 > GitHub: https://github.com/storm-orm/storm-framework
 > License: Apache 2.0
 
-# Generated: 2026-07-19T07:40:11Z
+# Generated: 2026-07-21T18:55:08Z
 
 ========================================
 ## Source: index.md
@@ -9240,6 +9240,8 @@ dependencies {
 
 Storm auto-detects the serialization library at runtime. Just add the dependency and it works.
 
+Storm compiles against kotlinx-serialization 1.7.3 and uses only its stable core API, so any 1.7.3 or newer release works: your project's dependency resolution picks the version, and Storm floats along with it.
+
 ---
 
 ## JSON Columns
@@ -12250,6 +12252,21 @@ var fetchedPet = (Pet) inserted.get(0); // fetchedPet.owner() carries the genera
 
 Visit fetchedVisit = orm.writeSet().insertAndFetch(visit);       // single root, typed
 ```
+`insertAndFetchIds` returns just the primary keys of the explicit members, in input order, without re-reading the rows: the keys come from the insert itself. It is the middle tier between `insert` (nothing back) and `insertAndFetch` (rows re-read with database-applied state), and the natural fit for a create endpoint that responds with ids. The batch is homogeneous in its id type; entity types may differ as long as they share it, and a batch that mixes id types keeps using `insertAndFetch`, where each returned entity carries its own id.
+
+[Kotlin]
+
+```kotlin
+val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)   // keys in input order, no re-read
+val id: Long = orm.writeSet().insertAndFetchId(visit)            // single root
+```
+
+[Java]
+
+```java
+List<Long> ids = orm.writeSet().insertAndFetchIds(visits);       // keys in input order, no re-read
+Long id = orm.writeSet().insertAndFetchId(visit);                // single root
+```
 ## Refs
 
 Foreign key fields typed as `Ref` participate through entity-wrapped refs, which carry the instance:
@@ -12326,7 +12343,7 @@ The unsaved entity's default id in the key component is a placeholder; the write
 The remaining actions follow the same contract, each with the ordering that suits it:
 
 - `update` groups the explicit members by type and updates them with the usual semantics, including transaction-scoped dirty checking: unchanged entities are skipped. Referenced entities are never updated implicitly: an updated `Owner` held inside a `Pet` you update is not written, it contributes only its primary key. Pass both when both changed; dirty checking skips whichever members are unchanged. Unsaved members are rejected; a row that does not exist cannot be updated.
-- `upsert` applies the per-repository upsert semantics to the explicit members and inserts the discovered members of the insertion closure, with keys propagating as for insert. Explicit membership takes precedence: a keyed entity that is both supplied and referenced by another member is upserted, and is written before the members that reference it. Whether an upsert can create a row for a member carrying a preset key follows the dialect's per-repository upsert behavior.
+- `upsert` applies the per-repository upsert semantics to the explicit members and inserts the discovered members of the insertion closure, with keys propagating as for insert. Explicit membership takes precedence: a keyed entity that is both supplied and referenced by another member is upserted, and is written before the members that reference it. Whether an upsert can create a row for a member carrying a preset key follows the dialect's per-repository upsert behavior. `upsertAndFetch` and `upsertAndFetchIds` mirror the insert-side variants: rows re-read, or just the keys.
 - `remove` deletes exactly the explicit members, children before parents. Members are correlated by entity type and primary key rather than by instance, so a member referencing another member is removed first regardless of which instance its foreign key field holds. Referenced entities are never removed implicitly.
 
 [Kotlin]

--- a/website/static/skills/storm-repository-java.md
+++ b/website/static/skills/storm-repository-java.md
@@ -266,6 +266,9 @@ orm.writeSet().insert(List.of(wolfie, rex, visit));        // owner discovered a
 // Typed single-root variant: whole graph in, keyed root out
 Visit fetched = orm.writeSet().insertAndFetch(visit);
 
+// Keys only, in input order, no re-read: the middle tier between insert and insertAndFetch
+List<Long> ids = orm.writeSet().insertAndFetchIds(List.of(visit));
+
 // update/remove write only the entities passed, no discovery; children are removed before parents
 orm.writeSet().update(List.of(changedOwner, changedPet));
 orm.writeSet().remove(List.of(visit, pet, owner));

--- a/website/static/skills/storm-repository-kotlin.md
+++ b/website/static/skills/storm-repository-kotlin.md
@@ -370,6 +370,9 @@ orm.writeSet().insert(listOf(wolfie, rex, visit))   // owner discovered and inse
 // Typed single-root variant: whole graph in, keyed root out
 val fetched: Visit = orm.writeSet().insertAndFetch(visit)
 
+// Keys only, in input order, no re-read: the middle tier between insert and insertAndFetch
+val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)
+
 // Scoped block; each verb executes immediately, wrap in a transaction for atomicity
 transaction {
     orm.writeSet {


### PR DESCRIPTION
## Summary

Documentation for the `WriteSet` id-returning methods added in #303, plus one unrelated compatibility note.

- **`docs/write-sets.md`**: a new passage in Fetching the Result documents `insertAndFetchIds` / `insertAndFetchId` as the middle tier between `insert` and `insertAndFetch`: keys from the insert itself in input order, no re-read, explicit members only, homogeneous id type with mixed batches directed to `insertAndFetch`. The upsert section notes the `upsertAndFetch(Ids)` mirrors.
- **`docs/jpa-cascades-vs-write-sets.md`**: a pointer after the `insertAndFetch` migration example for readers who only need the keys.
- **Skills** (`storm-repository-java.md`, `storm-repository-kotlin.md`) and the **object-graphs tutorial**: the id tier added to the write-set examples.
- **`llms-full.txt`**: regenerated from the docs.
- **`docs/json.md`**: states the kotlinx-serialization compatibility contract: Storm compiles against 1.7.3 using only stable core API, so any newer release works and the project's own resolution picks the version.

Docs changes appear at /docs/next until the next release snapshot; the skills and tutorial deploy with the site.