### PR TITLE
perf(core): specialize factory-created refs by key shape

### DIFF
--- a/storm-core/src/main/java/st/orm/core/spi/AbstractRef.java
+++ b/storm-core/src/main/java/st/orm/core/spi/AbstractRef.java
@@ -15,7 +15,6 @@
  */
 package st.orm.core.spi;
 
-import jakarta.annotation.Nullable;
 import java.util.Objects;
 import st.orm.Data;
 import st.orm.Ref;
@@ -36,19 +35,12 @@ import st.orm.Ref;
 abstract class AbstractRef<T extends Data> implements Ref<T> {
 
     /**
-     * Row identity of the id. Assigned at construction when the creator has already resolved the identity at type
-     * level (a factory creating refs per row); otherwise computed lazily on first use, because only map-keyed usage
-     * needs the identity. The lazy computation is idempotent over the immutable id, so the unsynchronized
-     * publication is a benign race, as with {@code String} hash caching.
+     * Lazily computed row identity of the id. Computed outside construction because only map-keyed usage needs the
+     * identity; the computation is idempotent over the immutable id, so the unsynchronized publication is a benign
+     * race, as with {@code String} hash caching. Keys that are their own row identity are served by a specialized
+     * implementation that carries no cache at all (see {@code DirectKeyRefImpl}).
      */
     private Object rowId;
-
-    AbstractRef() {
-    }
-
-    AbstractRef(@Nullable Object rowId) {
-        this.rowId = rowId;
-    }
 
     private Object rowId() {
         Object rowId = this.rowId;
@@ -61,8 +53,7 @@ abstract class AbstractRef<T extends Data> implements Ref<T> {
 
     /**
      * Lazily computed hash code over the type and row identity, both immutable; zero means not yet computed and a
-     * value that genuinely hashes to zero is recomputed on each call, as with {@code String} hash caching. The
-     * formula is allocation-free, unlike a varargs-based hash.
+     * value that genuinely hashes to zero is recomputed on each call, as with {@code String} hash caching.
      */
     private int hash;
 
@@ -70,7 +61,7 @@ abstract class AbstractRef<T extends Data> implements Ref<T> {
     public int hashCode() {
         int hash = this.hash;
         if (hash == 0) {
-            hash = (31 + type().hashCode()) * 31 + Objects.hashCode(rowId());
+            hash = RowIdentity.hash(type(), rowId());
             this.hash = hash;
         }
         return hash;
@@ -86,8 +77,7 @@ abstract class AbstractRef<T extends Data> implements Ref<T> {
                     && Objects.equals(rowId(), other.rowId());
         }
         if (obj instanceof Ref<?> l) {
-            return Objects.equals(type(), l.type())
-                    && Objects.equals(rowId(), RowIdentity.normalize(l.id()));
+            return RowIdentity.refEquals(type(), rowId(), l);
         }
         return false;
     }

--- a/storm-core/src/main/java/st/orm/core/spi/DirectKeyRefImpl.java
+++ b/storm-core/src/main/java/st/orm/core/spi/DirectKeyRefImpl.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.util.Objects;
 import st.orm.Data;
 import st.orm.Entity;
 import st.orm.Ref;
@@ -26,17 +27,24 @@ import st.orm.core.repository.EntityRepository;
 import st.orm.core.template.impl.LazySupplier;
 
 /**
- * Default {@link Ref} implementation.
+ * {@link Ref} implementation for keys that are their own row identity.
+ *
+ * <p>The factory selects this implementation at type level, when the pk class carries no non-key state (see
+ * {@link RowIdentity#requiresNormalization(Class)}). The identity of such a ref is the pk itself and its hash is a
+ * few instructions, so this implementation carries neither the row identity nor the hash cache of the general
+ * implementation, keeping refs created per row during materialization at their minimal footprint. Equality and
+ * hash follow the shared contract in {@link RowIdentity}, so instances compare correctly against every other ref
+ * implementation.</p>
  *
  * @param <T> record type.
  * @param <ID> primary key type.
  */
-final class RefImpl<T extends Data, ID> extends AbstractRef<T> {
+final class DirectKeyRefImpl<T extends Data, ID> implements Ref<T> {
     private final LazySupplier<T> supplier;
     private final Class<T> type;
     private final ID pk;
 
-    RefImpl(@Nonnull LazySupplier<T> supplier, @Nonnull Class<T> type, @Nonnull ID pk) {
+    DirectKeyRefImpl(@Nonnull LazySupplier<T> supplier, @Nonnull Class<T> type, @Nonnull ID pk) {
         this.supplier = requireNonNull(supplier, "supplier");
         this.type = requireNonNull(type, "type");
         this.pk = requireNonNull(pk, "pk");
@@ -56,7 +64,6 @@ final class RefImpl<T extends Data, ID> extends AbstractRef<T> {
      * Returns the record if it has already been fetched, without triggering a database call.
      *
      * @return the record if already loaded, or {@code null} if not yet fetched.
-     * @since 1.7
      */
     @Nullable
     @Override
@@ -67,9 +74,6 @@ final class RefImpl<T extends Data, ID> extends AbstractRef<T> {
     /**
      * Returns the primary key of the record.
      *
-     * <p>This method is provided for convenience. If the type of the id is known, you can cast it to the appropriate
-     * type.</p>
-     *
      * @return the primary key as an Object.
      */
     @Override
@@ -78,11 +82,10 @@ final class RefImpl<T extends Data, ID> extends AbstractRef<T> {
     }
 
     /**
-     * Fetches the record from the database if the record has not been fetched yet. The record will be fetched at most
-     * once.
+     * Fetches the record from the database if the record has not been fetched yet. The record will be fetched at
+     * most once.
      *
      * @return the fetched record.
-     * @since 1.7
      */
     @Override
     public T fetchOrNull() {
@@ -92,16 +95,7 @@ final class RefImpl<T extends Data, ID> extends AbstractRef<T> {
     /**
      * Returns whether this ref is attached to a database context and capable of fetching the record on demand.
      *
-     * <p>A fetchable ref has access to a database connection and can attempt to retrieve the record when
-     * {@link #fetch()} or {@link #fetchOrNull()} is called. A non-fetchable (detached) ref can only return
-     * data that was already loaded at the time of its creation.</p>
-     *
-     * <p>Note that this method indicates the <em>capability</em> to fetch, not a guarantee of success. A fetchable
-     * ref may still fail to retrieve a record if it has been deleted from the database or if the connection
-     * encounters an error.</p>
-     *
-     * @return {@code true} if this ref can attempt to fetch from the database, {@code false} if it is detached.
-     * @since 1.7
+     * @return {@code true}, this implementation is created attached to a database context.
      */
     @Override
     public boolean isFetchable() {
@@ -109,8 +103,8 @@ final class RefImpl<T extends Data, ID> extends AbstractRef<T> {
     }
 
     /**
-     * Returns a detached ref with the same identity but without data. The returned ref is not attached to a database
-     * context. To obtain an attached ref that can re-fetch the record, use
+     * Returns a detached ref with the same identity but without data. The returned ref is not attached to a
+     * database context. To obtain an attached ref that can re-fetch the record, use
      * {@link EntityRepository#unload(Entity) EntityRepository.unload()} instead.
      *
      * @return a detached ref with the same type and primary key but without cached data.
@@ -118,5 +112,34 @@ final class RefImpl<T extends Data, ID> extends AbstractRef<T> {
     @Override
     public Ref<T> unload() {
         return Ref.of(type, pk);
+    }
+
+    @Override
+    public int hashCode() {
+        return RowIdentity.hash(type, pk);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof DirectKeyRefImpl<?, ?> other) {
+            // Both sides hold their identity as the raw pk of a class that is its own row identity; the type gate guarantees the
+            // pk classes match.
+            return Objects.equals(type, other.type) && pk.equals(other.pk);
+        }
+        if (obj instanceof Ref<?> l) {
+            return RowIdentity.refEquals(type, pk, l);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        Class<?> type = this.type;
+        return type == Record.class
+                ? "%s".formatted(pk)
+                : "%s@%s".formatted(type.getSimpleName(), pk);
     }
 }

--- a/storm-core/src/main/java/st/orm/core/spi/RefFactoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/spi/RefFactoryImpl.java
@@ -40,11 +40,11 @@ public final class RefFactoryImpl implements RefFactory {
     /**
      * The pk class most recently resolved as being its own row identity. Refs are created per row during
      * materialization with the same pk class throughout, so this resolves the row identity decision at type level
-     * once and hands every ref its identity at construction, leaving one pointer comparison per ref. A single field
-     * keeps the unsynchronized access safe: a stale read can only miss (falling back to the resolution or to the
-     * ref's lazy path), never claim self-identity for a class that requires normalization.
+     * once and selects the ref implementation at construction, leaving one pointer comparison per ref. A single
+     * field keeps the unsynchronized access safe: a stale read can only miss (falling back to the resolution or to
+     * the general implementation), never claim own-row-identity for a class that requires normalization.
      */
-    private Class<?> selfIdentityPkClass;
+    private Class<?> ownRowIdentityPkClass;
 
     public RefFactoryImpl(@Nonnull QueryFactory factory,
                           @Nonnull ModelBuilder modelBuilder,
@@ -135,23 +135,24 @@ public final class RefFactoryImpl implements RefFactory {
      * @param <ID> primary key type.
      */
     private <T extends Data, ID> Ref<T> create(@Nonnull LazySupplier<T> supplier, @Nonnull Class<T> type, @Nonnull ID pk) {
-        return new RefImpl<>(supplier, type, pk, rowIdentity(pk));
+        return isOwnRowIdentity(pk)
+                ? new DirectKeyRefImpl<>(supplier, type, pk)
+                : new RefImpl<>(supplier, type, pk);
     }
 
     /**
-     * Returns the row identity of the given pk when its class is known to be its own identity, or {@code null} to
-     * defer to the ref's lazy computation.
+     * Returns whether the pk class is its own row identity, selecting the ref implementation that carries no
+     * identity or hash cache.
      */
-    @Nullable
-    private Object rowIdentity(@Nonnull Object pk) {
+    private boolean isOwnRowIdentity(@Nonnull Object pk) {
         Class<?> pkClass = pk.getClass();
-        if (pkClass == selfIdentityPkClass) {
-            return pk;
+        if (pkClass == ownRowIdentityPkClass) {
+            return true;
         }
         if (!RowIdentity.requiresNormalization(pkClass)) {
-            selfIdentityPkClass = pkClass;
-            return pk;
+            ownRowIdentityPkClass = pkClass;
+            return true;
         }
-        return null;
+        return false;
     }
 }

--- a/storm-core/src/main/java/st/orm/core/spi/RowIdentity.java
+++ b/storm-core/src/main/java/st/orm/core/spi/RowIdentity.java
@@ -15,10 +15,12 @@
  */
 package st.orm.core.spi;
 
+import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import st.orm.Entity;
@@ -58,7 +60,7 @@ public final class RowIdentity {
     /** Decided once per class: whether values of this class can carry non-key state that normalization must strip. */
     private static final ClassValue<Boolean> NORMALIZATION_REQUIRED = new ClassValue<>() {
         @Override
-        protected Boolean computeValue(Class<?> type) {
+        protected Boolean computeValue(@Nonnull Class<?> type) {
             return requiresNormalization(type, new HashSet<>());
         }
     };
@@ -95,6 +97,36 @@ public final class RowIdentity {
      */
     public static boolean requiresNormalization(Class<?> type) {
         return NORMALIZATION_REQUIRED.get(type);
+    }
+
+    /**
+     * Returns the hash code of a ref identity: its type and the row identity of its id.
+     *
+     * <p>Shared by the ref implementations so that the hash contract cannot drift between them: every
+     * implementation of an equal ref identity must produce this value.</p>
+     *
+     * @param type the ref's record type.
+     * @param rowId the row identity of the ref's id.
+     * @return the identity hash code.
+     */
+    public static int hash(@Nullable Class<?> type, @Nullable Object rowId) {
+        return (31 + Objects.hashCode(type)) * 31 + Objects.hashCode(rowId);
+    }
+
+    /**
+     * Returns whether a ref identity, given as its type and the row identity of its id, equals the identity of the
+     * given ref.
+     *
+     * <p>Shared by the ref implementations so that the equality contract cannot drift between them; implementations
+     * may only shortcut this comparison when both sides are known to hold their identity in the same form.</p>
+     *
+     * @param type the ref's record type.
+     * @param rowId the row identity of the ref's id.
+     * @param other the ref to compare against.
+     * @return {@code true} if both describe the same database row.
+     */
+    public static boolean refEquals(@Nullable Class<?> type, @Nullable Object rowId, @Nonnull Ref<?> other) {
+        return Objects.equals(type, other.type()) && Objects.equals(rowId, normalize(other.id()));
     }
 
     /**


### PR DESCRIPTION
## What

Factory-created refs whose pk class is its own row identity (scalars, and composite key records carrying only scalars) are now served by `DirectKeyRefImpl`, an implementation without the row identity and hash cache fields of the general implementation. `RefFactoryImpl` resolves the per-class decision once (the same single-field cache introduced in #311) and selects the implementation at construction, so the type-level knowledge lives in the vtable rather than in per-instance state.

## Why

For these key shapes both cache fields are pure footprint: the row identity would alias the pk, and the hash formula over a `Class` identity hash and the pk hash is a few instructions, cheaper to recompute than to remember. Dropping both fields takes a factory-created ref from 32 to 24 bytes with compressed oops, a 25% smaller object for the overwhelmingly common case; materialization creates one to two of these per row. Notably, a hash cache alone is not a viable middle ground: a lone `int` field pads the 24-byte layout straight back to 32, so the specialization is all-or-nothing.

Keys that require normalization (entity-typed keys, composites embedding entities) keep the general `RefImpl`, where the caches pay for themselves. Detached refs (`Ref.of`) are unchanged: they are created without a type-level decision point, and taxing their creation to save 8 bytes on one-off instances would be the wrong trade.

## Contract safety

The equality and hash contract is factored into `RowIdentity.hash` and `RowIdentity.refEquals`, and both core implementations are one-liners over them, so the contract cannot drift between implementations. Cross-implementation comparisons (direct-key vs general vs detached) all route through the same semantics; the direct-key same-class fast path compares raw pks, valid because the type gate guarantees matching pk classes. The general implementation reverts to purely lazy computation, with its construction-time identity parameter superseded by implementation selection.

## Verification

storm-foundation 320, storm-core 2332, storm-kotlin 1636, storm-h2 158, storm-jackson2 98, storm-jackson3 117, all green. Expected effect based on the #311 A/B measurements: roughly 8-16 KB/op less allocation on ref-heavy materialization workloads and a smaller retained footprint for refs held in grouped maps; no time change.