### PR TITLE
perf(core): build grouped results in a single pass over pre-sized maps

### DIFF
--- a/docs/hydration.md
+++ b/docs/hydration.md
@@ -363,7 +363,7 @@ val city: City = user.city.fetch()  // Loads City from database
 
 ## Query-Level Identity (Interning)
 
-When the same entity appears multiple times in a query result (e.g., through joins), Storm ensures they share the same object instance within that query. This is called **interning**.
+When the same entity appears multiple times in a query result (e.g., through joins), Storm guarantees they share the same object instance within that query. This is called **interning**.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -459,6 +459,8 @@ orderRepository.select().resultFlow.collect { order ->
     // order can be cleaned up after this iteration
 }
 ```
+
+This cleanup never weakens identity. An entry is only cleared once your code no longer holds the instance, so any instance you still hold is guaranteed to be reused for later duplicates in the same query. Code that could compare two occurrences necessarily still holds the first one, which is exactly what keeps its entry alive: interning is a guarantee, not a best-effort optimization.
 
 ### Relationship with Entity Cache
 

--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -187,7 +187,7 @@ Map<City, List<User>> usersByCity = orm.entity(User.class)
 
 The grouped terminal returns an unmodifiable, insertion-ordered map: parents appear in the order
 their first row is encountered, children in row order within each parent. Because duplicate entities within a
-result set share the same instance, each child's reference to its parent is the map key itself, and repeated
+result set are guaranteed to share the same instance, each child's reference to its parent is the map key itself, and repeated
 parents are materialized once rather than once per row. The path must resolve to a non-null record for every
 result; narrow queries over nullable foreign keys with a `where()` clause first. This replaces the manual
 pattern of querying the many side and grouping in memory, and it loads the whole graph in a single query,

--- a/storm-core/src/main/java/st/orm/core/spi/WeakInterner.java
+++ b/storm-core/src/main/java/st/orm/core/spi/WeakInterner.java
@@ -40,6 +40,12 @@ import st.orm.Entity;
  * <p>The primary key-based lookup for entities avoids potentially expensive deep equality checks on complex entity
  * objects, while maintaining correct identity semantics (same type and primary key = same canonical instance).</p>
  *
+ * <p>Weak references are cleared only when their referent is no longer strongly reachable, which makes interning a
+ * guarantee rather than a best-effort optimization: as long as a caller retains a strong reference to an interned
+ * instance, later equivalent objects resolve to that same instance. A caller in a position to compare two duplicates
+ * necessarily still holds the first one, which is exactly what keeps its entry alive, so duplicates can never be
+ * observed as distinct instances.</p>
+ *
  * <p>This class is not thread-safe. A new instance is expected to be created for each result set processing call,
  * ensuring that interning is scoped to a single query execution.</p>
  */

--- a/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
@@ -970,14 +970,22 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     }
 
     /**
+     * Expected distinct-group count for the grouped terminals. Grouping typically collects children per parent, so
+     * group counts regularly reach the dozens; the grouping maps are sized so that such results build up without a
+     * resize, at a cost of roughly 2 KB per call for small results.
+     */
+    private static final int EXPECTED_GROUPS = 64;
+
+    /**
      * Executes the query and returns the results grouped by the record reached via {@code path}, typically the
      * parent entity of a foreign key. The SQL is not affected by the grouping; the same select is executed and the
      * results are grouped during hydration.
      *
      * <p>The returned map and its lists are unmodifiable and insertion-ordered: groups appear in the order their
      * first result is encountered, and results appear in encounter order within each group. Use {@code orderBy()} to
-     * control both. Since duplicate entities within a result set share the same instance, each result's reference to
-     * its group key is the map key itself.</p>
+     * control both. Duplicate entities within a result set are guaranteed to share the same instance as long as
+     * earlier occurrences remain strongly reachable, and the grouping retains every result and group key while the
+     * result set is consumed; each result's reference to its group key is therefore the map key itself.</p>
      *
      * <p>This method requires an entity query: the result type must be the table type {@code T} so that the path can
      * be resolved against the results. The path must also resolve to a non-null record for every result; paths over
@@ -998,16 +1006,20 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public final <V extends Data> SequencedMap<V, List<R>> getResultGroupedBy(@Nonnull TypedMetamodel<T, V, V> path) {
         requireNonNull(path, "path");
         try (var stream = getMaterializedResultStream()) {
-            // Duplicate records within a result set share the same instance (query-scoped interning), so the per-row
-            // lookup can use reference identity instead of hashing every field of the group record. The identity map
-            // carries no order and no value semantics; both are restored during assembly below.
-            var groups = new IdentityHashMap<V, Group<R>>();
-            var order = new ArrayList<V>();
+            // Duplicate records within a result set share the same instance (query-scoped interning), so the identity
+            // map serves as a per-instance memo of each key's canonical group: the value-based hash of the group
+            // record is paid once per distinct instance rather than once per row. The maps' strong references pin the
+            // interner entries for every group key, so this holds regardless of the interner's reference strength.
+            // Equal-by-value keys that were not interned resolve to the same group through the result map, so the
+            // result is correct even without interning.
+            var root = path.root();
+            var groups = new IdentityHashMap<V, Group<R>>(EXPECTED_GROUPS);
+            var result = LinkedHashMap.<V, List<R>>newLinkedHashMap(EXPECTED_GROUPS);
             stream.forEach(element -> {
-                if (!path.root().isInstance(element)) {
+                if (!root.isInstance(element)) {
                     throw new PersistenceException(
                             "Grouped results require an entity query rooted at %s, but got a result of type %s."
-                                    .formatted(path.root().getName(),
+                                    .formatted(root.getName(),
                                             element == null ? "null" : element.getClass().getName()));
                 }
                 // Object intermediate on purpose: assigning the typed return directly would insert a checkcast to
@@ -1029,24 +1041,12 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
                 V group = (V) value;
                 var elements = groups.get(group);
                 if (elements == null) {
-                    elements = new Group<>();
+                    elements = (Group<R>) result.computeIfAbsent(group, ignore -> new Group<>());
                     groups.put(group, elements);
-                    order.add(group);
                 }
                 elements.elements.add(element);
             });
-            // Assembly hashes each distinct group once; equal-by-value groups merge, so the result is correct even
-            // for records that were not interned. The group count is known here, so the map is allocated at its
-            // final size. The values are unmodifiable views over the lists built above, so no copy or re-wrapping
-            // is needed.
-            var result = LinkedHashMap.<V, List<R>>newLinkedHashMap(order.size());
-            for (V group : order) {
-                var elements = groups.get(group);
-                var existing = result.putIfAbsent(group, elements);
-                if (existing != null) {
-                    ((Group<R>) existing).elements.addAll(elements);
-                }
-            }
+            // The values are unmodifiable views over the lists built above, so no copy or re-wrapping is needed.
             return Collections.unmodifiableSequencedMap(result);
         }
     }
@@ -1094,12 +1094,13 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
             // Refs hash and compare by primary key, so the grouping map is cheap without an identity-based fast path.
             // The values are unmodifiable views appended through their backing lists, so no copy or re-wrapping is
             // needed when the result is returned.
-            var groups = new LinkedHashMap<Ref<V>, List<R>>();
+            var root = path.root();
+            var groups = LinkedHashMap.<Ref<V>, List<R>>newLinkedHashMap(EXPECTED_GROUPS);
             stream.forEach(element -> {
-                if (!path.root().isInstance(element)) {
+                if (!root.isInstance(element)) {
                     throw new PersistenceException(
                             "Grouped results require an entity query rooted at %s, but got a result of type %s."
-                                    .formatted(path.root().getName(),
+                                    .formatted(root.getName(),
                                             element == null ? "null" : element.getClass().getName()));
                 }
                 //noinspection unchecked

--- a/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
+++ b/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
@@ -16,24 +16,16 @@
 package st.orm.template;
 
 import static java.lang.StringTemplate.RAW;
-import static java.util.Objects.requireNonNull;
 import static st.orm.Operator.EQUALS;
 import static st.orm.Operator.IN;
 
 import jakarta.annotation.Nonnull;
-import java.util.AbstractList;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.RandomAccess;
 import java.util.SequencedMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import st.orm.Data;
-import st.orm.Entity;
 import st.orm.JoinType;
 import st.orm.Metamodel;
 import st.orm.NoResultException;
@@ -833,26 +825,6 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public abstract Stream<R> getResultStream();
 
     /**
-     * Executes the query and returns a stream of results for eager, full consumption.
-     *
-     * <p>Unlike {@link #getResultStream()}, implementations may execute without a fetch-size hint, since eagerly
-     * consumed results gain nothing from cursor-based fetching. On dialects where cursors require a
-     * transaction, this avoids wrapping auto-commit queries in a transaction. The eager terminal
-     * operations, such as {@link #getResultList()} and {@link #getSingleResult()}, consume this stream.</p>
-     *
-     * <p>The same resource-handling rules as {@link #getResultStream()} apply: close the stream after usage,
-     * preferably with a {@code try-with-resources} block.</p>
-     *
-     * @return a stream of results for eager consumption.
-     * @throws PersistenceException if the query operation fails due to underlying database issues, such as
-     *                              connectivity.
-     * @since 1.13
-     */
-    protected Stream<R> getMaterializedResultStream() {
-        return getResultStream();
-    }
-
-    /**
      * Returns the number of results of this query.
      *
      * @return the total number of results of this query as a long value.
@@ -871,12 +843,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the list of results.
      * @throws PersistenceException if the query fails.
      */
-    public List<R> getResultList() {
-        try (var stream = getMaterializedResultStream()) {
-            return stream.toList();
-        }
-    }
-
+    public abstract List<R> getResultList();
 
     /**
      * Executes the query and returns the results grouped by the record reached via {@code path}, typically the
@@ -885,8 +852,9 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      *
      * <p>The returned map and its lists are unmodifiable and insertion-ordered: groups appear in the order their
      * first result is encountered, and results appear in encounter order within each group. Use {@code orderBy()} to
-     * control both. Since duplicate entities within a result set share the same instance, each result's reference to
-     * its group key is the map key itself.</p>
+     * control both. Duplicate entities within a result set are guaranteed to share the same instance as long as
+     * earlier occurrences remain strongly reachable, and the grouping retains every result and group key while the
+     * result set is consumed; each result's reference to its group key is therefore the map key itself.</p>
      *
      * <p>This method requires an entity query: the result type must be the table type {@code T} so that the path can
      * be resolved against the results. The path must also resolve to a non-null record for every result; paths over
@@ -904,61 +872,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      *                              resolves to null for a result.
      * @since 1.13
      */
-    public <V extends Data> SequencedMap<V, List<R>> getResultGroupedBy(@Nonnull TypedMetamodel<T, V, V> path) {
-        requireNonNull(path, "path");
-        try (var stream = getMaterializedResultStream()) {
-            // Duplicate records within a result set share the same instance (query-scoped interning), so the per-row
-            // lookup can use reference identity instead of hashing every field of the group record. The identity map
-            // carries no order and no value semantics; both are restored during assembly below.
-            var groups = new IdentityHashMap<V, Group<R>>();
-            var order = new ArrayList<V>();
-            stream.forEach(element -> {
-                if (!path.root().isInstance(element)) {
-                    throw new PersistenceException(
-                            "Grouped results require an entity query rooted at %s, but got a result of type %s."
-                                    .formatted(path.root().getName(),
-                                            element == null ? "null" : element.getClass().getName()));
-                }
-                // Object intermediate on purpose: assigning the typed return directly would insert a checkcast to
-                // V's bound and fail with a bare ClassCastException for dynamically built ref paths, bypassing the
-                // descriptive backstop below.
-                //noinspection unchecked
-                Object value = path.getValue((T) element);
-                if (value == null) {
-                    throw new PersistenceException(
-                            "Cannot group by %s: the path resolved to null. Narrow the query with a where() clause to exclude results without a %s."
-                                    .formatted(path, path.fieldType().getSimpleName()));
-                }
-                if (value instanceof Ref<?>) {
-                    throw new PersistenceException(
-                            "Cannot group by %s: the path resolves to a ref because %s is mapped as a Ref field. Use getResultGroupedByRef() instead."
-                                    .formatted(path, path.fieldType().getSimpleName()));
-                }
-                //noinspection unchecked
-                V group = (V) value;
-                var elements = groups.get(group);
-                if (elements == null) {
-                    elements = new Group<>();
-                    groups.put(group, elements);
-                    order.add(group);
-                }
-                elements.elements.add(element);
-            });
-            // Assembly hashes each distinct group once; equal-by-value groups merge, so the result is correct even
-            // for records that were not interned. The group count is known here, so the map is allocated at its
-            // final size. The values are unmodifiable views over the lists built above, so no copy or re-wrapping
-            // is needed.
-            var result = LinkedHashMap.<V, List<R>>newLinkedHashMap(order.size());
-            for (V group : order) {
-                var elements = groups.get(group);
-                var existing = result.putIfAbsent(group, elements);
-                if (existing != null) {
-                    ((Group<R>) existing).elements.addAll(elements);
-                }
-            }
-            return Collections.unmodifiableSequencedMap(result);
-        }
-    }
+    public abstract <V extends Data> SequencedMap<V, List<R>> getResultGroupedBy(@Nonnull TypedMetamodel<T, V, V> path);
 
     /**
      * Executes the query and returns the results grouped by a lightweight ref to the record reached via
@@ -997,63 +911,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      *                              not reference an entity or ref, or if the path resolves to null for a result.
      * @since 1.13
      */
-    public <V extends Data> SequencedMap<Ref<V>, List<R>> getResultGroupedByRef(@Nonnull Metamodel<T, V> path) {
-        requireNonNull(path, "path");
-        try (var stream = getMaterializedResultStream()) {
-            // Refs hash and compare by primary key, so the grouping map is cheap without an identity-based fast path.
-            // The values are unmodifiable views appended through their backing lists, so no copy or re-wrapping is
-            // needed when the result is returned.
-            var groups = new LinkedHashMap<Ref<V>, List<R>>();
-            stream.forEach(element -> {
-                if (!path.root().isInstance(element)) {
-                    throw new PersistenceException(
-                            "Grouped results require an entity query rooted at %s, but got a result of type %s."
-                                    .formatted(path.root().getName(),
-                                            element == null ? "null" : element.getClass().getName()));
-                }
-                //noinspection unchecked
-                Object value = path.getValue((T) element);
-                if (value == null) {
-                    throw new PersistenceException(
-                            "Cannot group by %s: the path resolved to null. Narrow the query with a where() clause to exclude results without a %s."
-                                    .formatted(path, path.fieldType().getSimpleName()));
-                }
-                Ref<V> group;
-                if (value instanceof Ref<?> ref) {
-                    //noinspection unchecked
-                    group = (Ref<V>) ref;
-                } else if (value instanceof Entity<?> entity) {
-                    //noinspection unchecked
-                    group = (Ref<V>) Ref.of(entity);
-                } else {
-                    throw new PersistenceException(
-                            "Cannot group by ref at %s: the path must reference an entity or a ref, but resolved to %s."
-                                    .formatted(path, value.getClass().getName()));
-                }
-                ((Group<R>) groups.computeIfAbsent(group, ignore -> new Group<>())).elements.add(element);
-            });
-            return Collections.unmodifiableSequencedMap(groups);
-        }
-    }
-
-    /**
-     * Unmodifiable list view over a group's elements. The grouping terminals append through {@link #elements} while
-     * building, so the map values are unmodifiable from the start and require no copy or re-wrapping when the result
-     * is returned.
-     */
-    private static final class Group<R> extends AbstractList<R> implements RandomAccess {
-        final ArrayList<R> elements = new ArrayList<>();
-
-        @Override
-        public R get(int index) {
-            return elements.get(index);
-        }
-
-        @Override
-        public int size() {
-            return elements.size();
-        }
-    }
+    public abstract <V extends Data> SequencedMap<Ref<V>, List<R>> getResultGroupedByRef(@Nonnull Metamodel<T, V> path);
 
     /**
      * Executes the query and returns a single result.
@@ -1063,14 +921,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @throws NonUniqueResultException if more than one result.
      * @throws PersistenceException if the query fails.
      */
-    public R getSingleResult() {
-        try (var stream = getMaterializedResultStream()) {
-            return stream
-                    .reduce((_, _) -> {
-                        throw new NonUniqueResultException("Expected single result, but found more than one.");
-                    }).orElseThrow(() -> new NoResultException("Expected single result, but found none."));
-        }
-    }
+    public abstract R getSingleResult();
 
     /**
      * Executes the query and returns an optional result.
@@ -1079,13 +930,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @throws NonUniqueResultException if more than one result.
      * @throws PersistenceException if the query fails.
      */
-    public Optional<R> getOptionalResult() {
-        try (var stream = getMaterializedResultStream()) {
-            return stream.reduce((_, _) -> {
-                throw new NonUniqueResultException("Expected single result, but found more than one.");
-            });
-        }
-    }
+    public abstract Optional<R> getOptionalResult();
 
     /**
      * Execute a DELETE statement.

--- a/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
@@ -1076,8 +1076,9 @@ abstract class QueryBuilder<T : Data, R, ID> {
      * The SQL is not affected by the grouping; the same select is executed and the results are grouped during
      * hydration. The returned map and its lists are unmodifiable and insertion-ordered: groups appear in the order
      * their first result is encountered, and results appear in encounter order within each group. Use `orderBy()` to
-     * control both. Since duplicate entities within a result set share the same instance, each result's reference to
-     * its group key is the map key itself.
+     * control both. Duplicate entities within a result set are guaranteed to share the same instance as long as
+     * earlier occurrences remain strongly reachable, and the grouping retains every result and group key while the
+     * result set is consumed; each result's reference to its group key is therefore the map key itself.
      *
      * This method requires an entity query: the result type must be the table type `T` so that the path can be
      * resolved against the results. The path must also resolve to a non-null record for every result; paths over


### PR DESCRIPTION
## What

**Single-pass grouping.** `getResultGroupedBy` builds the value-ordered result map during the row loop. The `IdentityHashMap` acts as a per-instance memo pointing at each key's canonical group, so per-row work stays reference-identity only and the deep hash of the group record is paid once per distinct instance. The separate assembly loop, the encounter-order lists, and the chunk-merge path are gone. `computeIfAbsent` allocates a `Group` only for genuinely new keys, and `path.root()` is hoisted out of the row loop (also in the ref variant).

**Pre-sized grouping maps.** Both grouping terminals size their maps for 64 expected groups (`EXPECTED_GROUPS`). Grouping typically collects children per parent, so group counts regularly reach the dozens; the identity map's first resize moves from 22 to 86 distinct groups at a cost of roughly 2 KB per call.

**java21 delegates to core.** The `st.orm.template.QueryBuilder` base class kept full copies of the grouped and eager terminal bodies even though `QueryBuilderImpl` overrides them all with delegation to storm-core, which is the Kotlin layer's pattern. The bodies are now abstract declarations, and the unused `getMaterializedResultStream` hook and `Group` helper are removed: one implementation left.

**Interning stated as a guarantee.** `WeakInterner`, the grouped-by javadoc on all three language surfaces, and the docs (`hydration.md`, `relationships.md`) now document query-scoped identity as a guarantee conditioned on strong reachability: a reference is cleared only when its referent is no longer strongly reachable, so any caller able to compare two duplicate occurrences necessarily still holds the first, which is what keeps its interner entry alive. The grouped terminals hold every result and key while consuming the result set, so the guarantee is unconditional there.

## Notes

- Behavior is unchanged: group order (first encounter), within-group order (row order), value-based map semantics, and the equal-but-not-interned merge case are all preserved.
- The grouped terminals are `@since 1.13` (unreleased), so the java21 abstract conversion has no compatibility impact; `getResultList`/`getSingleResult`/`getOptionalResult` becoming abstract only affects external subclasses of the abstract builder.
- The `docs/` wording changes appear at `/docs/next` until the next release snapshot.

## Testing

- storm-core `QueryBuilderPredicateIntegrationTest`: 43/43
- storm-java21 full suite: 517/517
- storm-kotlin `QueryBuilderTest`: green