### PR TITLE
perf(core): trim the dirty-check hot path and keep observed state warm after updates

### DIFF
--- a/docs/hydration.md
+++ b/docs/hydration.md
@@ -363,7 +363,7 @@ val city: City = user.city.fetch()  // Loads City from database
 
 ## Query-Level Identity (Interning)
 
-When the same entity appears multiple times in a query result (e.g., through joins), Storm guarantees they share the same object instance within that query. This is called **interning**.
+When the same entity appears multiple times in a query result (e.g., through joins), Storm guarantees they share the same object instance within that query, as long as your code still holds the earlier occurrence when the later one is hydrated. This is called **interning**. Code in a position to compare two occurrences necessarily holds the first one, so the guarantee holds wherever it can be observed; see [Memory Safety](#memory-safety) for why cleanup never weakens it.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐

--- a/storm-core/src/main/java/st/orm/core/repository/impl/DirtySupport.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/DirtySupport.java
@@ -192,18 +192,6 @@ public final class DirtySupport<E extends Entity<ID>, ID> {
     }
 
     /**
-     * Returns whether the entity declares a version column.
-     *
-     * <p>Version columns are bumped by the database update itself, so the in-memory entity no longer matches the
-     * row after an update; callers use this to decide whether a written entity can serve as observed state.</p>
-     *
-     * @return {@code true} if the entity declares a version column.
-     */
-    boolean hasVersionColumn() {
-        return versionColumn != null;
-    }
-
-    /**
      * Returns the maximum number of distinct update shapes that may be generated when dynamic updates are enabled.
      *
      * <p>This value is configured via the {@code storm.update.max_shapes} property (see {@link StormConfig}). It limits the number of

--- a/storm-core/src/main/java/st/orm/core/repository/impl/DirtySupport.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/DirtySupport.java
@@ -192,6 +192,18 @@ public final class DirtySupport<E extends Entity<ID>, ID> {
     }
 
     /**
+     * Returns whether the entity declares a version column.
+     *
+     * <p>Version columns are bumped by the database update itself, so the in-memory entity no longer matches the
+     * row after an update; callers use this to decide whether a written entity can serve as observed state.</p>
+     *
+     * @return {@code true} if the entity declares a version column.
+     */
+    boolean hasVersionColumn() {
+        return versionColumn != null;
+    }
+
+    /**
      * Returns the maximum number of distinct update shapes that may be generated when dynamic updates are enabled.
      *
      * <p>This value is configured via the {@code storm.update.max_shapes} property (see {@link StormConfig}). It limits the number of
@@ -292,22 +304,28 @@ public final class DirtySupport<E extends Entity<ID>, ID> {
             return CLEAN;
         }
         dirtyCheckMetrics.recordDirty();
-        BitSet key = (BitSet) dirtyFields.clone(); // Defensive copy.
-        int sizeBefore = dirtyFieldsCache.size();
-        var result = Optional.of(dirtyFieldsCache.computeIfAbsent(key, bits -> {
-            Set<Metamodel<?, ?>> set = new HashSet<>();
-            for (int i = bits.nextSetBit(0); i >= 0; i = bits.nextSetBit(i + 1)) {
-                set.add(model.columns().get(i).metamodel());
+        // A map lookup does not retain its key, so the mutable bit set probes the cache directly; the defensive
+        // copy and the new-shape bookkeeping are only needed when the shape is actually inserted.
+        var fields = dirtyFieldsCache.get(dirtyFields);
+        if (fields == null) {
+            BitSet key = (BitSet) dirtyFields.clone();
+            boolean[] inserted = new boolean[1];
+            fields = dirtyFieldsCache.computeIfAbsent(key, bits -> {
+                inserted[0] = true;
+                Set<Metamodel<?, ?>> set = new HashSet<>();
+                for (int i = bits.nextSetBit(0); i >= 0; i = bits.nextSetBit(i + 1)) {
+                    set.add(model.columns().get(i).metamodel());
+                }
+                if (versionColumn != null) {
+                    set.add(versionColumn.metamodel());
+                }
+                return Set.copyOf(set);
+            });
+            if (inserted[0]) {
+                dirtyCheckMetrics.recordNewShape(model.type().getSimpleName());
             }
-            if (versionColumn != null) {
-                set.add(versionColumn.metamodel());
-            }
-            return Set.copyOf(set);
-        }));
-        if (dirtyFieldsCache.size() > sizeBefore) {
-            dirtyCheckMetrics.recordNewShape(model.type().getSimpleName());
         }
-        return result;
+        return Optional.of(fields);
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/repository/impl/DirtySupport.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/DirtySupport.java
@@ -293,24 +293,25 @@ public final class DirtySupport<E extends Entity<ID>, ID> {
         }
         dirtyCheckMetrics.recordDirty();
         // A map lookup does not retain its key, so the mutable bit set probes the cache directly; the defensive
-        // copy and the new-shape bookkeeping are only needed when the shape is actually inserted.
+        // copy and the new-shape bookkeeping are only needed when the shape is actually inserted. Put-if-absent
+        // keeps the new-shape metric exact when two threads race on the same shape: only the winning insert
+        // records it.
         var fields = dirtyFieldsCache.get(dirtyFields);
         if (fields == null) {
-            BitSet key = (BitSet) dirtyFields.clone();
-            boolean[] inserted = new boolean[1];
-            fields = dirtyFieldsCache.computeIfAbsent(key, bits -> {
-                inserted[0] = true;
-                Set<Metamodel<?, ?>> set = new HashSet<>();
-                for (int i = bits.nextSetBit(0); i >= 0; i = bits.nextSetBit(i + 1)) {
-                    set.add(model.columns().get(i).metamodel());
-                }
-                if (versionColumn != null) {
-                    set.add(versionColumn.metamodel());
-                }
-                return Set.copyOf(set);
-            });
-            if (inserted[0]) {
+            Set<Metamodel<?, ?>> set = new HashSet<>();
+            for (int i = dirtyFields.nextSetBit(0); i >= 0; i = dirtyFields.nextSetBit(i + 1)) {
+                set.add(model.columns().get(i).metamodel());
+            }
+            if (versionColumn != null) {
+                set.add(versionColumn.metamodel());
+            }
+            var candidate = Set.copyOf(set);
+            var existing = dirtyFieldsCache.putIfAbsent((BitSet) dirtyFields.clone(), candidate);
+            if (existing == null) {
                 dirtyCheckMetrics.recordNewShape(model.type().getSimpleName());
+                fields = candidate;
+            } else {
+                fields = existing;
             }
         }
         return Optional.of(fields);

--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -966,6 +966,15 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         } else if (result != 1) {
             throw new PersistenceException("Update of %s failed. 0 rows were affected, possibly because the row does not exist or a constraint prevented the update.".formatted(model.type().getSimpleName()));
         }
+        // The written entity equals the database row for unversioned types, so it can serve as observed state,
+        // keeping dirty checking warm for subsequent updates of the same entity within the transaction.
+        if (!dirtySupport.hasVersionColumn()) {
+            entityCache.ifPresent(cache -> {
+                if (!model.isDefaultPrimaryKey(e.id())) {
+                    cache.intern(e);
+                }
+            });
+        }
         fireAfterUpdate(e);
     }
 
@@ -1944,7 +1953,25 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         } else if (IntStream.of(result).anyMatch(r -> r != 1)) {
             throw new PersistenceException("Batch update of %s failed. One or more rows were not affected.".formatted(model.type().getSimpleName()));
         }
+        reinternAfterUpdate(batch, cache);
         batch.forEach(this::fireAfterUpdate);
+    }
+
+    /**
+     * Re-interns the given entities after a successful update. The written state equals the database row for
+     * unversioned types, so it can serve as observed state, keeping dirty checking warm for subsequent updates of
+     * the same entities within the transaction. Versioned types are skipped: the database bumps the version during
+     * the update, so the written entity no longer matches the row.
+     */
+    private void reinternAfterUpdate(@Nonnull List<E> batch, @Nullable EntityCache<E, ID> cache) {
+        if (cache == null || dirtySupport.hasVersionColumn()) {
+            return;
+        }
+        for (var entity : batch) {
+            if (!model.isDefaultPrimaryKey(entity.id())) {
+                cache.intern(entity);
+            }
+        }
     }
 
     protected List<ID> updateAndFetchIds(@Nonnull List<E> batch, @Nonnull PreparedQuery query, @Nullable EntityCache<E, ID> cache) {
@@ -1963,6 +1990,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         } else if (IntStream.of(result).anyMatch(r -> r != 1)) {
             throw new PersistenceException("Batch update of %s failed. One or more rows were not affected.".formatted(model.type().getSimpleName()));
         }
+        reinternAfterUpdate(batch, cache);
         batch.forEach(this::fireAfterUpdate);
         return batch.stream().map(Entity::id).toList();
     }

