### PR TITLE
docs: use real repository API in write sets junction example

### DIFF
--- a/docs/write-sets.md
+++ b/docs/write-sets.md
@@ -183,7 +183,9 @@ data class UserRole(
     @PK val userRolePk: UserRolePk,
     @FK @Persist(insertable = false, updatable = false) val user: User,
     @FK @Persist(insertable = false, updatable = false) val role: Role
-) : Entity<UserRolePk>
+) : Entity<UserRolePk> {
+    constructor(user: User, role: Role) : this(UserRolePk(user.id, role.id), user, role)
+}
 ```
 
 </TabItem>
@@ -195,11 +197,18 @@ record UserRolePk(int userId, int roleId) {}
 record UserRole(@PK UserRolePk userRolePk,
                 @FK @Persist(insertable = false, updatable = false) User user,
                 @FK @Persist(insertable = false, updatable = false) Role role
-) implements Entity<UserRolePk> {}
+) implements Entity<UserRolePk> {
+
+    public UserRole(User user, Role role) {
+        this(new UserRolePk(user.id(), role.id()), user, role);
+    }
+}
 ```
 
 </TabItem>
 </Tabs>
+
+The secondary constructor derives the key components from the referenced entities, so call sites pass the entities and never spell out the composite key.
 
 Write sets recognize this shape. A non-insertable foreign key field whose column value is carried by an insertable component of the primary key participates in the insertion closure like any other edge: an unsaved entity held by the field is discovered and inserted first, and its generated key is written into the carrying key component before the junction row is inserted. The key components for already-persisted entities are set as usual, so mixed rows work naturally:
 
@@ -208,8 +217,8 @@ Write sets recognize this shape. A non-insertable foreign key field whose column
 
 ```kotlin
 val user = User(name = "Alice")                               // unsaved
-val role = orm.entity<Role>().findByName("admin")             // saved
-val userRole = UserRole(UserRolePk(user.id, role.id), user, role)
+val role = orm.get(Role_.name eq "admin")                     // saved
+val userRole = UserRole(user, role)
 
 orm.writeSet().insert(userRole)           // user is inserted first; its key lands in userRolePk.userId
 ```
@@ -219,8 +228,8 @@ orm.writeSet().insert(userRole)           // user is inserted first; its key lan
 
 ```java
 var user = new User("Alice");                                 // unsaved
-var role = orm.entity(Role.class).findByName("admin");        // saved
-var userRole = new UserRole(new UserRolePk(user.id(), role.id()), user, role);
+var role = orm.entity(Role.class).getBy(Role_.name, "admin"); // saved
+var userRole = new UserRole(user, role);
 
 orm.writeSet().insert(userRole);          // user is inserted first; its key lands in userRolePk.userId
 ```

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -18,7 +18,7 @@
 > GitHub: https://github.com/storm-orm/storm-framework
 > License: Apache 2.0
 
-# Generated: 2026-07-21T18:55:08Z
+# Generated: 2026-07-22T21:52:07Z
 
 ========================================
 ## Source: index.md
@@ -12254,11 +12254,14 @@ Visit fetchedVisit = orm.writeSet().insertAndFetch(visit);       // single root,
 ```
 `insertAndFetchIds` returns just the primary keys of the explicit members, in input order, without re-reading the rows: the keys come from the insert itself. It is the middle tier between `insert` (nothing back) and `insertAndFetch` (rows re-read with database-applied state), and the natural fit for a create endpoint that responds with ids. The batch is homogeneous in its id type; entity types may differ as long as they share it, and a batch that mixes id types keeps using `insertAndFetch`, where each returned entity carries its own id.
 
+Kotlin additionally offers the id-returning methods as vararg extension functions (in `st.orm.repository`). The interface itself cannot declare them: `@SafeVarargs` is not applicable to interface default methods, so a Java-side generic vararg would emit heap-pollution warnings at every call site. Java call sites pass `List.of(...)`, which supplies the varargs ergonomics there.
+
 [Kotlin]
 
 ```kotlin
