### PR TITLE
feat(kotlin): vararg insertAndFetchIds and upsertAndFetchIds extensions for WriteSet

### DIFF
--- a/docs/write-sets.md
+++ b/docs/write-sets.md
@@ -119,12 +119,15 @@ Visit fetchedVisit = orm.writeSet().insertAndFetch(visit);       // single root,
 
 `insertAndFetchIds` returns just the primary keys of the explicit members, in input order, without re-reading the rows: the keys come from the insert itself. It is the middle tier between `insert` (nothing back) and `insertAndFetch` (rows re-read with database-applied state), and the natural fit for a create endpoint that responds with ids. The batch is homogeneous in its id type; entity types may differ as long as they share it, and a batch that mixes id types keeps using `insertAndFetch`, where each returned entity carries its own id.
 
+Kotlin additionally offers the id-returning methods as vararg extension functions (in `st.orm.repository`). The interface itself cannot declare them: `@SafeVarargs` is not applicable to interface default methods, so a Java-side generic vararg would emit heap-pollution warnings at every call site. Java call sites pass `List.of(...)`, which supplies the varargs ergonomics there.
+
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
 
 ```kotlin
-val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)   // keys in input order, no re-read
-val id: Long = orm.writeSet().insertAndFetchId(visit)            // single root
+val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)     // keys in input order, no re-read
+val two: List<Long> = orm.writeSet().insertAndFetchIds(pet, visit) // vararg extension; one shared id type
+val id: Long = orm.writeSet().insertAndFetchId(visit)              // single root
 ```
 
 </TabItem>

--- a/storm-kotlin/src/main/kotlin/st/orm/repository/RepositoryLookup.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/repository/RepositoryLookup.kt
@@ -139,6 +139,30 @@ inline fun <R> RepositoryLookup.writeSet(block: WriteSet.() -> R): R = writeSet(
 inline fun <R> Repository.writeSet(block: WriteSet.() -> R): R = writeSet().block()
 
 /**
+ * Inserts the given entities and their insertion closure and returns the primary keys of the explicit members, in
+ * argument order; see [WriteSet.insertAndFetchIds].
+ *
+ * The batch is homogeneous in its id type; entity types may differ as long as they share it. The vararg form is a
+ * Kotlin extension because the interface cannot offer it: `@SafeVarargs` is not applicable to interface default
+ * methods, so a Java-side generic vararg would emit heap-pollution warnings at every call site.
+ *
+ * @since 1.13
+ */
+fun <ID : Any> WriteSet.insertAndFetchIds(vararg entities: Entity<ID>): List<ID> = insertAndFetchIds(entities.asList())
+
+/**
+ * Upserts the given entities and their insertion closure and returns the primary keys of the explicit members, in
+ * argument order; see [WriteSet.upsertAndFetchIds].
+ *
+ * The batch is homogeneous in its id type; entity types may differ as long as they share it. The vararg form is a
+ * Kotlin extension because the interface cannot offer it: `@SafeVarargs` is not applicable to interface default
+ * methods, so a Java-side generic vararg would emit heap-pollution warnings at every call site.
+ *
+ * @since 1.13
+ */
+fun <ID : Any> WriteSet.upsertAndFetchIds(vararg entities: Entity<ID>): List<ID> = upsertAndFetchIds(entities.asList())
+
+/**
  * Returns the repository for entity type [T] with primary key type [ID].
  *
  * The primary key type can be inferred from the entity declaration with the underscore operator:

--- a/storm-kotlin/src/test/kotlin/st/orm/template/WriteSetTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/WriteSetTest.kt
@@ -14,6 +14,7 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import st.orm.PersistenceException
 import st.orm.repository.entity
+import st.orm.repository.insertAndFetchIds
 import st.orm.repository.writeSet
 import st.orm.template.model.Address
 import st.orm.template.model.City
@@ -125,5 +126,16 @@ open class WriteSetTest(
         orm.entity<Owner, _>().findAll().none { it.firstName == "Vera" } shouldBe true
         orm.entity<Pet, _>().findAll().none { it.name == "VarargPet" } shouldBe true
         orm.entity<Visit, _>().findAll().none { it.description == "Vararg visit" } shouldBe true
+    }
+
+    @Test
+    fun `insertAndFetchIds should accept entities as varargs`() {
+        val owner = newOwner("Ida")
+        val pet = Pet(name = "VarargIdsPet", birthDate = LocalDate.of(2024, 5, 5), type = dog, owner = owner)
+        val visit = Visit(visitDate = LocalDate.of(2026, 7, 22), description = "Vararg ids visit", pet = pet, timestamp = Instant.now())
+        val ids = orm.writeSet().insertAndFetchIds(pet, visit)
+        ids shouldHaveSize 2
+        orm.entity<Pet, _>().findAll().single { it.name == "VarargIdsPet" }.id shouldBe ids[0]
+        orm.entity<Visit, _>().findAll().single { it.description == "Vararg ids visit" }.id shouldBe ids[1]
     }
 }

--- a/website/static/skills/storm-repository-kotlin.md
+++ b/website/static/skills/storm-repository-kotlin.md
@@ -372,6 +372,7 @@ val fetched: Visit = orm.writeSet().insertAndFetch(visit)
 
 // Keys only, in input order, no re-read: the middle tier between insert and insertAndFetch
 val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)
+val two: List<Long> = orm.writeSet().insertAndFetchIds(pet, visit)   // vararg extension; one shared id type
 
 // Scoped block; each verb executes immediately, wrap in a transaction for atomicity
 transaction {


### PR DESCRIPTION
## Summary

Adds Kotlin vararg forms of the id-returning write-set methods as extension functions in `st.orm.repository` (storm-kotlin):

```kotlin
val ids: List<Int> = orm.writeSet().insertAndFetchIds(pet, visit)   // keys in argument order, no re-read
```

The interface itself cannot offer these: `@SafeVarargs` is not applicable to interface default methods, so a Java-side generic `Entity<ID>...` overload would emit an unsuppressible heap-pollution warning at every call site. The fetch-tier varargs (`insert`, `insertAndFetch`, `remove`, ...) are unaffected because `Entity<?>...` is a reifiable array type. Java call sites keep passing `List.of(...)`, which supplies the varargs ergonomics there; the KDoc and docs record this rationale.

## Changes

- `RepositoryLookup.kt`: `WriteSet.insertAndFetchIds(vararg)` and `WriteSet.upsertAndFetchIds(vararg)` extensions, delegating to the `Iterable` members.
- `WriteSetTest.kt`: new test asserting the vararg form returns the persisted keys in argument order.
- `docs/write-sets.md` and `website/static/skills/storm-repository-kotlin.md`: vararg form shown in the Kotlin snippets, with a note on why the Java surface stays on `List.of(...)`.

## Testing

`./mvnw -pl storm-kotlin test -Dtest=WriteSetTest`: 8 tests, 0 failures. No upsert-vararg test on H2: `upsertAndFetchIds` throws on H2 per the existing dialect tests, and the extension is a trivial delegate.