--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -935,14 +935,12 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         E e = fireBeforeUpdate(entity);
         if (model.isJoinedInheritance()) {
             validateUpdate(e);
-            var joinedEntityCache = entityCache();
-            joinedEntityCache.ifPresent(cache -> {
+            entityCache().ifPresent(cache -> {
                 if (!model.isDefaultPrimaryKey(e.id())) {
                     cache.remove(e.id());
                 }
             });
             JoinedEntityHelper.update(ormTemplate, model, e);
-            reinternAfterUpdate(List.of(e), joinedEntityCache.orElse(null));
             fireAfterUpdate(e);
             return;
         }
@@ -968,7 +966,6 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         } else if (result != 1) {
             throw new PersistenceException("Update of %s failed. 0 rows were affected, possibly because the row does not exist or a constraint prevented the update.".formatted(model.type().getSimpleName()));
         }
-        reinternAfterUpdate(List.of(e), entityCache.orElse(null));
         fireAfterUpdate(e);
     }
 
@@ -1871,7 +1868,6 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
                         .filter(e -> !model.isDefaultPrimaryKey(e.id()))
                         .forEach(e -> cache.remove(e.id())));
                 JoinedEntityHelper.updateBatch(ormTemplate, model, batch);
-                reinternAfterUpdate(batch, entityCache.orElse(null));
                 batch.forEach(this::fireAfterUpdate);
             });
             return;
