### PR TITLE
docs: use the wolfie example variable in the vararg ids snippets

### DIFF
--- a/docs/write-sets.md
+++ b/docs/write-sets.md
@@ -125,9 +125,9 @@ Kotlin additionally offers the id-returning methods as vararg extension function
 <TabItem value="kotlin" label="Kotlin" default>
 
 ```kotlin
-val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)     // keys in input order, no re-read
-val two: List<Long> = orm.writeSet().insertAndFetchIds(pet, visit) // vararg extension; one shared id type
-val id: Long = orm.writeSet().insertAndFetchId(visit)              // single root
+val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)        // keys in input order, no re-read
+val two: List<Long> = orm.writeSet().insertAndFetchIds(wolfie, visit) // vararg extension; one shared id type
+val id: Long = orm.writeSet().insertAndFetchId(visit)                 // single root
 ```
 
 </TabItem>

--- a/website/static/skills/storm-repository-kotlin.md
+++ b/website/static/skills/storm-repository-kotlin.md
@@ -372,7 +372,7 @@ val fetched: Visit = orm.writeSet().insertAndFetch(visit)
 
 // Keys only, in input order, no re-read: the middle tier between insert and insertAndFetch
 val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)
-val two: List<Long> = orm.writeSet().insertAndFetchIds(pet, visit)   // vararg extension; one shared id type
+val two: List<Long> = orm.writeSet().insertAndFetchIds(wolfie, visit)   // vararg extension; one shared id type
 
 // Scoped block; each verb executes immediately, wrap in a transaction for atomicity
 transaction {


### PR DESCRIPTION
Follow-up to #306, addressing the Copilot review comments: the vararg `insertAndFetchIds` snippets in `docs/write-sets.md` and the Kotlin repository skill referenced `pet`, a variable the surrounding examples never define. The examples define `wolfie`, `rex` and `visit`, so the snippets now pass `wolfie, visit`, keeping them copy/paste consistent with the rest of the write-set documentation.