### PR TITLE
fix(core): row identity for entity-typed primary keys in write sets, caches and refs

### DIFF
--- a/storm-core/src/main/java/st/orm/core/repository/impl/DirtySupport.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/DirtySupport.java
@@ -255,6 +255,9 @@ public final class DirtySupport<E extends Entity<ID>, ID> {
             dirtyCheckMetrics.recordDirtyCacheMiss();
             return DIRTY;
         }
+        // The cache keys by row identity (see RowIdentity), so the lookup hits even when an entity-typed key
+        // diverges from the cached state in a non-key column. A miss falls through to the conservative answer:
+        // treat every field as dirty and issue a full update.
         var cached = cache.get(entity.id()).orElse(null);
         if (cached == null) {
             // Not cached, assume all fields are dirty.

--- a/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/WriteSetImpl.java
@@ -44,6 +44,7 @@ import st.orm.core.repository.RepositoryLookup;
 import st.orm.core.spi.Instantiators;
 import st.orm.core.spi.ORMReflection;
 import st.orm.core.spi.Providers;
+import st.orm.core.spi.RowIdentity;
 import st.orm.core.template.Column;
 import st.orm.core.template.Model;
 import st.orm.mapping.Instantiator;
@@ -444,11 +445,21 @@ public final class WriteSetImpl implements WriteSet {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     private void remove(@Nonnull EntityRepository repository, @Nonnull List<Object> batch) {
-        repository.remove((Iterable) batch);
+        repository.remove(batch);
     }
 
-    /** Key correlating remove members by row rather than by instance. */
-    private record TypeIdKey(Class<?> type, Object id) {}
+    /**
+     * Key correlating members by database row rather than by instance. The id is normalized through
+     * {@link RowIdentity}: comparing raw ids would make row identity depend on every non-key column of an
+     * entity-typed key, so two representations of the same row would fail to correlate whenever such a column does
+     * not round-trip bit-exact (a second-precision timestamp column, a database-managed column, a numeric scale
+     * difference).
+     */
+    private record TypeIdKey(Class<?> type, Object id) {
+        TypeIdKey {
+            id = RowIdentity.normalize(id);
+        }
+    }
 
     //
     // Shared machinery.

--- a/storm-core/src/main/java/st/orm/core/spi/AbstractRef.java
+++ b/storm-core/src/main/java/st/orm/core/spi/AbstractRef.java
@@ -15,6 +15,7 @@
  */
 package st.orm.core.spi;
 
+import jakarta.annotation.Nullable;
 import java.util.Objects;
 import st.orm.Data;
 import st.orm.Ref;
@@ -23,14 +24,56 @@ import st.orm.Ref;
  * Abstract implementation of {@link Ref} to have consistent implementations of {@link #hashCode()}
  * and {@link #equals(Object)}.
  *
+ * <p>Equality is based on the type and the row identity of the id (see {@link RowIdentity}), matching the detached
+ * ref implementations of the foundation module: an entity-typed id counts by its primary key rather than by
+ * structural equality, so two refs describing the same database row compare equal even when a non-key column of
+ * the key entity does not round-trip bit-exact. Scalar ids, and composite ids carrying only scalars, are compared
+ * as-is.</p>
+ *
  * @param <T> record type.
  * @since 1.3
  */
 abstract class AbstractRef<T extends Data> implements Ref<T> {
 
+    /**
+     * Row identity of the id. Assigned at construction when the creator has already resolved the identity at type
+     * level (a factory creating refs per row); otherwise computed lazily on first use, because only map-keyed usage
+     * needs the identity. The lazy computation is idempotent over the immutable id, so the unsynchronized
+     * publication is a benign race, as with {@code String} hash caching.
+     */
+    private Object rowId;
+
+    AbstractRef() {
+    }
+
+    AbstractRef(@Nullable Object rowId) {
+        this.rowId = rowId;
+    }
+
+    private Object rowId() {
+        Object rowId = this.rowId;
+        if (rowId == null) {
+            rowId = RowIdentity.normalize(id());
+            this.rowId = rowId;
+        }
+        return rowId;
+    }
+
+    /**
+     * Lazily computed hash code over the type and row identity, both immutable; zero means not yet computed and a
+     * value that genuinely hashes to zero is recomputed on each call, as with {@code String} hash caching. The
+     * formula is allocation-free, unlike a varargs-based hash.
+     */
+    private int hash;
+
     @Override
     public int hashCode() {
-        return Objects.hash(type(), id());
+        int hash = this.hash;
+        if (hash == 0) {
+            hash = (31 + type().hashCode()) * 31 + Objects.hashCode(rowId());
+            this.hash = hash;
+        }
+        return hash;
     }
 
     @Override
@@ -38,9 +81,13 @@ abstract class AbstractRef<T extends Data> implements Ref<T> {
         if (this == obj) {
             return true;
         }
+        if (obj instanceof AbstractRef<?> other) {
+            return Objects.equals(type(), other.type())
+                    && Objects.equals(rowId(), other.rowId());
+        }
         if (obj instanceof Ref<?> l) {
             return Objects.equals(type(), l.type())
-                    && Objects.equals(id(), l.id());
+                    && Objects.equals(rowId(), RowIdentity.normalize(l.id()));
         }
         return false;
     }

--- a/storm-core/src/main/java/st/orm/core/spi/EntityCacheImpl.java
+++ b/storm-core/src/main/java/st/orm/core/spi/EntityCacheImpl.java
@@ -84,8 +84,17 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
     /** Queue for tracking garbage-collected entities to enable lazy cleanup of {@link #map}. */
     private final ReferenceQueue<E> queue = new ReferenceQueue<>();
 
-    /** Map from primary key to referenced entity. Keys are held strongly; values are weak or soft references. */
-    private final Map<ID, PkReference<ID, E>> map = new HashMap<>();
+    /**
+     * Map from row identity to referenced entity. Keys are held strongly; values are weak or soft references.
+     *
+     * <p>Keys are primary key values normalized through {@link RowIdentity}, so an entity-typed key matches by its
+     * database key rather than by structural equality: two representations of the same row that diverge in a
+     * non-key column (for example after a lossy database round-trip) still resolve to the same entry. A wrong hit
+     * remains impossible, because equal row identities denote the same row by construction. Scalar keys, and
+     * composite keys carrying only scalars, are used as-is; the per-class decision is cached, so such keys pay a
+     * single cached class probe and no allocation.</p>
+     */
+    private final Map<Object, PkReference<E>> map = new HashMap<>();
 
     /**
      * Retrieves an entity from the cache by primary key, if available.
@@ -99,7 +108,8 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
      */
     @Override
     public Optional<E> get(@Nonnull ID pk) {
-        PkReference<ID, E> ref = map.get(requireNonNull(pk));
+        Object key = RowIdentity.normalize(requireNonNull(pk));
+        PkReference<E> ref = map.get(key);
         if (ref == null) {
             metrics.recordGetMiss();
             return Optional.empty();
@@ -110,7 +120,7 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
             return Optional.of(value);
         }
         // Collected but not yet drained.
-        map.remove(pk, ref);
+        map.remove(key, ref);
         metrics.recordGetMiss();
         return Optional.empty();
     }
@@ -135,8 +145,8 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
     @Override
     public E intern(@Nonnull E entity) {
         drainQueue();
-        ID pk = entity.id();
-        PkReference<ID, E> existingRef = map.get(pk);
+        Object key = RowIdentity.normalize(entity.id());
+        PkReference<E> existingRef = map.get(key);
         if (existingRef != null) {
             E existing = existingRef.get();
             if (existing != null && existing.equals(entity)) {
@@ -144,7 +154,7 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
                 return existing;
             }
         }
-        map.put(pk, createReference(pk, entity));
+        map.put(key, createReference(key, entity));
         metrics.recordInternMiss();
         return entity;
     }
@@ -152,14 +162,14 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
     /**
      * Creates a reference to the given entity with the configured retention behavior.
      *
-     * @param pk the primary key.
+     * @param key the normalized primary key.
      * @param entity the entity to reference.
      * @return a reference based on {@link #retention}.
      */
-    private PkReference<ID, E> createReference(ID pk, E entity) {
+    private PkReference<E> createReference(Object key, E entity) {
         return retention == CacheRetention.LIGHT
-                ? new PkWeakReference<>(pk, entity, queue)
-                : new PkSoftReference<>(pk, entity, queue);
+                ? new PkWeakReference<>(key, entity, queue)
+                : new PkSoftReference<>(key, entity, queue);
     }
 
     /**
@@ -172,7 +182,7 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
      */
     @Override
     public void remove(@Nonnull ID pk) {
-        map.remove(requireNonNull(pk));
+        map.remove(RowIdentity.normalize(requireNonNull(pk)));
         metrics.recordRemoval();
     }
 
@@ -198,9 +208,8 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
     private void drainQueue() {
         Reference<? extends E> ref;
         while ((ref = queue.poll()) != null) {
-            if (ref instanceof PkReference<?, ?> pkRef) {
-                //noinspection unchecked
-                if (map.remove(((PkReference<ID, E>) pkRef).pk(), pkRef)) {
+            if (ref instanceof PkReference<?> pkRef) {
+                if (map.remove(pkRef.pk(), pkRef)) {
                     metrics.recordEviction();
                 }
             }
@@ -208,32 +217,31 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
     }
 
     /**
-     * A reference to an entity that retains the associated primary key for map cleanup.
+     * A reference to an entity that retains the associated normalized primary key for map cleanup.
      *
      * <p>When the entity is garbage collected, this reference is enqueued in the {@link ReferenceQueue}, allowing
-     * {@link #drainQueue()} to remove the corresponding entry from {@link #map} using the stored primary key.</p>
+     * {@link #drainQueue()} to remove the corresponding entry from {@link #map} using the stored key.</p>
      *
-     * @param <ID> the primary key type.
      * @param <E> the entity type.
      */
-    private sealed interface PkReference<ID, E> permits PkWeakReference, PkSoftReference {
-        ID pk();
+    private sealed interface PkReference<E> permits PkWeakReference, PkSoftReference {
+        Object pk();
         E get();
     }
 
     /**
      * A weak reference implementation of {@link PkReference}.
      */
-    private static final class PkWeakReference<ID, E> extends WeakReference<E> implements PkReference<ID, E> {
-        private final ID pk;
+    private static final class PkWeakReference<E> extends WeakReference<E> implements PkReference<E> {
+        private final Object pk;
 
-        PkWeakReference(ID pk, E referent, ReferenceQueue<? super E> q) {
+        PkWeakReference(Object pk, E referent, ReferenceQueue<? super E> q) {
             super(referent, q);
             this.pk = pk;
         }
 
         @Override
-        public ID pk() {
+        public Object pk() {
             return pk;
         }
     }
@@ -241,16 +249,16 @@ public final class EntityCacheImpl<E extends Entity<ID>, ID> implements EntityCa
     /**
      * A soft reference implementation of {@link PkReference}.
      */
-    private static final class PkSoftReference<ID, E> extends SoftReference<E> implements PkReference<ID, E> {
-        private final ID pk;
+    private static final class PkSoftReference<E> extends SoftReference<E> implements PkReference<E> {
+        private final Object pk;
 
-        PkSoftReference(ID pk, E referent, ReferenceQueue<? super E> q) {
+        PkSoftReference(Object pk, E referent, ReferenceQueue<? super E> q) {
             super(referent, q);
             this.pk = pk;
         }
 
         @Override
-        public ID pk() {
+        public Object pk() {
             return pk;
         }
     }

--- a/storm-core/src/main/java/st/orm/core/spi/RefFactoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/spi/RefFactoryImpl.java
@@ -37,6 +37,15 @@ import st.orm.core.template.impl.ORMTemplateImpl;
 public final class RefFactoryImpl implements RefFactory {
     private final QueryTemplate template;
 
+    /**
+     * The pk class most recently resolved as being its own row identity. Refs are created per row during
+     * materialization with the same pk class throughout, so this resolves the row identity decision at type level
+     * once and hands every ref its identity at construction, leaving one pointer comparison per ref. A single field
+     * keeps the unsynchronized access safe: a stale read can only miss (falling back to the resolution or to the
+     * ref's lazy path), never claim self-identity for a class that requires normalization.
+     */
+    private Class<?> selfIdentityPkClass;
+
     public RefFactoryImpl(@Nonnull QueryFactory factory,
                           @Nonnull ModelBuilder modelBuilder,
                           @Nullable Predicate<? super Provider> providerFilter) {
@@ -126,6 +135,23 @@ public final class RefFactoryImpl implements RefFactory {
      * @param <ID> primary key type.
      */
     private <T extends Data, ID> Ref<T> create(@Nonnull LazySupplier<T> supplier, @Nonnull Class<T> type, @Nonnull ID pk) {
-        return new RefImpl<>(supplier, type, pk);
+        return new RefImpl<>(supplier, type, pk, rowIdentity(pk));
+    }
+
+    /**
+     * Returns the row identity of the given pk when its class is known to be its own identity, or {@code null} to
+     * defer to the ref's lazy computation.
+     */
+    @Nullable
+    private Object rowIdentity(@Nonnull Object pk) {
+        Class<?> pkClass = pk.getClass();
+        if (pkClass == selfIdentityPkClass) {
+            return pk;
+        }
+        if (!RowIdentity.requiresNormalization(pkClass)) {
+            selfIdentityPkClass = pkClass;
+            return pk;
+        }
+        return null;
     }
 }

--- a/storm-core/src/main/java/st/orm/core/spi/RefImpl.java
+++ b/storm-core/src/main/java/st/orm/core/spi/RefImpl.java
@@ -36,7 +36,8 @@ final class RefImpl<T extends Data, ID> extends AbstractRef<T> {
     private final Class<T> type;
     private final ID pk;
 
-    RefImpl(@Nonnull LazySupplier<T> supplier, @Nonnull Class<T> type, @Nonnull ID pk) {
+    RefImpl(@Nonnull LazySupplier<T> supplier, @Nonnull Class<T> type, @Nonnull ID pk, @Nullable Object rowId) {
+        super(rowId);
         this.supplier = requireNonNull(supplier, "supplier");
         this.type = requireNonNull(type, "type");
         this.pk = requireNonNull(pk, "pk");

--- a/storm-core/src/main/java/st/orm/core/spi/RowIdentity.java
+++ b/storm-core/src/main/java/st/orm/core/spi/RowIdentity.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.spi;
+
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import st.orm.Entity;
+import st.orm.Ref;
+import st.orm.mapping.RecordField;
+import st.orm.mapping.RecordType;
+
+/**
+ * Normalizes primary key values to row identity: the value the SQL layer binds in a WHERE clause.
+ *
+ * <p>A scalar key is its own row identity. An entity-typed key carries the key column plus every non-key column of
+ * the entity and its foreign key closure, so structural equality on it is wider than the identity it denotes: two
+ * representations of the same row diverge whenever a non-key column does not round-trip bit-exact (a
+ * second-precision timestamp column, a database-managed column, a numeric scale difference). Normalization reduces
+ * such a key to its scalar form: an entity contributes only its own primary key, applied recursively, a ref
+ * contributes the key it wraps, and a composite key record contributes its components, normalized element-wise.
+ * Composite keys are detected through the pluggable reflection support, covering Java records and Kotlin data
+ * classes alike.</p>
+ *
+ * <p>Whether a class requires normalization is decided once per class, from its declared component types, and
+ * cached. Values of classes whose key graph cannot carry non-key state (scalars, and composite key records
+ * containing only scalars) are returned unchanged, so lookups keyed by such values pay a single cached class probe
+ * and no allocation.</p>
+ *
+ * @since 1.13
+ */
+public final class RowIdentity {
+
+    private RowIdentity() {
+    }
+
+    /** Defers provider resolution to first use, keeping class initialization free of provider lookups. */
+    private static final class ReflectionHolder {
+        static final ORMReflection REFLECTION = Providers.getORMReflection();
+    }
+
+    /** Decided once per class: whether values of this class can carry non-key state that normalization must strip. */
+    private static final ClassValue<Boolean> NORMALIZATION_REQUIRED = new ClassValue<>() {
+        @Override
+        protected Boolean computeValue(Class<?> type) {
+            return requiresNormalization(type, new HashSet<>());
+        }
+    };
+
+    private static boolean requiresNormalization(Class<?> type, Set<Class<?>> visited) {
+        if (Ref.class.isAssignableFrom(type) || Entity.class.isAssignableFrom(type)) {
+            return true;
+        }
+        if (!visited.add(type)) {
+            // A self-referential component type contributes no component types beyond those already inspected.
+            return false;
+        }
+        Optional<RecordType> recordType = ReflectionHolder.REFLECTION.findRecordType(type);
+        if (recordType.isEmpty()) {
+            return false;
+        }
+        for (RecordField field : recordType.get().fields()) {
+            if (requiresNormalization(field.type(), visited)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns whether values of the given class require normalization to obtain their row identity.
+     *
+     * <p>The decision is made once per class and cached. Values of classes for which this method returns
+     * {@code false} are their own row identity: {@link #normalize(Object)} returns them unchanged, so callers that
+     * resolve this decision at type level can skip normalization entirely for such values.</p>
+     *
+     * @param type the class of the primary key value.
+     * @return {@code true} if values of this class carry non-key state that normalization must strip.
+     */
+    public static boolean requiresNormalization(Class<?> type) {
+        return NORMALIZATION_REQUIRED.get(type);
+    }
+
+    /**
+     * Returns the row identity of the given primary key value.
+     *
+     * <p>Values of classes that cannot carry non-key state are returned as-is; equal inputs always map to equal
+     * results, and results of the same key class are directly comparable with each other.</p>
+     *
+     * @param id the primary key value to normalize, may be {@code null}.
+     * @return the row identity of the value, or the value itself when its class requires no normalization.
+     */
+    @Nullable
+    public static Object normalize(@Nullable Object id) {
+        if (id == null || !NORMALIZATION_REQUIRED.get(id.getClass())) {
+            return id;
+        }
+        if (id instanceof Ref<?> ref) {
+            return normalize(ref.id());
+        }
+        if (id instanceof Entity<?> entity) {
+            return normalize(entity.id());
+        }
+        RecordType recordType = ReflectionHolder.REFLECTION.getRecordType(id.getClass());
+        int fieldCount = recordType.fields().size();
+        List<Object> normalized = new ArrayList<>(fieldCount);
+        for (int i = 0; i < fieldCount; i++) {
+            normalized.add(normalize(ReflectionHolder.REFLECTION.getRecordValue(id, i)));
+        }
+        return normalized;
+    }
+}

--- a/storm-core/src/test/java/st/orm/core/WriteSetIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/WriteSetIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.annotation.Nonnull;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.sql.DataSource;
@@ -25,6 +26,9 @@ import st.orm.Persist;
 import st.orm.PersistenceException;
 import st.orm.Ref;
 import st.orm.core.model.Address;
+import st.orm.core.model.Appointment;
+import st.orm.core.model.AppointmentReport;
+import st.orm.core.model.AppointmentReportReview;
 import st.orm.core.model.City;
 import st.orm.core.model.Owner;
 import st.orm.core.model.OwnerPrimaryPet;
@@ -368,6 +372,56 @@ public class WriteSetIntegrationTest {
         var fetched = orm.writeSet().insertAndFetch(new OwnerPrimaryPet(owner, pet));
         assertNotEquals(0, (int) fetched.owner().id());
         assertEquals(fetched.owner().id(), fetched.pet().owner().id());
+    }
+
+    @Test
+    public void testInsertAndFetchEntityTypedKeyWithSubSecondTimestamp() {
+        var orm = orm();
+        // The appointment carries sub-second precision that the second-precision column does not store, so the
+        // key entity read back from the database differs structurally from the in-memory instance; the fetch
+        // correlates by the database key.
+        var appointment = new Appointment(0, "Vaccination", LocalDateTime.of(2026, 5, 4, 10, 30, 15, 123_456_789));
+        var fetched = orm.writeSet().insertAndFetch(new AppointmentReport(appointment, "All clear"));
+        assertNotEquals(0, (int) fetched.appointment().id());
+        assertEquals("All clear", fetched.report());
+        // The database column stores no sub-second precision, so the fetched key entity is structurally different
+        // from the in-memory one even though both describe the same row.
+        assertEquals(0, fetched.appointment().scheduledAt().getNano());
+        assertNotEquals(appointment.scheduledAt(), fetched.appointment().scheduledAt());
+    }
+
+    @Test
+    public void testInsertOrdersReferenceToKeyedMemberByDatabaseKey() {
+        var orm = orm();
+        var appointment = orm.writeSet().insertAndFetch(new Appointment(0, "Surgery", LocalDateTime.of(2026, 6, 2, 14, 0)));
+        var report = new AppointmentReport(appointment, "Planned");
+        // The review references the report row through a different key entity instance that diverges in a non-key
+        // column; write ordering still places the report before the review.
+        var divergentAppointment = new Appointment(appointment.id(), "Surgery", appointment.scheduledAt().withNano(123_456_789));
+        var review = new AppointmentReportReview(0, new AppointmentReport(divergentAppointment, "Planned"), "Follow-up");
+        orm.writeSet().insert(List.of(review, report));
+        var reviews = orm.entity(AppointmentReportReview.class).select().getResultList().stream()
+                .filter(candidate -> candidate.appointmentReport().appointment().id().equals(appointment.id()))
+                .toList();
+        assertEquals(1, reviews.size());
+        assertEquals("Follow-up", reviews.getFirst().review());
+    }
+
+    @Test
+    public void testRemoveCorrelatesDivergentInstancesOfEntityTypedKeyRow() {
+        var orm = orm();
+        var appointment = orm.writeSet().insertAndFetch(new Appointment(0, "Dental", LocalDateTime.of(2026, 6, 1, 9, 0)));
+        var report = orm.writeSet().insertAndFetch(new AppointmentReport(appointment, "Initial"));
+        var review = orm.writeSet().insertAndFetch(new AppointmentReportReview(0, report, "Thorough"));
+        // The review embeds a report instance whose key entity diverges from the passed report member in a non-key
+        // column; delete ordering still recognizes them as the same row and removes the review before the report.
+        var divergentAppointment = new Appointment(appointment.id(), "Dental", appointment.scheduledAt().withNano(987_654_321));
+        var divergentReview = new AppointmentReportReview(review.id(), new AppointmentReport(divergentAppointment, "Initial"), "Thorough");
+        orm.writeSet().remove(List.of(report, divergentReview));
+        assertTrue(orm.entity(AppointmentReportReview.class).select().getResultList().stream()
+                .noneMatch(candidate -> candidate.id().equals(review.id())));
+        assertTrue(orm.entity(AppointmentReport.class).select().getResultList().stream()
+                .noneMatch(candidate -> candidate.appointment().id().equals(appointment.id())));
     }
 
     @DbTable("vet_badge")

--- a/storm-core/src/test/java/st/orm/core/model/Appointment.java
+++ b/storm-core/src/test/java/st/orm/core/model/Appointment.java
@@ -1,0 +1,16 @@
+package st.orm.core.model;
+
+import jakarta.annotation.Nonnull;
+import java.time.LocalDateTime;
+import st.orm.Entity;
+import st.orm.PK;
+
+/**
+ * Entity whose {@code scheduled_at} column is declared with second precision, so a database round-trip drops any
+ * sub-second part of the in-memory value and the two representations are not structurally equal.
+ */
+public record Appointment(
+        @PK Integer id,
+        @Nonnull String description,
+        @Nonnull LocalDateTime scheduledAt
+) implements Entity<Integer> {}

--- a/storm-core/src/test/java/st/orm/core/model/AppointmentReport.java
+++ b/storm-core/src/test/java/st/orm/core/model/AppointmentReport.java
@@ -1,0 +1,18 @@
+package st.orm.core.model;
+
+import static st.orm.GenerationStrategy.NONE;
+
+import jakarta.annotation.Nonnull;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+
+/**
+ * Junction-style entity whose primary key is an entity-typed foreign key to {@link Appointment}. Because the
+ * appointment carries a column that does not round-trip bit-exact, correlating this entity by its raw id value
+ * requires more than the database key; operations on it must correlate by the key column instead.
+ */
+public record AppointmentReport(
+        @Nonnull @PK(generation = NONE) @FK("appointment_id") Appointment appointment,
+        @Nonnull String report
+) implements Entity<Appointment> {}

--- a/storm-core/src/test/java/st/orm/core/model/AppointmentReportReview.java
+++ b/storm-core/src/test/java/st/orm/core/model/AppointmentReportReview.java
@@ -1,0 +1,15 @@
+package st.orm.core.model;
+
+import jakarta.annotation.Nonnull;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+
+/**
+ * Child of {@link AppointmentReport}, referencing the junction row through its entity-typed primary key.
+ */
+public record AppointmentReportReview(
+        @PK Integer id,
+        @Nonnull @FK("appointment_report_id") AppointmentReport appointmentReport,
+        @Nonnull String review
+) implements Entity<Integer> {}

--- a/storm-core/src/test/java/st/orm/core/spi/EntityCacheImplTest.java
+++ b/storm-core/src/test/java/st/orm/core/spi/EntityCacheImplTest.java
@@ -17,6 +17,8 @@ public class EntityCacheImplTest {
 
     record TestEntity(@PK Integer id, String name) implements Entity<Integer> {}
 
+    record TestEntityTag(@PK TestEntity entity, String tag) implements Entity<TestEntity> {}
+
     @BeforeEach
     public void resetMetrics() {
         EntityCacheMetrics.getInstance().reset();
@@ -79,6 +81,27 @@ public class EntityCacheImplTest {
 
         Optional<TestEntity> result = cache.get(1);
         assertTrue(result.isEmpty(), "Should be empty after removal");
+    }
+
+    @Test
+    public void testGetHitsForDivergentEntityTypedKey() {
+        EntityCacheImpl<TestEntityTag, TestEntity> cache = new EntityCacheImpl<>(CacheRetention.DEFAULT);
+        TestEntityTag tag = new TestEntityTag(new TestEntity(1, "Alice"), "gold");
+        cache.intern(tag);
+
+        // The key entity diverges in a non-key column; the cache resolves by row identity.
+        Optional<TestEntityTag> result = cache.get(new TestEntity(1, "Alice B."));
+        assertTrue(result.isPresent());
+        assertSame(tag, result.get());
+    }
+
+    @Test
+    public void testRemoveWithDivergentEntityTypedKey() {
+        EntityCacheImpl<TestEntityTag, TestEntity> cache = new EntityCacheImpl<>(CacheRetention.DEFAULT);
+        cache.intern(new TestEntityTag(new TestEntity(1, "Alice"), "gold"));
+
+        cache.remove(new TestEntity(1, "Alice B."));
+        assertTrue(cache.get(new TestEntity(1, "Alice")).isEmpty());
     }
 
     @Test

--- a/storm-core/src/test/java/st/orm/core/spi/RefEqualityTest.java
+++ b/storm-core/src/test/java/st/orm/core/spi/RefEqualityTest.java
@@ -1,0 +1,66 @@
+package st.orm.core.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+import st.orm.Entity;
+import st.orm.PK;
+import st.orm.Ref;
+
+/**
+ * Tests for ref equality across row-identity normalization: refs describing the same database row compare equal
+ * regardless of non-key divergence in an entity-typed id.
+ */
+public class RefEqualityTest {
+
+    record Town(@PK Integer id, String name) implements Entity<Integer> {}
+
+    record TownBadge(@PK Town town, String label) implements Entity<Town> {}
+
+    @Test
+    public void testScalarKeyedRefsCompareById() {
+        assertEquals(Ref.of(Town.class, 5), Ref.of(Town.class, 5));
+        assertEquals(Ref.of(Town.class, 5).hashCode(), Ref.of(Town.class, 5).hashCode());
+        assertNotEquals(Ref.of(Town.class, 5), Ref.of(Town.class, 6));
+    }
+
+    @Test
+    public void testDetachedIdRefEqualsWrappedEntityRef() {
+        Ref<Town> byId = Ref.of(Town.class, 5);
+        Ref<Town> wrapped = Ref.of(new Town(5, "Sun Paririe"));
+        assertEquals(byId, wrapped);
+        assertEquals(wrapped, byId);
+        assertEquals(byId.hashCode(), wrapped.hashCode());
+    }
+
+    @Test
+    public void testEntityTypedKeyRefsCompareByRowIdentity() {
+        // The key entities diverge in a non-key column only; both refs describe the same row.
+        Ref<TownBadge> first = Ref.of(TownBadge.class, new Town(5, "Sun Paririe"));
+        Ref<TownBadge> second = Ref.of(TownBadge.class, new Town(5, "Sun Prairie"));
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+
+    @Test
+    public void testEntityTypedKeyWrappedRefsCompareByRowIdentity() {
+        Ref<TownBadge> first = Ref.of(new TownBadge(new Town(5, "Sun Paririe"), "founders"));
+        Ref<TownBadge> second = Ref.of(TownBadge.class, new Town(5, "Sun Prairie"));
+        assertEquals(first, second);
+        assertEquals(second, first);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+
+    @Test
+    public void testDifferentRowsCompareUnequal() {
+        assertNotEquals(
+                Ref.of(TownBadge.class, new Town(5, "Sun Paririe")),
+                Ref.of(TownBadge.class, new Town(6, "Sun Paririe")));
+    }
+
+    @Test
+    public void testDifferentTypesCompareUnequal() {
+        assertNotEquals(Ref.of(Town.class, 5), Ref.of(TownBadge.class, new Town(5, "Sun Paririe")));
+    }
+}

--- a/storm-core/src/test/java/st/orm/core/spi/RowIdentityTest.java
+++ b/storm-core/src/test/java/st/orm/core/spi/RowIdentityTest.java
@@ -1,0 +1,86 @@
+package st.orm.core.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+import st.orm.Entity;
+import st.orm.PK;
+import st.orm.Ref;
+
+/**
+ * Tests for {@link RowIdentity}.
+ */
+public class RowIdentityTest {
+
+    record Town(@PK Integer id, String name) implements Entity<Integer> {}
+
+    record TownBadge(@PK Town town, String label) implements Entity<Town> {}
+
+    record ScalarKey(int high, int low) {}
+
+    record CompositeKey(Town town, int sequence) {}
+
+    @Test
+    public void testRequiresNormalizationDecidesPerClass() {
+        assertEquals(false, RowIdentity.requiresNormalization(Integer.class));
+        assertEquals(false, RowIdentity.requiresNormalization(String.class));
+        assertEquals(false, RowIdentity.requiresNormalization(ScalarKey.class));
+        assertEquals(true, RowIdentity.requiresNormalization(Town.class));
+        assertEquals(true, RowIdentity.requiresNormalization(TownBadge.class));
+        assertEquals(true, RowIdentity.requiresNormalization(CompositeKey.class));
+    }
+
+    @Test
+    public void testScalarKeyPassesThroughUnchanged() {
+        Integer id = 42;
+        assertSame(id, RowIdentity.normalize(id));
+    }
+
+    @Test
+    public void testScalarOnlyCompositeKeyPassesThroughUnchanged() {
+        ScalarKey key = new ScalarKey(1, 2);
+        assertSame(key, RowIdentity.normalize(key));
+    }
+
+    @Test
+    public void testNullPassesThrough() {
+        assertSame(null, RowIdentity.normalize(null));
+    }
+
+    @Test
+    public void testEntityKeyReducesToItsPrimaryKey() {
+        assertEquals(RowIdentity.normalize(7),
+                RowIdentity.normalize(new Town(7, "Sun Paririe")));
+    }
+
+    @Test
+    public void testEntityKeyChainReducesRecursively() {
+        TownBadge badge = new TownBadge(new Town(7, "Sun Paririe"), "founders");
+        assertEquals(RowIdentity.normalize(7), RowIdentity.normalize(badge));
+    }
+
+    @Test
+    public void testRefKeyReducesToItsPrimaryKey() {
+        assertEquals(RowIdentity.normalize(7), RowIdentity.normalize(Ref.of(Town.class, 7)));
+    }
+
+    @Test
+    public void testDivergentRepresentationsOfSameRowNormalizeEqual() {
+        // The two keys describe the same row; the towns diverge in a non-key column only.
+        Object first = RowIdentity.normalize(new CompositeKey(new Town(7, "Sun Paririe"), 3));
+        Object second = RowIdentity.normalize(new CompositeKey(new Town(7, "Sun Prairie"), 3));
+        assertEquals(first, second);
+        assertEquals(first.hashCode(), second.hashCode());
+    }
+
+    @Test
+    public void testDifferentRowsNormalizeUnequal() {
+        Object first = RowIdentity.normalize(new CompositeKey(new Town(7, "Sun Paririe"), 3));
+        Object second = RowIdentity.normalize(new CompositeKey(new Town(8, "Sun Paririe"), 3));
+        Object third = RowIdentity.normalize(new CompositeKey(new Town(7, "Sun Paririe"), 4));
+        assertNotEquals(first, second);
+        assertNotEquals(first, third);
+    }
+}

--- a/storm-core/src/test/resources/data.sql
+++ b/storm-core/src/test/resources/data.sql
@@ -1,3 +1,6 @@
+drop table if exists appointment_report_review CASCADE;
+drop table if exists appointment_report CASCADE;
+drop table if exists appointment CASCADE;
 drop table if exists tenant CASCADE;
 drop table if exists city CASCADE;
 drop table if exists owner CASCADE;
@@ -36,6 +39,12 @@ alter table visit add constraint visit_vet_specialty_fk foreign key (vet_id, spe
 create table tenant (id integer auto_increment, name varchar(255), owner_id integer not null, city_id integer not null, primary key (id));
 alter table tenant add constraint tenant_owner_fk foreign key (owner_id) references owner (id);
 alter table tenant add constraint tenant_city_fk foreign key (city_id) references city (id);
+-- scheduled_at has second precision: a database round-trip drops the sub-second part of the in-memory value.
+create table appointment (id integer auto_increment, description varchar(255), scheduled_at timestamp(0), primary key (id));
+create table appointment_report (appointment_id integer not null, report varchar(255), primary key (appointment_id));
+create table appointment_report_review (id integer auto_increment, appointment_report_id integer not null, review varchar(255), primary key (id));
+alter table appointment_report add constraint appointment_report_appointment_fk foreign key (appointment_id) references appointment (id);
+alter table appointment_report_review add constraint appointment_report_review_report_fk foreign key (appointment_report_id) references appointment_report (appointment_id);
 create view owner_view as select * from owner;
 create view visit_view as select visit_date, description, pet_id, "timestamp" from visit;
 

--- a/storm-foundation/src/main/java/st/orm/AbstractRef.java
+++ b/storm-foundation/src/main/java/st/orm/AbstractRef.java
@@ -21,14 +21,47 @@ import java.util.Objects;
  * Abstract implementation of {@link Ref} to have consistent implementations of {@link #hashCode()}
  * and {@link #equals(Object)}.
  *
+ * <p>Equality is based on the type and the row identity of the id: an entity-typed id counts by its primary key
+ * rather than by structural equality, so two refs describing the same database row compare equal even when a
+ * non-key column of the key entity does not round-trip bit-exact. Scalar ids, and composite ids carrying only
+ * scalars, are compared as-is.</p>
+ *
  * @param <T> record type.
  * @since 1.3
  */
 abstract class AbstractRef<T extends Data> implements Ref<T> {
 
+    /**
+     * Lazily computed row identity of the id. Computed outside construction because materialization creates refs
+     * per row while only map-keyed usage needs the identity; the computation is idempotent over the immutable id,
+     * so the unsynchronized publication is a benign race, as with {@code String} hash caching.
+     */
+    private Object rowId;
+
+    private Object rowId() {
+        Object rowId = this.rowId;
+        if (rowId == null) {
+            rowId = RowIdentityHelper.normalize(id());
+            this.rowId = rowId;
+        }
+        return rowId;
+    }
+
+    /**
+     * Lazily computed hash code over the type and row identity, both immutable; zero means not yet computed and a
+     * value that genuinely hashes to zero is recomputed on each call, as with {@code String} hash caching. The
+     * formula is allocation-free, unlike a varargs-based hash.
+     */
+    private int hash;
+
     @Override
     public int hashCode() {
-        return Objects.hash(type(), id());
+        int hash = this.hash;
+        if (hash == 0) {
+            hash = (31 + type().hashCode()) * 31 + Objects.hashCode(rowId());
+            this.hash = hash;
+        }
+        return hash;
     }
 
     @Override
@@ -36,9 +69,13 @@ abstract class AbstractRef<T extends Data> implements Ref<T> {
         if (this == obj) {
             return true;
         }
+        if (obj instanceof AbstractRef<?> other) {
+            return Objects.equals(type(), other.type())
+                    && Objects.equals(rowId(), other.rowId());
+        }
         if (obj instanceof Ref<?> l) {
             return Objects.equals(type(), l.type())
-                    && Objects.equals(id(), l.id());
+                    && Objects.equals(rowId(), RowIdentityHelper.normalize(l.id()));
         }
         return false;
     }

--- a/storm-foundation/src/main/java/st/orm/Ref.java
+++ b/storm-foundation/src/main/java/st/orm/Ref.java
@@ -67,7 +67,8 @@ public interface Ref<T extends Data> {
      * <p>The entity does not need to be persisted yet: a ref wrapping an unsaved entity can act as a graph edge for
      * dependency-aware write sets (see {@link WriteSet}), which insert the wrapped instance first and bind the
      * generated key. Outside a write set, using an unsaved wrapped ref as a foreign key value fails fast at persist
-     * time. Note that ref equality is based on type and id, so refs wrapping distinct unsaved entities compare equal
+     * time. Note that ref equality is based on type and the row identity of the id (an entity-typed id counts by its
+     * primary key rather than by structural equality), so refs wrapping distinct unsaved entities compare equal
      * until the entities are persisted.</p>
      *
      * @param entity the fully loaded entity to wrap in a ref.

--- a/storm-foundation/src/main/java/st/orm/RowIdentityHelper.java
+++ b/storm-foundation/src/main/java/st/orm/RowIdentityHelper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * Helper class for row identity of primary key values.
+ *
+ * <p>Delegates to the row identity support of the core module through a method handle bound once, following the
+ * same bridge as {@link EntityHelper}: an entity-typed id counts by its primary key rather than by structural
+ * equality, a ref id by the key it wraps, and a composite key record by its components; scalar ids are returned
+ * as-is.</p>
+ */
+class RowIdentityHelper {
+    private static final MethodHandle NORMALIZE;
+
+    static {
+        MethodHandle normalize;
+        try {
+            Class<?> rowIdentityClass = Class.forName("st.orm.core.spi.RowIdentity");
+            normalize = MethodHandles.publicLookup().findStatic(
+                    rowIdentityClass,
+                    "normalize",
+                    MethodType.methodType(Object.class, Object.class)
+            );
+        } catch (ClassNotFoundException e) {
+            // Without the core module there is no database access, so both sides of any ref comparison are
+            // in-memory constructs and raw ids compare consistently.
+            normalize = MethodHandles.identity(Object.class);
+        } catch (Throwable t) {
+            throw new PersistenceException(t);
+        }
+        NORMALIZE = normalize;
+    }
+
+    private RowIdentityHelper() {
+        // Prevent instantiation.
+    }
+
+    /**
+     * Returns the row identity of the given primary key value.
+     *
+     * @param id the primary key value to normalize, may be {@code null}.
+     * @return the row identity of the value, or the value itself when its class requires no normalization.
+     */
+    static Object normalize(Object id) {
+        try {
+            return (Object) NORMALIZE.invokeExact(id);
+        } catch (PersistenceException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new PersistenceException(t);
+        }
+    }
+}

--- a/storm-kotlin/src/test/kotlin/st/orm/template/WriteSetTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/WriteSetTest.kt
@@ -17,6 +17,8 @@ import st.orm.repository.entity
 import st.orm.repository.insertAndFetchIds
 import st.orm.repository.writeSet
 import st.orm.template.model.Address
+import st.orm.template.model.Appointment
+import st.orm.template.model.AppointmentReport
 import st.orm.template.model.City
 import st.orm.template.model.Owner
 import st.orm.template.model.Pet
@@ -24,6 +26,7 @@ import st.orm.template.model.PetType
 import st.orm.template.model.Visit
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
@@ -137,5 +140,18 @@ open class WriteSetTest(
         ids shouldHaveSize 2
         orm.entity<Pet, _>().findAll().single { it.name == "VarargIdsPet" }.id shouldBe ids[0]
         orm.entity<Visit, _>().findAll().single { it.description == "Vararg ids visit" }.id shouldBe ids[1]
+    }
+
+    @Test
+    fun `insertAndFetch should correlate an entity-typed key by database key`() {
+        // The appointment carries sub-second precision that the second-precision column does not store, so the
+        // key entity read back from the database differs structurally from the in-memory data class instance; the
+        // fetch correlates by the database key.
+        val appointment = Appointment(description = "Vaccination", scheduledAt = LocalDateTime.of(2026, 5, 4, 10, 30, 15, 123_456_789))
+        val fetched = orm.writeSet().insertAndFetch(AppointmentReport(appointment = appointment, report = "All clear"))
+        fetched.appointment.id shouldNotBe 0
+        fetched.report shouldBe "All clear"
+        fetched.appointment.scheduledAt.nano shouldBe 0
+        fetched.appointment.scheduledAt shouldNotBe appointment.scheduledAt
     }
 }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Appointment.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Appointment.kt
@@ -1,0 +1,15 @@
+package st.orm.template.model
+
+import st.orm.Entity
+import st.orm.PK
+import java.time.LocalDateTime
+
+/**
+ * Entity whose `scheduled_at` column is declared with second precision, so a database round-trip drops any
+ * sub-second part of the in-memory value and the two representations are not structurally equal.
+ */
+data class Appointment(
+    @PK val id: Int = 0,
+    val description: String,
+    val scheduledAt: LocalDateTime,
+) : Entity<Int>

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/AppointmentReport.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/AppointmentReport.kt
@@ -1,0 +1,16 @@
+package st.orm.template.model
+
+import st.orm.Entity
+import st.orm.FK
+import st.orm.GenerationStrategy.NONE
+import st.orm.PK
+
+/**
+ * Junction-style entity whose primary key is an entity-typed foreign key to [Appointment]. Because the appointment
+ * carries a column that does not round-trip bit-exact, operations on this entity must correlate by the key column
+ * rather than by structural equality of the key entity.
+ */
+data class AppointmentReport(
+    @PK(generation = NONE) @FK("appointment_id") val appointment: Appointment,
+    val report: String,
+) : Entity<Appointment>

--- a/storm-kotlin/src/test/resources/data.sql
+++ b/storm-kotlin/src/test/resources/data.sql
@@ -1,3 +1,5 @@
+drop table if exists appointment_report CASCADE;
+drop table if exists appointment CASCADE;
 drop table if exists city CASCADE;
 drop table if exists owner CASCADE;
 drop table if exists pet CASCADE;
@@ -22,6 +24,10 @@ alter table vet_specialty add constraint vet_specialty_specialty_fk foreign key 
 alter table vet_specialty add constraint vet_specialty_vet_fk foreign key (vet_id) references vet (id);
 alter table visit add constraint visit_pet_fk foreign key (pet_id) references pet (id);
 alter table visit add constraint visit_vet_specialty_fk foreign key (vet_id, specialty_id) references vet_specialty (vet_id, specialty_id);
+-- scheduled_at has second precision: a database round-trip drops the sub-second part of the in-memory value.
+create table appointment (id integer auto_increment, description varchar(255), scheduled_at timestamp(0), primary key (id));
+create table appointment_report (appointment_id integer not null, report varchar(255), primary key (appointment_id));
+alter table appointment_report add constraint appointment_report_appointment_fk foreign key (appointment_id) references appointment (id);
 create view owner_view as select * from owner;
 create view visit_view as select visit_date, description, pet_id, "timestamp" from visit;
 


### PR DESCRIPTION
## Problem

An entity-typed primary key (the junction pattern, e.g. `AppointmentReport implements Entity<Appointment>`) compares structurally: correlating rows by the raw `id()` value makes row identity depend on every non-key column of the key entity and its FK closure. Any column that does not round-trip bit-exact breaks correlation: a second-precision timestamp column against an in-memory value carrying sub-second precision, a database-managed column, a numeric scale or padding difference.

Three surfaces were affected:

- **Write sets** (#309): fetch-after-write threw `Failed to fetch ... after write` even though the row was written; the remove correlation and keyed-member ordering silently dropped dependency edges, worst case a referential integrity violation on write or delete order.
- **Entity cache and dirty checking**: lookups missed for divergent representations of the same row, degrading to a reload or a full update. Correct, but a lost optimization.
- **Ref equality** (#310): `Ref` documents equality as type plus id; for entity-typed keys that meant structural equality, so refs describing the same row could compare unequal, breaking ref-keyed maps for such types.

## Fix

`RowIdentity` (core spi) defines row identity once: the value the SQL layer binds in a WHERE clause. An entity-typed id reduces recursively to its own primary key, a ref id to the key it wraps, and a composite key record component-wise, detected through the pluggable reflection support so Java records and Kotlin data classes behave alike. A `ClassValue`-cached per-class decision returns scalar keys and scalar-only composite keys unchanged, so behavior and cost are unchanged for every type whose key carries no non-key state.

- The write set's `TypeIdKey` normalizes at all correlation sites (fetch-after-write, remove correlation, keyed-member ordering).
- `EntityCacheImpl` keys by row identity, which makes `DirtySupport` hit through the cache interface for divergent key representations.
- Both `AbstractRef` implementations compare type plus row identity. The foundation module reaches the normalizer through a method handle bound once, following the `EntityHelper` bridge, and falls back to the identity function when the core module is absent from the classpath.

Performance shape: `RefFactoryImpl` resolves the per-type decision once and hands every created ref its row identity at construction, leaving one pointer comparison per materialized ref; detached refs compute lazily on first use, memoized. The ref hash code is cached and computed with an allocation-free formula.

## Verification

- The write-set regression tests fail on the previous implementation with the exact reported failure modes: fetch-after-write exception, referential integrity violation on insert ordering, referential integrity violation on delete ordering (`WriteSetIntegrationTest`, Kotlin data class mirror in `WriteSetTest`). New `RowIdentityTest`, `RefEqualityTest` and entity-cache divergent-key cases cover the shared normalizer, ref equality and cache behavior.
- Suites: storm-foundation 320, storm-core 2332, storm-kotlin 1636, storm-h2 158, storm-jackson2 98, storm-jackson3 117, all green.
- storm-benchmarks A/B against the staged 1.13.0 (5 forks, deterministic GC, allocation profiler): no reproducible time delta on any of the six exercised workloads; allocation drops 16.2 KB/op on the 1000-row join and 1.7 KB/op on objectGraph, since the allocation-free cached hashing outweighs the two added ref fields; point and write workloads flat.

Fixes #309
Fixes #310