@@ -1948,25 +1944,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         } else if (IntStream.of(result).anyMatch(r -> r != 1)) {
             throw new PersistenceException("Batch update of %s failed. One or more rows were not affected.".formatted(model.type().getSimpleName()));
         }
-        reinternAfterUpdate(batch, cache);
         batch.forEach(this::fireAfterUpdate);
-    }
-
-    /**
-     * Re-interns the given entities after a successful update. The written state equals the database row for
-     * unversioned types, so it can serve as observed state, keeping dirty checking and same-transaction reads warm
-     * for the updated entities. Versioned types are skipped: the database bumps the version during the update, so
-     * the written entity no longer matches the row.
-     */
-    private void reinternAfterUpdate(@Nonnull List<E> batch, @Nullable EntityCache<E, ID> cache) {
-        if (cache == null || dirtySupport.hasVersionColumn()) {
-            return;
-        }
-        for (var entity : batch) {
-            if (!model.isDefaultPrimaryKey(entity.id())) {
-                cache.intern(entity);
-            }
-        }
     }
 
     protected List<ID> updateAndFetchIds(@Nonnull List<E> batch, @Nonnull PreparedQuery query, @Nullable EntityCache<E, ID> cache) {
@@ -1985,7 +1963,6 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         } else if (IntStream.of(result).anyMatch(r -> r != 1)) {
             throw new PersistenceException("Batch update of %s failed. One or more rows were not affected.".formatted(model.type().getSimpleName()));
         }
-        reinternAfterUpdate(batch, cache);
         batch.forEach(this::fireAfterUpdate);
         return batch.stream().map(Entity::id).toList();
     }

--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -935,12 +935,14 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         E e = fireBeforeUpdate(entity);
         if (model.isJoinedInheritance()) {
             validateUpdate(e);
-            entityCache().ifPresent(cache -> {
+            var joinedEntityCache = entityCache();
+            joinedEntityCache.ifPresent(cache -> {
                 if (!model.isDefaultPrimaryKey(e.id())) {
                     cache.remove(e.id());
                 }
             });
             JoinedEntityHelper.update(ormTemplate, model, e);
+            reinternAfterUpdate(List.of(e), joinedEntityCache.orElse(null));
             fireAfterUpdate(e);
             return;
         }
@@ -966,15 +968,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         } else if (result != 1) {
             throw new PersistenceException("Update of %s failed. 0 rows were affected, possibly because the row does not exist or a constraint prevented the update.".formatted(model.type().getSimpleName()));
         }
-        // The written entity equals the database row for unversioned types, so it can serve as observed state,
-        // keeping dirty checking warm for subsequent updates of the same entity within the transaction.
-        if (!dirtySupport.hasVersionColumn()) {
-            entityCache.ifPresent(cache -> {
-                if (!model.isDefaultPrimaryKey(e.id())) {
-                    cache.intern(e);
-                }
-            });
-        }
+        reinternAfterUpdate(List.of(e), entityCache.orElse(null));
         fireAfterUpdate(e);
     }
 