-val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)   // keys in input order, no re-read
-val id: Long = orm.writeSet().insertAndFetchId(visit)            // single root
+val ids: List<Long> = orm.writeSet().insertAndFetchIds(visits)        // keys in input order, no re-read
+val two: List<Long> = orm.writeSet().insertAndFetchIds(wolfie, visit) // vararg extension; one shared id type
+val id: Long = orm.writeSet().insertAndFetchId(visit)                 // single root
 ```
 
 [Java]
@@ -12302,7 +12305,9 @@ data class UserRole(
     @PK val userRolePk: UserRolePk,
     @FK @Persist(insertable = false, updatable = false) val user: User,
     @FK @Persist(insertable = false, updatable = false) val role: Role
-) : Entity<UserRolePk>
+) : Entity<UserRolePk> {
+    constructor(user: User, role: Role) : this(UserRolePk(user.id, role.id), user, role)
+}
 ```
 
 [Java]
@@ -12313,16 +12318,23 @@ record UserRolePk(int userId, int roleId) {}
 record UserRole(@PK UserRolePk userRolePk,
                 @FK @Persist(insertable = false, updatable = false) User user,
                 @FK @Persist(insertable = false, updatable = false) Role role
-) implements Entity<UserRolePk> {}
+) implements Entity<UserRolePk> {
+
+    public UserRole(User user, Role role) {
+        this(new UserRolePk(user.id(), role.id()), user, role);
+    }
+}
 ```
+The secondary constructor derives the key components from the referenced entities, so call sites pass the entities and never spell out the composite key.
+
 Write sets recognize this shape. A non-insertable foreign key field whose column value is carried by an insertable component of the primary key participates in the insertion closure like any other edge: an unsaved entity held by the field is discovered and inserted first, and its generated key is written into the carrying key component before the junction row is inserted. The key components for already-persisted entities are set as usual, so mixed rows work naturally:
 
 [Kotlin]
 
 ```kotlin
 val user = User(name = "Alice")                               // unsaved
-val role = orm.entity<Role>().findByName("admin")             // saved
-val userRole = UserRole(UserRolePk(user.id, role.id), user, role)
+val role = orm.get(Role_.name eq "admin")                     // saved
+val userRole = UserRole(user, role)
 
 orm.writeSet().insert(userRole)           // user is inserted first; its key lands in userRolePk.userId
 ```
@@ -12331,8 +12343,8 @@ orm.writeSet().insert(userRole)           // user is inserted first; its key lan
 
 ```java
 var user = new User("Alice");                                 // unsaved
-var role = orm.entity(Role.class).findByName("admin");        // saved
-var userRole = new UserRole(new UserRolePk(user.id(), role.id()), user, role);
+var role = orm.entity(Role.class).getBy(Role_.name, "admin"); // saved
+var userRole = new UserRole(user, role);
 
 orm.writeSet().insert(userRole);          // user is inserted first; its key lands in userRolePk.userId
 ```


### PR DESCRIPTION
## Summary

The junction table example in the write sets guide called `findByName` on a default entity repository. That method only exists on custom repository interfaces, so the snippet did not compile as shown.

- Replace the lookup with the default repository API: `orm.get(Role_.name eq "admin")` in Kotlin (matching the pattern used in the dirty checking and refs guides) and `orm.entity(Role.class).getBy(Role_.name, "admin")` in Java (matching the queries guide). `getBy` works with or without `@UK`: the `Metamodel.Key` overload binds for unique key fields, the field-based overload enforces single-result semantics at runtime.
- Add the secondary constructor to the `UserRole` definition, following the convenience constructor pattern from the upserts guide, so the call sites read `UserRole(user, role)` instead of spelling out the composite key. A prose line notes that the constructor derives the key components from the referenced entities.
- Regenerate `llms-full.txt`. The regeneration also syncs the previously committed wolfie vararg snippet from #307 that had not been regenerated in yet.

Docs-only change; the live site picks it up at `/docs/next` until the next release snapshot.