@@ -1877,6 +1871,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
                         .filter(e -> !model.isDefaultPrimaryKey(e.id()))
                         .forEach(e -> cache.remove(e.id())));
                 JoinedEntityHelper.updateBatch(ormTemplate, model, batch);
+                reinternAfterUpdate(batch, entityCache.orElse(null));
                 batch.forEach(this::fireAfterUpdate);
             });
             return;
@@ -1959,9 +1954,9 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
 
     /**
      * Re-interns the given entities after a successful update. The written state equals the database row for
-     * unversioned types, so it can serve as observed state, keeping dirty checking warm for subsequent updates of
-     * the same entities within the transaction. Versioned types are skipped: the database bumps the version during
-     * the update, so the written entity no longer matches the row.
+     * unversioned types, so it can serve as observed state, keeping dirty checking and same-transaction reads warm
+     * for the updated entities. Versioned types are skipped: the database bumps the version during the update, so
+     * the written entity no longer matches the row.
      */
     private void reinternAfterUpdate(@Nonnull List<E> batch, @Nullable EntityCache<E, ID> cache) {
         if (cache == null || dirtySupport.hasVersionColumn()) {

--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlTemplateImpl.java
@@ -419,7 +419,8 @@ public final class SqlTemplateImpl implements SqlTemplate {
         try {
             var fragments = bindingContext.fragments();
             var elements = bindingContext.elements();
-            var compilationKey = new ArrayList<>();
+            // Runs for every processed template; sized for the common case of one key per fragment and element.
+            var compilationKey = new ArrayList<>(fragments.size() + elements.size());
             for (int i = 0, size = fragments.size(); i < size; i++) {
                 compilationKey.add(fragments.get(i));
                 if (i < elements.size()) {


### PR DESCRIPTION
## What

**Dirty-shape lookup without per-update overhead.** `DirtySupport.getDirty` probes the shape cache with the mutable `BitSet` first; a map lookup does not retain its key, so this is safe. The defensive clone, the set construction, and the new-shape metric now run only when a shape is actually inserted, which happens at most `maxShapes` times per entity type. In steady state a FIELD-mode dirty update pays a single CHM `get`. Insertion goes through `putIfAbsent`, so the new-shape metric is recorded exactly once per shape regardless of the backing map implementation.

**Pre-sized compilation key.** The template compilation key list in `SqlTemplateImpl` is sized for one key per fragment and element. It is built for every processed template in the framework.

**Interning guarantee qualified consistently.** The interning introduction in `hydration.md` now carries the strong-reachability condition already stated in the Memory Safety section and the `WeakInterner` javadoc.

## Notes

- No behavior change: SQL shapes, optimistic-lock handling, and cache-miss fallbacks are unchanged.
- An earlier revision of this branch also re-interned written entities into the transaction entity cache after successful updates. That was withdrawn: the cache holds observed state hydrated from actual rows, which is what lets hydration's early lookup skip reading the row on a cache hit. Serving written (assumed) state to re-reads would mask database-side transformations such as triggers, ON UPDATE clauses, and type coercion until the transaction ends. Splitting observed from assumed state so only the dirty check sees written state is a possible follow-up if repeat-update flows ever show up in a profile.
- SQL generation for dynamic updates was verified to already be cached per shape (the compiled `TemplateProcessor` LRU keyed by structural compilation key, bounded by `maxShapes`); the remaining per-call work is preprocess and parameter binding. Skipping preprocess would need a compiled-plan bind API on `SqlTemplate`, which is left out of scope here.

## Testing

- Full storm-core suite: 2332/2332 after each revision
- Targeted: `DynamicUpdateIntegrationTest`, `EntityRepository*IntegrationTest`, `JoinedEntityCrudIntegrationTest`, `JoinedEntityCallbackIntegrationTest`, `QueryModelAndUpsertIntegrationTest`, `RepositoryPreparedStatementIntegrationTest`, `EntityCacheImplTest`, `MetricsIntegrationTest`, `EqualitySupportIntegrationTest`, `RecordMapperTest` all pass