### PR TITLE
feat(core): compiled query plans for record-bound and constant statements

### DIFF
--- a/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
@@ -29,6 +29,8 @@ import jakarta.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -64,6 +66,9 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
 
     /** Lazily created by-id select plan, bound per call via the primary key; racy initialization is benign. */
     private volatile QueryPlan findByIdPlan;
+
+    /** Lazily created by-key select plans for unique-key lookups; the population is the finite set of unique keys. */
+    private final ConcurrentMap<Metamodel<E, ?>, QueryPlan> findByKeyPlans = new ConcurrentHashMap<>();
 
     /**
      * Cleared on the first failed plan creation. Plans require template processing support ahead of execution;
@@ -330,6 +335,11 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      *                              connectivity problems or query execution errors.
      */
     public Optional<E> findByRef(@Nonnull Ref<E> ref) {
+        //noinspection unchecked
+        var query = findByIdQuery((ID) ref.id());
+        if (query != null) {
+            return query.getOptionalResult(model.type());
+        }
         return select().where(ref).getOptionalResult();
     }
 
@@ -373,7 +383,7 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
             }
             if (plan != null) {
                 // Eager consumption; the fetch-size hint is skipped like the builder's eager terminal does.
-                return plan.bindId(id).withoutFetchSize();
+                return plan.bindValue(id).withoutFetchSize();
             }
         }
         return null;
@@ -393,6 +403,11 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      *                              connectivity problems or query execution errors.
      */
     public E getByRef(@Nonnull Ref<E> ref) {
+        //noinspection unchecked
+        var query = findByIdQuery((ID) ref.id());
+        if (query != null) {
+            return query.getSingleResult(model.type());
+        }
         return select().where(ref).getSingleResult();
     }
 
@@ -408,6 +423,10 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      * @throws PersistenceException if the retrieval operation fails due to underlying database issues.
      */
     public <V> Optional<E> findBy(@Nonnull Metamodel.Key<E, V> key, @Nonnull V value) {
+        var query = findByKeyQuery(key, value);
+        if (query != null) {
+            return query.getOptionalResult(model.type());
+        }
         return select().where(key, EQUALS, value).getOptionalResult();
     }
 
@@ -422,7 +441,40 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      * @throws PersistenceException if the retrieval operation fails due to underlying database issues.
      */
     public <V> E getBy(@Nonnull Metamodel.Key<E, V> key, @Nonnull V value) {
+        var query = findByKeyQuery(key, value);
+        if (query != null) {
+            return query.getSingleResult(model.type());
+        }
         return select().where(key, EQUALS, value).getSingleResult();
+    }
+
+    /**
+     * Returns a query that selects the entity graph by the given unique key, served from a cached plan, or
+     * {@code null} when plans are unavailable; see {@link #usePlans()} for the guards.
+     */
+    private @Nullable Query findByKeyQuery(@Nonnull Metamodel<E, ?> key, @Nonnull Object value) {
+        if (usePlans()) {
+            var plan = findByKeyPlans.get(key);
+            if (plan == null) {
+                var created = createPlanQuietly(() -> {
+                    var bindVars = ormTemplate.createBindVars();
+                    return ormTemplate.plan(TemplateString.raw("""
+                            SELECT \0
+                            FROM \0
+                            WHERE \0""", model.type(), Templates.from(model.type(), true),
+                            Templates.where(key, bindVars)));
+                });
+                if (created != null) {
+                    var existing = findByKeyPlans.putIfAbsent(key, created);
+                    plan = existing != null ? existing : created;
+                }
+            }
+            if (plan != null) {
+                // Eager consumption; the fetch-size hint is skipped like the builder's eager terminal does.
+                return plan.bindValue(value).withoutFetchSize();
+            }
+        }
+        return null;
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
@@ -25,10 +25,12 @@ import static st.orm.core.spi.Providers.selectRefFrom;
 import static st.orm.core.template.TemplateString.wrap;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import st.orm.Data;
@@ -40,7 +42,9 @@ import st.orm.core.repository.Repository;
 import st.orm.core.template.Model;
 import st.orm.core.template.ORMTemplate;
 import st.orm.core.template.QueryBuilder;
+import st.orm.core.template.QueryPlan;
 import st.orm.core.template.TemplateString;
+import st.orm.core.template.impl.SqlInterceptorManager;
 
 /**
  * Base implementation for all repositories.
@@ -51,12 +55,42 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
     protected final Model<E, ID> model;
     private final boolean compoundPrimaryKey;
 
+    /** Lazily created constant plans for the parameter-less statement shapes; racy initialization is benign. */
+    private volatile QueryPlan findAllPlan;
+    private volatile QueryPlan findAllRefPlan;
+    private volatile QueryPlan countPlan;
+
+    /**
+     * Cleared on the first failed plan creation. Plans require template processing support ahead of execution;
+     * templates without it, such as JPA, keep the per-call path, and genuine template errors surface through that
+     * same path.
+     */
+    private volatile boolean plansSupported = true;
+
     public BaseRepositoryImpl(@Nonnull ORMTemplate ormTemplate, @Nonnull Model<E, ID> model) {
         this.ormTemplate = requireNonNull(ormTemplate);
         this.model = requireNonNull(model);
         this.compoundPrimaryKey = model.getPrimaryKeyMetamodel()
                 .filter(Metamodel::isInline)
                 .isPresent();
+    }
+
+    /**
+     * Returns whether repository statements are served from cached plans. Plans are processed against the
+     * repository's own template; while a scoped template customizer is active, the customized template must
+     * generate the statement, so the cached plans are bypassed.
+     */
+    protected final boolean usePlans() {
+        return plansSupported && !SqlInterceptorManager.hasLocalCustomizers();
+    }
+
+    protected final @Nullable QueryPlan createPlanQuietly(@Nonnull Supplier<QueryPlan> factory) {
+        try {
+            return factory.get();
+        } catch (PersistenceException e) {
+            plansSupported = false;
+            return null;
+        }
     }
 
     /**
@@ -205,6 +239,16 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      * connectivity.
      */
     public long count() {
+        if (usePlans()) {
+            var plan = countPlan;
+            if (plan == null) {
+                plan = createPlanQuietly(() -> selectCount().plan());
+                countPlan = plan;
+            }
+            if (plan != null) {
+                return plan.query().withoutFetchSize().getSingleResult(Long.class);
+            }
+        }
         return selectCount().getSingleResult();
     }
 
@@ -384,10 +428,34 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      *                              connectivity.
      */
     public List<E> findAll() {
+        if (usePlans()) {
+            var plan = findAllPlan;
+            if (plan == null) {
+                plan = createPlanQuietly(() -> select().plan());
+                findAllPlan = plan;
+            }
+            if (plan != null) {
+                // Eager consumption; the fetch-size hint is skipped like the builder's eager terminal does.
+                return plan.query().withoutFetchSize().getResultList(model.type());
+            }
+        }
         return select().getResultList();
     }
 
     public List<Ref<E>> findAllRef() {
+        if (usePlans()) {
+            var plan = findAllRefPlan;
+            if (plan == null) {
+                plan = createPlanQuietly(() -> selectRef().plan());
+                findAllRefPlan = plan;
+            }
+            if (plan != null) {
+                // Eager consumption; the fetch-size hint is skipped like the builder's eager terminal does.
+                try (var stream = plan.query().withoutFetchSize().getRefStream(model.type(), model.primaryKeyType())) {
+                    return stream.toList();
+                }
+            }
+        }
         return selectRef().getResultList();
     }
 

--- a/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/BaseRepositoryImpl.java
@@ -41,9 +41,11 @@ import st.orm.Ref;
 import st.orm.core.repository.Repository;
 import st.orm.core.template.Model;
 import st.orm.core.template.ORMTemplate;
+import st.orm.core.template.Query;
 import st.orm.core.template.QueryBuilder;
 import st.orm.core.template.QueryPlan;
 import st.orm.core.template.TemplateString;
+import st.orm.core.template.Templates;
 import st.orm.core.template.impl.SqlInterceptorManager;
 
 /**
@@ -59,6 +61,9 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
     private volatile QueryPlan findAllPlan;
     private volatile QueryPlan findAllRefPlan;
     private volatile QueryPlan countPlan;
+
+    /** Lazily created by-id select plan, bound per call via the primary key; racy initialization is benign. */
+    private volatile QueryPlan findByIdPlan;
 
     /**
      * Cleared on the first failed plan creation. Plans require template processing support ahead of execution;
@@ -306,6 +311,10 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      *                              connectivity problems or query execution errors.
      */
     public Optional<E> findById(@Nonnull ID id) {
+        var query = findByIdQuery(id);
+        if (query != null) {
+            return query.getOptionalResult(model.type());
+        }
         return select().where(id).getOptionalResult();
     }
 
@@ -338,7 +347,36 @@ abstract class BaseRepositoryImpl<E extends Data, ID> implements Repository {
      *                              connectivity problems or query execution errors.
      */
     public E getById(@Nonnull ID id) {
+        var query = findByIdQuery(id);
+        if (query != null) {
+            return query.getSingleResult(model.type());
+        }
         return select().where(id).getSingleResult();
+    }
+
+    /**
+     * Returns a query that selects the entity graph by primary key, served from a cached plan, or {@code null} when
+     * plans are unavailable; see {@link #usePlans()} for the guards.
+     */
+    private @Nullable Query findByIdQuery(@Nonnull ID id) {
+        if (usePlans()) {
+            var plan = findByIdPlan;
+            if (plan == null) {
+                plan = createPlanQuietly(() -> {
+                    var bindVars = ormTemplate.createBindVars();
+                    return ormTemplate.plan(TemplateString.raw("""
+                            SELECT \0
+                            FROM \0
+                            WHERE \0""", model.type(), Templates.from(model.type(), true), bindVars));
+                });
+                findByIdPlan = plan;
+            }
+            if (plan != null) {
+                // Eager consumption; the fetch-size hint is skipped like the builder's eager terminal does.
+                return plan.bindId(id).withoutFetchSize();
+            }
+        }
+        return null;
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -57,7 +59,9 @@ import st.orm.core.template.Column;
 import st.orm.core.template.Model;
 import st.orm.core.template.ORMTemplate;
 import st.orm.core.template.PreparedQuery;
+import st.orm.core.template.Query;
 import st.orm.core.template.QueryBuilder;
+import st.orm.core.template.QueryPlan;
 import st.orm.core.template.TemplateString;
 import st.orm.core.template.Templates;
 import st.orm.core.template.impl.Elements;
@@ -90,6 +94,19 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
     private final DirtySupport<E, ID> dirtySupport;
     private final CacheRetention cacheRetention;
     private final List<EntityCallback<E>> entityCallbacks;
+
+    /**
+     * Bounded cache of single-update plans keyed by dirty shape. It admits the configured maximum number of dynamic
+     * shapes plus the full-update shape; shapes beyond the bound fall back to per-call template processing, keeping
+     * the cached statement fan-out aligned with what maxShapes allows for batches.
+     */
+    private final ConcurrentMap<Set<Metamodel<?, ?>>, QueryPlan> updatePlans = new ConcurrentHashMap<>();
+
+    /** Lazily created plans for the fixed single-entity statement shapes; racy initialization is benign. */
+    private volatile QueryPlan insertPlan;
+    private volatile QueryPlan insertIgnoringAutoGeneratePlan;
+    private volatile QueryPlan removePlan;
+    private volatile QueryPlan removeAllPlan;
 
     public EntityRepositoryImpl(@Nonnull ORMTemplate ormTemplate, @Nonnull Model<E, ID> model) {
         super(ormTemplate, model);
@@ -571,10 +588,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
             fireAfterInsert(entity);
             return;
         }
-        var query = ormTemplate.query(TemplateString.raw("""
-                INSERT INTO \0
-                VALUES \0""", model.type(), entity))
-                .managed();
+        var query = insertQuery(entity, false);
         if (query.executeUpdate() != 1) {
             throw new PersistenceException("Insert of %s failed. 0 rows were affected, which may indicate a trigger, constraint, or BEFORE INSERT hook prevented the row from being written.".formatted(model.type().getSimpleName()));
         }
@@ -599,10 +613,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
     public void insert(@Nonnull E entity, boolean ignoreAutoGenerate) {
         entity = fireBeforeInsert(entity);
         validateInsert(entity, ignoreAutoGenerate);
-        var query = ormTemplate.query(TemplateString.raw("""
-                INSERT INTO \0
-                VALUES \0""", Templates.insert(model.type(), ignoreAutoGenerate), Templates.values(entity, ignoreAutoGenerate)))
-                .managed();
+        var query = insertQuery(entity, ignoreAutoGenerate);
         if (query.executeUpdate() != 1) {
             throw new PersistenceException("Insert of %s failed. 0 rows were affected, which may indicate a trigger, constraint, or BEFORE INSERT hook prevented the row from being written.".formatted(model.type().getSimpleName()));
         }
@@ -955,11 +966,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
                 cache.remove(e.id());
             }
         });
-        var query = ormTemplate.query(TemplateString.raw("""
-                UPDATE \0
-                SET \0
-                WHERE \0""", model.type(), Templates.set(e, dirty.get()), e))
-                .managed();
+        var query = updateQuery(e, dirty.get());
         int result = query.executeUpdate();
         if (query.isVersionAware() && result == 0) {
             throw new OptimisticLockException("Update of %s failed due to optimistic lock. The entity may have been modified or deleted by another transaction.".formatted(model.type().getSimpleName()));
@@ -1142,11 +1149,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
             return;
         }
         // Don't use query builder to prevent WHERE IN clause.
-        int result = ormTemplate.query(TemplateString.raw("""
-                DELETE FROM \0
-                WHERE \0""", model.type(), entity))
-                .managed()
-                .executeUpdate();
+        int result = removeQuery(entity).executeUpdate();
         if (result != 1) {
             throw new PersistenceException("Remove of %s failed. 0 rows were affected, possibly because the entity does not exist or a foreign key constraint prevents deletion.".formatted(model.type().getSimpleName()));
         }
@@ -1213,6 +1216,20 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
     @Override
     public void removeAll() {
         entityCache().ifPresent(EntityCache::clear);
+        if (usePlans()) {
+            var plan = removeAllPlan;
+            if (plan == null) {
+                plan = createPlanQuietly(() -> ormTemplate.plan(TemplateString.raw("DELETE FROM \0", model.type())));
+                removeAllPlan = plan;
+            }
+            if (plan != null) {
+                plan.query()
+                        .unsafe() // Omission of WHERE clause is intentional.
+                        .managed()
+                        .executeUpdate();
+                return;
+            }
+        }
         // Don't use query builder to prevent WHERE IN clause.
         ormTemplate.query(TemplateString.raw("DELETE FROM \0", model.type()))
                 .unsafe() // Omission of WHERE clause is intentional.
@@ -1917,6 +1934,107 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
      */
     protected int getMaxShapes() {
         return dirtySupport.getMaxShapes();
+    }
+
+    /**
+     * Returns a managed query that updates the given entity's dirty {@code fields}.
+     *
+     * <p>The query is served from a plan cached per dirty shape whenever plans are supported and the shape bound
+     * admits it; template processing then runs once per shape rather than once per update. Shapes beyond the bound,
+     * and templates without bind variables support, use per-call template processing.</p>
+     */
+    private Query updateQuery(@Nonnull E entity, @Nonnull Set<Metamodel<?, ?>> fields) {
+        if (usePlans()) {
+            var plan = updatePlans.get(fields);
+            if (plan == null && updatePlans.size() <= dirtySupport.getMaxShapes()) {
+                plan = createUpdatePlan(fields);
+            }
+            if (plan != null) {
+                return plan.bind(entity).managed();
+            }
+        }
+        return ormTemplate.query(TemplateString.raw("""
+                UPDATE \0
+                SET \0
+                WHERE \0""", model.type(), Templates.set(entity, fields), entity))
+                .managed();
+    }
+
+    private QueryPlan createUpdatePlan(@Nonnull Set<Metamodel<?, ?>> fields) {
+        var plan = createPlanQuietly(() -> {
+            var bindVars = ormTemplate.createBindVars();
+            return ormTemplate.plan(TemplateString.raw("""
+                    UPDATE \0
+                    SET \0
+                    WHERE \0""", model.type(), Templates.set(bindVars, fields), bindVars));
+        });
+        if (plan == null) {
+            return null;
+        }
+        var existing = updatePlans.putIfAbsent(fields, plan);
+        return existing != null ? existing : plan;
+    }
+
+    /**
+     * Returns a managed query that inserts the given entity. The query is served from a cached plan whenever plans
+     * are supported, so template processing runs once per repository rather than once per insert; see
+     * {@link #usePlans()} for the guards.
+     */
+    private Query insertQuery(@Nonnull E entity, boolean ignoreAutoGenerate) {
+        if (usePlans()) {
+            var plan = ignoreAutoGenerate ? insertIgnoringAutoGeneratePlan : insertPlan;
+            if (plan == null) {
+                plan = createPlanQuietly(() -> {
+                    var bindVars = ormTemplate.createBindVars();
+                    return ormTemplate.plan(TemplateString.raw("""
+                            INSERT INTO \0
+                            VALUES \0""",
+                            Templates.insert(model.type(), ignoreAutoGenerate),
+                            Templates.values(bindVars, ignoreAutoGenerate)));
+                });
+                if (ignoreAutoGenerate) {
+                    insertIgnoringAutoGeneratePlan = plan;
+                } else {
+                    insertPlan = plan;
+                }
+            }
+            if (plan != null) {
+                return plan.bind(entity).managed();
+            }
+        }
+        return ormTemplate.query(TemplateString.raw("""
+                INSERT INTO \0
+                VALUES \0""",
+                Templates.insert(model.type(), ignoreAutoGenerate),
+                Templates.values(entity, ignoreAutoGenerate)))
+                .managed();
+    }
+
+    /**
+     * Returns a managed query that deletes the given entity by its identifying columns. The query is served from a
+     * cached plan whenever plans are supported, so template processing runs once per repository rather than once per
+     * remove; see {@link #usePlans()} for the guards.
+     */
+    private Query removeQuery(@Nonnull E entity) {
+        if (usePlans()) {
+            var plan = removePlan;
+            if (plan == null) {
+                plan = createPlanQuietly(() -> {
+                    var bindVars = ormTemplate.createBindVars();
+                    return ormTemplate.plan(TemplateString.raw("""
+                            DELETE FROM \0
+                            WHERE \0""", model.type(), bindVars));
+                });
+                removePlan = plan;
+            }
+            if (plan != null) {
+                return plan.bind(entity).managed();
+            }
+        }
+        return ormTemplate.query(TemplateString.raw("""
+                DELETE FROM \0
+                WHERE \0""", model.type(), entity))
+                .managed();
     }
 
     protected PreparedQuery prepareUpdateQuery(@Nonnull Set<Metamodel<?, ?>> fields) {

--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -1193,7 +1193,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
                 removeByIdPlan = plan;
             }
             if (plan != null) {
-                plan.bindId(id).managed().executeUpdate();
+                plan.bindValue(id).managed().executeUpdate();
                 return;
             }
         }
@@ -1219,6 +1219,22 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
     public void removeByRef(@Nonnull Ref<E> ref) {
         //noinspection unchecked
         entityCache().ifPresent(cache -> cache.remove((ID) ref.id()));
+        if (!versionedEntity && !model.isJoinedInheritance() && usePlans()) {
+            var plan = removeByIdPlan;
+            if (plan == null) {
+                plan = createPlanQuietly(() -> {
+                    var bindVars = ormTemplate.createBindVars();
+                    return ormTemplate.plan(TemplateString.raw("""
+                            DELETE FROM \0
+                            WHERE \0""", model.type(), bindVars));
+                });
+                removeByIdPlan = plan;
+            }
+            if (plan != null) {
+                plan.bindValue(ref.id()).managed().executeUpdate();
+                return;
+            }
+        }
         // Don't use query builder to prevent WHERE IN clause.
         ormTemplate.query(TemplateString.raw("""
                 DELETE FROM \0

--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -107,9 +107,17 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
     private volatile QueryPlan insertIgnoringAutoGeneratePlan;
     private volatile QueryPlan removePlan;
     private volatile QueryPlan removeAllPlan;
+    private volatile QueryPlan removeByIdPlan;
+
+    /**
+     * Version columns participate in the identifying WHERE columns of delete statements, and an id cannot supply a
+     * version value, so versioned types keep the per-call path for removal by id.
+     */
+    private final boolean versionedEntity;
 
     public EntityRepositoryImpl(@Nonnull ORMTemplate ormTemplate, @Nonnull Model<E, ID> model) {
         super(ormTemplate, model);
+        this.versionedEntity = model.declaredColumns().stream().anyMatch(Column::version);
         this.defaultBatchSize = 1000;
         this.primaryKeyColumns = model.declaredColumns().stream()
                 .filter(Column::primaryKey)
@@ -1172,6 +1180,22 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         if (model.isJoinedInheritance()) {
             JoinedEntityHelper.removeById(ormTemplate, model, id);
             return;
+        }
+        if (!versionedEntity && usePlans()) {
+            var plan = removeByIdPlan;
+            if (plan == null) {
+                plan = createPlanQuietly(() -> {
+                    var bindVars = ormTemplate.createBindVars();
+                    return ormTemplate.plan(TemplateString.raw("""
+                            DELETE FROM \0
+                            WHERE \0""", model.type(), bindVars));
+                });
+                removeByIdPlan = plan;
+            }
+            if (plan != null) {
+                plan.bindId(id).managed().executeUpdate();
+                return;
+            }
         }
         // Don't use query builder to prevent WHERE IN clause.
         ormTemplate.query(TemplateString.raw("""

--- a/storm-core/src/main/java/st/orm/core/spi/QueryFactory.java
+++ b/storm-core/src/main/java/st/orm/core/spi/QueryFactory.java
@@ -62,12 +62,14 @@ public interface QueryFactory {
     /**
      * Compiles the specified query {@code template} into a reusable plan.
      *
-     * <p>The default implementation does not support plans and throws; factories that process templates ahead of
-     * execution override this method.</p>
+     * <p>The template's variable parts must be expressed as bind variables; templates without any parameters compile
+     * to constant plans, and templates with fixed parameter values are rejected. The default implementation does not
+     * support plans and throws; factories that process templates ahead of execution override this method.</p>
      *
-     * @param template the template to compile; must contain bind variables.
+     * @param template the template to compile.
      * @return a reusable plan for the template.
-     * @throws PersistenceException if this factory does not support plans or the template is invalid.
+     * @throws PersistenceException if this factory does not support plans, the template is invalid, or it carries
+     *                              fixed parameter values.
      * @since 1.13
      */
     default QueryPlan plan(@Nonnull TemplateString template) {

--- a/storm-core/src/main/java/st/orm/core/spi/QueryFactory.java
+++ b/storm-core/src/main/java/st/orm/core/spi/QueryFactory.java
@@ -21,6 +21,7 @@ import javax.sql.DataSource;
 import st.orm.BindVars;
 import st.orm.PersistenceException;
 import st.orm.core.template.Query;
+import st.orm.core.template.QueryPlan;
 import st.orm.core.template.SqlTemplate;
 import st.orm.core.template.TemplateString;
 
@@ -57,6 +58,21 @@ public interface QueryFactory {
      * @throws PersistenceException if the template is invalid.
      */
     Query create(@Nonnull TemplateString template);
+
+    /**
+     * Compiles the specified query {@code template} into a reusable plan.
+     *
+     * <p>The default implementation does not support plans and throws; factories that process templates ahead of
+     * execution override this method.</p>
+     *
+     * @param template the template to compile; must contain bind variables.
+     * @return a reusable plan for the template.
+     * @throws PersistenceException if this factory does not support plans or the template is invalid.
+     * @since 1.13
+     */
+    default QueryPlan plan(@Nonnull TemplateString template) {
+        throw new PersistenceException("Query plans are not supported by %s.".formatted(getClass().getSimpleName()));
+    }
 
     /**
      * Returns the {@link DataSource} backing this factory, or {@code null} if the factory was created from a raw

--- a/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
@@ -669,6 +669,20 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public abstract Query build();
 
     /**
+     * Compiles this query into a reusable plan.
+     *
+     * <p>The builder's template is processed once; see {@link QueryTemplate#plan(TemplateString)} for the plan
+     * contract. Queries without parameters, such as unfiltered selects and counts, execute via
+     * {@link QueryPlan#query()}; queries whose variable parts are expressed as bind variables bind records via
+     * {@link QueryPlan#bind(Data)}. Queries carrying fixed parameter values are rejected.</p>
+     *
+     * @return a reusable plan for this query.
+     * @throws PersistenceException if the query carries fixed parameter values, or plans are not supported.
+     * @since 1.13
+     */
+    public abstract QueryPlan plan();
+
+    /**
      * Prepares the query for execution.
      *
      * <p>Unlike regular queries, which are constructed lazily, prepared queries are constructed eagerly.

--- a/storm-core/src/main/java/st/orm/core/template/QueryPlan.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryPlan.java
@@ -52,6 +52,21 @@ public interface QueryPlan {
     Query bind(@Nonnull Data record);
 
     /**
+     * Binds the given primary key against the plan's statement and returns an executable query.
+     *
+     * <p>Id binding is available when the plan's bind variables consist solely of a WHERE clause matching the
+     * primary key, such as a find, exists, or delete by id. Composite primary keys bind their id record's
+     * constituent values.</p>
+     *
+     * @param id the primary key supplying the values for the plan's bind variables.
+     * @return a query bound to the primary key.
+     * @throws st.orm.PersistenceException if this plan is constant, or its bind variables are not purely
+     *                                     primary-key based.
+     * @since 1.13
+     */
+    Query bindId(@Nonnull Object id);
+
+    /**
      * Returns an executable query for a constant plan.
      *
      * <p>Constant plans are compiled from templates without bind variables and carry no per-call values; each call

--- a/storm-core/src/main/java/st/orm/core/template/QueryPlan.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryPlan.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.template;
+
+import jakarta.annotation.Nonnull;
+import st.orm.Data;
+
+/**
+ * A compiled query plan backed by a pre-processed template.
+ *
+ * <p>A plan is created via {@link QueryTemplate#plan(TemplateString)}. Template processing runs once at plan
+ * creation; executions skip the per-call template processing that {@link QueryTemplate#query(TemplateString)}
+ * performs. Plans come in two forms:</p>
+ * <ul>
+ *   <li><strong>Record-bound</strong>: the template expresses its variable parts as bind variables (see
+ *       {@link QueryTemplate#createBindVars()}); each {@link #bind(Data)} call extracts the record's parameter
+ *       values and returns a regular {@link Query} backed by the already generated statement.</li>
+ *   <li><strong>Constant</strong>: the template has no parameters at all, such as an unfiltered select or count;
+ *       {@link #query()} returns a query over the fixed statement.</li>
+ * </ul>
+ *
+ * <p>Plans are immutable, thread-safe, and independent of any connection: the query returned by {@code bind} acquires
+ * a connection on execution like any other query. Registered {@code SqlInterceptor} instances observe every bound
+ * statement. A plan is pinned to the SQL template configuration it was compiled with: scoped template customizations
+ * that start after compilation do not affect the plan's statement.</p>
+ *
+ * @since 1.13
+ */
+public interface QueryPlan {
+
+    /**
+     * Binds the given record's values against the plan's statement and returns an executable query.
+     *
+     * @param record the record supplying the values for the plan's bind variables.
+     * @return a query bound to the record's values.
+     * @throws st.orm.PersistenceException if this plan is constant, or the record does not match the plan's bind
+     *                                     variables.
+     */
+    Query bind(@Nonnull Data record);
+
+    /**
+     * Returns an executable query for a constant plan.
+     *
+     * <p>Constant plans are compiled from templates without bind variables and carry no per-call values; each call
+     * returns a fresh query over the plan's statement. Plans with bind variables bind records via
+     * {@link #bind(Data)} instead.</p>
+     *
+     * @return a query over the plan's statement.
+     * @throws st.orm.PersistenceException if this plan has bind variables.
+     * @since 1.13
+     */
+    Query query();
+}

--- a/storm-core/src/main/java/st/orm/core/template/QueryPlan.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryPlan.java
@@ -52,19 +52,20 @@ public interface QueryPlan {
     Query bind(@Nonnull Data record);
 
     /**
-     * Binds the given primary key against the plan's statement and returns an executable query.
+     * Binds the given value against the plan's statement and returns an executable query.
      *
-     * <p>Id binding is available when the plan's bind variables consist solely of a WHERE clause matching the
-     * primary key, such as a find, exists, or delete by id. Composite primary keys bind their id record's
+     * <p>Value binding is available when the plan's bind variables consist solely of a WHERE clause over the
+     * primary key, such as a find or delete by id, or over a specific key compiled via
+     * {@code Templates.where(key, bindVars)}, such as a unique-key lookup. Composite keys bind their record's
      * constituent values.</p>
      *
-     * @param id the primary key supplying the values for the plan's bind variables.
-     * @return a query bound to the primary key.
+     * @param value the primary key or key value supplying the values for the plan's bind variables.
+     * @return a query bound to the value.
      * @throws st.orm.PersistenceException if this plan is constant, or its bind variables are not purely
-     *                                     primary-key based.
+     *                                     key based.
      * @since 1.13
      */
-    Query bindId(@Nonnull Object id);
+    Query bindValue(@Nonnull Object value);
 
     /**
      * Returns an executable query for a constant plan.

--- a/storm-core/src/main/java/st/orm/core/template/QueryPlan.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryPlan.java
@@ -54,10 +54,11 @@ public interface QueryPlan {
     /**
      * Binds the given value against the plan's statement and returns an executable query.
      *
-     * <p>Value binding is available when the plan's bind variables consist solely of a WHERE clause over the
+     * <p>Value binding is available when the plan's bind variables consist of a single WHERE clause over the
      * primary key, such as a find or delete by id, or over a specific key compiled via
      * {@code Templates.where(key, bindVars)}, such as a unique-key lookup. Composite keys bind their record's
-     * constituent values.</p>
+     * constituent values through that one clause; plans with multiple bind variables segments bind records via
+     * {@link #bind(Data)}, which supplies each segment's own values.</p>
      *
      * @param value the primary key or key value supplying the values for the plan's bind variables.
      * @return a query bound to the value.

--- a/storm-core/src/main/java/st/orm/core/template/QueryTemplate.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryTemplate.java
@@ -20,6 +20,7 @@ import static st.orm.core.template.TemplateString.wrap;
 import jakarta.annotation.Nonnull;
 import st.orm.BindVars;
 import st.orm.Data;
+import st.orm.PersistenceException;
 import st.orm.Ref;
 
 /**
@@ -175,4 +176,21 @@ public interface QueryTemplate extends SubqueryTemplate {
      * @return the query.
      */
     Query query(@Nonnull TemplateString template);
+
+    /**
+     * Compiles the specified query {@code template} into a reusable plan.
+     *
+     * <p>The template's variable parts must be expressed as bind variables (see {@link #createBindVars()}), bound
+     * per execution via {@link QueryPlan#bind(Data)}. Templates without any parameters, such as unfiltered selects
+     * and counts, compile to constant plans executed via {@link QueryPlan#query()}. Templates with fixed parameter
+     * values are rejected. The returned plan is immutable, thread-safe, and independent of any connection, so it can
+     * be cached and shared; executions skip template processing entirely.</p>
+     *
+     * @param template the query template.
+     * @return a reusable plan for the template.
+     * @throws PersistenceException if the template is invalid, carries fixed parameter values, or the underlying
+     *                              implementation does not support plans.
+     * @since 1.13
+     */
+    QueryPlan plan(@Nonnull TemplateString template);
 }

--- a/storm-core/src/main/java/st/orm/core/template/Templates.java
+++ b/storm-core/src/main/java/st/orm/core/template/Templates.java
@@ -973,6 +973,22 @@ public interface Templates {
     }
 
     /**
+     * Generates a WHERE element matching the specified {@code key} using the given {@link BindVars}.
+     *
+     * <p>This method creates a {@code WHERE} clause over the columns of the given key, with the value supplied per
+     * execution through the bind variables. Query plans use this form to compile unique-key lookups that bind their
+     * value per execution.</p>
+     *
+     * @param key the metamodel key identifying the column(s) to match.
+     * @param bindVars the {@link BindVars} instance used for binding variables in the WHERE clause.
+     * @return an {@link Element} representing the WHERE clause.
+     * @since 1.13
+     */
+    static Element where(@Nonnull Metamodel<?, ?> key, @Nonnull BindVars bindVars) {
+        return new Where(null, requireNonNull(bindVars, "bindVars"), requireNonNull(key, "key"));
+    }
+
+    /**
      * Generates a DELETE element for the specified table class.
      *
      * <p>This method creates a {@code DELETE} clause for the provided table record. It is designed to be used

--- a/storm-core/src/main/java/st/orm/core/template/impl/BindVarsImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/BindVarsImpl.java
@@ -115,6 +115,17 @@ final class BindVarsImpl implements BindVars, BindVariables {
         parameterExtractors.add(parameterExtractor);
     }
 
+    /**
+     * Returns an immutable snapshot of the registered parameter extractors.
+     *
+     * <p>The snapshot lets a query plan reuse the extractors without retaining this single-use instance.</p>
+     *
+     * @return the registered parameter extractors.
+     */
+    List<Function<Data, List<PositionalParameter>>> extractors() {
+        return List.copyOf(parameterExtractors);
+    }
+
     @Override
     public String toString() {
         return "%s@%s".formatted(getClass().getSimpleName(), toHexString(identityHashCode(this)));

--- a/storm-core/src/main/java/st/orm/core/template/impl/BindVarsImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/BindVarsImpl.java
@@ -37,11 +37,13 @@ import st.orm.core.template.SqlTemplate.PositionalParameter;
  */
 final class BindVarsImpl implements BindVars, BindVariables {
     private final List<Function<Data, List<PositionalParameter>>> parameterExtractors;
+    private final List<Function<Object, List<PositionalParameter>>> idParameterExtractors;
     private BatchListener batchListener;
     private RecordListener recordListener;
 
     public BindVarsImpl() {
         this.parameterExtractors = new ArrayList<>();
+        this.idParameterExtractors = new ArrayList<>();
     }
 
     /**
@@ -116,6 +118,18 @@ final class BindVarsImpl implements BindVars, BindVariables {
     }
 
     /**
+     * Registers a function that extracts positional parameters from a primary key value.
+     *
+     * <p>Id extractors are registered alongside the record extractor for bind variables whose identifying columns
+     * are exactly the primary key, letting query plans bind a raw id where a full record is not available.</p>
+     *
+     * @param idParameterExtractor the function that extracts positional parameters from a primary key value.
+     */
+    void addIdParameterExtractor(@Nonnull Function<Object, List<PositionalParameter>> idParameterExtractor) {
+        idParameterExtractors.add(idParameterExtractor);
+    }
+
+    /**
      * Returns an immutable snapshot of the registered parameter extractors.
      *
      * <p>The snapshot lets a query plan reuse the extractors without retaining this single-use instance.</p>
@@ -124,6 +138,15 @@ final class BindVarsImpl implements BindVars, BindVariables {
      */
     List<Function<Data, List<PositionalParameter>>> extractors() {
         return List.copyOf(parameterExtractors);
+    }
+
+    /**
+     * Returns an immutable snapshot of the registered id parameter extractors.
+     *
+     * @return the registered id parameter extractors.
+     */
+    List<Function<Object, List<PositionalParameter>>> idExtractors() {
+        return List.copyOf(idParameterExtractors);
     }
 
     @Override

--- a/storm-core/src/main/java/st/orm/core/template/impl/BindVarsImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/BindVarsImpl.java
@@ -37,13 +37,13 @@ import st.orm.core.template.SqlTemplate.PositionalParameter;
  */
 final class BindVarsImpl implements BindVars, BindVariables {
     private final List<Function<Data, List<PositionalParameter>>> parameterExtractors;
-    private final List<Function<Object, List<PositionalParameter>>> idParameterExtractors;
+    private final List<Function<Object, List<PositionalParameter>>> valueParameterExtractors;
     private BatchListener batchListener;
     private RecordListener recordListener;
 
     public BindVarsImpl() {
         this.parameterExtractors = new ArrayList<>();
-        this.idParameterExtractors = new ArrayList<>();
+        this.valueParameterExtractors = new ArrayList<>();
     }
 
     /**
@@ -125,8 +125,8 @@ final class BindVarsImpl implements BindVars, BindVariables {
      *
      * @param idParameterExtractor the function that extracts positional parameters from a primary key value.
      */
-    void addIdParameterExtractor(@Nonnull Function<Object, List<PositionalParameter>> idParameterExtractor) {
-        idParameterExtractors.add(idParameterExtractor);
+    void addValueParameterExtractor(@Nonnull Function<Object, List<PositionalParameter>> idParameterExtractor) {
+        valueParameterExtractors.add(idParameterExtractor);
     }
 
     /**
@@ -145,8 +145,8 @@ final class BindVarsImpl implements BindVars, BindVariables {
      *
      * @return the registered id parameter extractors.
      */
-    List<Function<Object, List<PositionalParameter>>> idExtractors() {
-        return List.copyOf(idParameterExtractors);
+    List<Function<Object, List<PositionalParameter>>> valueExtractors() {
+        return List.copyOf(valueParameterExtractors);
     }
 
     @Override

--- a/storm-core/src/main/java/st/orm/core/template/impl/DeleteBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/DeleteBuilderImpl.java
@@ -29,6 +29,7 @@ import st.orm.core.template.Column;
 import st.orm.core.template.Model;
 import st.orm.core.template.Query;
 import st.orm.core.template.QueryBuilder;
+import st.orm.core.template.QueryPlan;
 import st.orm.core.template.QueryTemplate;
 import st.orm.core.template.TemplateString;
 import st.orm.core.template.impl.Elements.Where;
@@ -243,6 +244,32 @@ public class DeleteBuilderImpl<T extends Data, ID> extends QueryBuilderImpl<T, O
             query = query.unsafe();
         }
         return query;
+    }
+
+    /**
+     * Compiles this query into a reusable plan.
+     *
+     * @return a reusable plan for this query.
+     */
+    @Override
+    public QueryPlan plan() {
+        var plan = queryTemplate.plan(toTemplateString());
+        if (!unsafe && where.isEmpty()) {
+            return plan;
+        }
+        // Queries built by this builder suppress the unsafe warning under the same condition; the returned plan
+        // applies it to every query it produces.
+        return new QueryPlan() {
+            @Override
+            public Query bind(@Nonnull Data record) {
+                return plan.bind(record).unsafe();
+            }
+
+            @Override
+            public Query query() {
+                return plan.query().unsafe();
+            }
+        };
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/DeleteBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/DeleteBuilderImpl.java
@@ -266,6 +266,11 @@ public class DeleteBuilderImpl<T extends Data, ID> extends QueryBuilderImpl<T, O
             }
 
             @Override
+            public Query bindId(@Nonnull Object id) {
+                return plan.bindId(id).unsafe();
+            }
+
+            @Override
             public Query query() {
                 return plan.query().unsafe();
             }

--- a/storm-core/src/main/java/st/orm/core/template/impl/DeleteBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/DeleteBuilderImpl.java
@@ -266,8 +266,8 @@ public class DeleteBuilderImpl<T extends Data, ID> extends QueryBuilderImpl<T, O
             }
 
             @Override
-            public Query bindId(@Nonnull Object id) {
-                return plan.bindId(id).unsafe();
+            public Query bindValue(@Nonnull Object id) {
+                return plan.bindValue(id).unsafe();
             }
 
             @Override

--- a/storm-core/src/main/java/st/orm/core/template/impl/Elements.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/Elements.java
@@ -98,7 +98,12 @@ public final class Elements {
     }
     public record TemplateExpression(@Nonnull TemplateString template) implements Expression {}
 
-    public record Where(@Nullable Expression expression, @Nullable BindVars bindVars) implements Element {}
+    public record Where(@Nullable Expression expression, @Nullable BindVars bindVars,
+                        @Nullable Metamodel<?, ?> bindVarsKey) implements Element {
+        public Where(@Nullable Expression expression, @Nullable BindVars bindVars) {
+            this(expression, bindVars, null);
+        }
+    }
 
     public record Delete(@Nonnull Class<? extends Data> table, @Nonnull String alias) implements Element {
         public Delete {

--- a/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
@@ -701,14 +701,14 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
                     ? sqlTemplateImpl.process(template, false)
                     : customizedTemplate.process(template);
             SqlDialect dialect = customizedTemplate.dialect();
+            // Fixed parameter values are rejected rather than frozen, for constant and bind-vars plans alike:
+            // silently pinning a value that reads like a variable hides a likely mistake, and bind variables
+            // express the variable parts explicitly.
+            if (!sql.parameters().isEmpty()) {
+                throw new PersistenceException("Cannot compile a plan for a template with fixed parameter values. Pass createBindVars() for the variable parts, or execute the template directly via query().");
+            }
             var bindVariables = sql.bindVariables().orElse(null);
             if (bindVariables == null) {
-                // Constant plan: the statement carries no per-call values. Templates with fixed parameter values
-                // are rejected rather than frozen: silently pinning a value that reads like a variable hides a
-                // likely mistake, and bind variables express the variable parts explicitly.
-                if (!sql.parameters().isEmpty()) {
-                    throw new PersistenceException("Cannot compile a plan for a template with fixed parameter values. Pass createBindVars() for the variable parts, or execute the template directly via query().");
-                }
                 return new QueryPlanImpl(sql, List.of(), List.of(), bound -> createQuery(bound, dialect));
             }
             if (!(bindVariables instanceof BindVarsImpl bindVars)) {

--- a/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
@@ -683,11 +683,12 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
      * <p>The template is processed once; the resulting statement, the value-independent parameter extractors
      * registered for its bind variables, and the statement metadata are snapshotted into an immutable plan. The
      * single-use bind variables instance embedded in the processed SQL is never wired to a statement, so the plan
-     * can bind any number of records on any connection.</p>
+     * can bind any number of records on any connection. Templates without any parameters compile to constant plans;
+     * templates with fixed parameter values are rejected.</p>
      *
-     * @param template the template to compile; must contain bind variables.
+     * @param template the template to compile.
      * @return a reusable plan for the template.
-     * @throws PersistenceException if the template is invalid or contains no bind variables.
+     * @throws PersistenceException if the template is invalid or carries fixed parameter values.
      */
     @Override
     public QueryPlan plan(@Nonnull TemplateString template) {
@@ -713,7 +714,7 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
             if (!(bindVariables instanceof BindVarsImpl bindVars)) {
                 throw new PersistenceException("Cannot compile a plan: unsupported bind variables implementation %s.".formatted(bindVariables.getClass().getName()));
             }
-            return new QueryPlanImpl(sql, bindVars.extractors(), bindVars.idExtractors(), bound -> createQuery(bound, dialect));
+            return new QueryPlanImpl(sql, bindVars.extractors(), bindVars.valueExtractors(), bound -> createQuery(bound, dialect));
         } catch (SqlTemplateException e) {
             throw new PersistenceException(e);
         }

--- a/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
@@ -708,12 +708,12 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
                 if (!sql.parameters().isEmpty()) {
                     throw new PersistenceException("Cannot compile a plan for a template with fixed parameter values. Pass createBindVars() for the variable parts, or execute the template directly via query().");
                 }
-                return new QueryPlanImpl(sql, List.of(), bound -> createQuery(bound, dialect));
+                return new QueryPlanImpl(sql, List.of(), List.of(), bound -> createQuery(bound, dialect));
             }
             if (!(bindVariables instanceof BindVarsImpl bindVars)) {
                 throw new PersistenceException("Cannot compile a plan: unsupported bind variables implementation %s.".formatted(bindVariables.getClass().getName()));
             }
-            return new QueryPlanImpl(sql, bindVars.extractors(), bound -> createQuery(bound, dialect));
+            return new QueryPlanImpl(sql, bindVars.extractors(), bindVars.idExtractors(), bound -> createQuery(bound, dialect));
         } catch (SqlTemplateException e) {
             throw new PersistenceException(e);
         }

--- a/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
@@ -70,6 +70,7 @@ import st.orm.core.spi.TransactionTemplateProvider;
 import st.orm.core.template.ORMTemplate;
 import st.orm.core.template.PreparedStatementTemplate;
 import st.orm.core.template.Query;
+import st.orm.core.template.QueryPlan;
 import st.orm.core.template.Sql;
 import st.orm.core.template.SqlDialect;
 import st.orm.core.template.SqlTemplate;
@@ -668,28 +669,73 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
         try {
             var customizedTemplate = sqlTemplate();
             var sql = customizedTemplate.process(template);
-            var bindVariables = sql.bindVariables().orElse(null);
             // The dialect of the template that generated the SQL; a provider lookup could select a different
             // dialect than the one the statement was generated with.
-            SqlDialect dialect = customizedTemplate.dialect();
-            var environment = new QueryImpl.Environment(
-                    refFactory,
-                    strategies.transactionTemplateProvider(),
-                    strategies.queryObserver(),
-                    getExceptionTransformer(sql, strategies.exceptionMapper(), strategies.transactionTemplateProvider()),
-                    sql.operation(),
-                    sql.dataType().orElse(null),
-                    sql.statement());
-            return new QueryImpl(environment, unsafe -> {
-                try {
-                    return templateProcessor.process(sql, unsafe);
-                } catch (SQLException e) {
-                    throw new PersistenceException(e);
-                }
-            }, bindVariables == null ? null : bindVariables.getHandle(), sql.affectedType().orElse(null), sql.versionAware(), false, false, dialect.defaultFetchSize(), dialect.streamOnlyFetchSize(), dialect.streamingRequiresTransaction());
+            return createQuery(sql, customizedTemplate.dialect());
         } catch (SqlTemplateException e) {
             throw new PersistenceException(e);
         }
+    }
+
+    /**
+     * Compiles the specified query {@code template} into a reusable plan.
+     *
+     * <p>The template is processed once; the resulting statement, the value-independent parameter extractors
+     * registered for its bind variables, and the statement metadata are snapshotted into an immutable plan. The
+     * single-use bind variables instance embedded in the processed SQL is never wired to a statement, so the plan
+     * can bind any number of records on any connection.</p>
+     *
+     * @param template the template to compile; must contain bind variables.
+     * @return a reusable plan for the template.
+     * @throws PersistenceException if the template is invalid or contains no bind variables.
+     */
+    @Override
+    public QueryPlan plan(@Nonnull TemplateString template) {
+        try {
+            var customizedTemplate = sqlTemplate();
+            // The stored statement must not bake in Sql interceptor rewrites: binding applies the interceptor
+            // chain, so every execution is intercepted exactly once, and interceptors scoped around plan
+            // compilation do not leak into the cached plan.
+            var sql = customizedTemplate instanceof SqlTemplateImpl sqlTemplateImpl
+                    ? sqlTemplateImpl.process(template, false)
+                    : customizedTemplate.process(template);
+            SqlDialect dialect = customizedTemplate.dialect();
+            var bindVariables = sql.bindVariables().orElse(null);
+            if (bindVariables == null) {
+                // Constant plan: the statement carries no per-call values. Templates with fixed parameter values
+                // are rejected rather than frozen: silently pinning a value that reads like a variable hides a
+                // likely mistake, and bind variables express the variable parts explicitly.
+                if (!sql.parameters().isEmpty()) {
+                    throw new PersistenceException("Cannot compile a plan for a template with fixed parameter values. Pass createBindVars() for the variable parts, or execute the template directly via query().");
+                }
+                return new QueryPlanImpl(sql, List.of(), bound -> createQuery(bound, dialect));
+            }
+            if (!(bindVariables instanceof BindVarsImpl bindVars)) {
+                throw new PersistenceException("Cannot compile a plan: unsupported bind variables implementation %s.".formatted(bindVariables.getClass().getName()));
+            }
+            return new QueryPlanImpl(sql, bindVars.extractors(), bound -> createQuery(bound, dialect));
+        } catch (SqlTemplateException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    private Query createQuery(@Nonnull Sql sql, @Nonnull SqlDialect dialect) {
+        var bindVariables = sql.bindVariables().orElse(null);
+        var environment = new QueryImpl.Environment(
+                refFactory,
+                strategies.transactionTemplateProvider(),
+                strategies.queryObserver(),
+                getExceptionTransformer(sql, strategies.exceptionMapper(), strategies.transactionTemplateProvider()),
+                sql.operation(),
+                sql.dataType().orElse(null),
+                sql.statement());
+        return new QueryImpl(environment, unsafe -> {
+            try {
+                return templateProcessor.process(sql, unsafe);
+            } catch (SQLException e) {
+                throw new PersistenceException(e);
+            }
+        }, bindVariables == null ? null : bindVariables.getHandle(), sql.affectedType().orElse(null), sql.versionAware(), false, false, dialect.defaultFetchSize(), dialect.streamOnlyFetchSize(), dialect.streamingRequiresTransaction());
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryPlanImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryPlanImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.template.impl;
+
+import static java.util.Objects.requireNonNull;
+import static st.orm.core.template.impl.SqlInterceptorManager.intercept;
+
+import jakarta.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import st.orm.Data;
+import st.orm.PersistenceException;
+import st.orm.core.template.Query;
+import st.orm.core.template.QueryPlan;
+import st.orm.core.template.Sql;
+import st.orm.core.template.SqlTemplate.Parameter;
+import st.orm.core.template.SqlTemplate.PositionalParameter;
+
+/**
+ * Compiled query plan backed by a processed template.
+ *
+ * <p>The plan holds the processed SQL and an immutable snapshot of the value-independent parameter extractors that
+ * template processing registered for the template's bind variables. Binding a record runs the extractors and derives
+ * a value-bound {@link Sql} that flows through the regular one-shot execution path. The plan carries no connection or
+ * statement state, making it thread-safe and reusable across executions.</p>
+ */
+final class QueryPlanImpl implements QueryPlan {
+
+    private final Sql sql;
+    private final List<Function<Data, List<PositionalParameter>>> parameterExtractors;
+    private final Function<Sql, Query> queryFactory;
+
+    QueryPlanImpl(@Nonnull Sql sql,
+                  @Nonnull List<Function<Data, List<PositionalParameter>>> parameterExtractors,
+                  @Nonnull Function<Sql, Query> queryFactory) {
+        this.sql = requireNonNull(sql, "sql");
+        this.parameterExtractors = List.copyOf(parameterExtractors);
+        this.queryFactory = requireNonNull(queryFactory, "queryFactory");
+    }
+
+    @Override
+    public Query bind(@Nonnull Data record) {
+        requireNonNull(record, "record");
+        if (parameterExtractors.isEmpty()) {
+            throw new PersistenceException("Cannot bind a record against a constant plan: the plan's template has no bind variables. Use query() instead.");
+        }
+        try {
+            var parameters = new ArrayList<Parameter>(sql.parameters().size() + parameterExtractors.size());
+            parameters.addAll(sql.parameters());
+            for (var extractor : parameterExtractors) {
+                parameters.addAll(extractor.apply(record));
+            }
+            // Interceptors observe every bound statement, matching the observability of per-call processing.
+            return queryFactory.apply(intercept(sql.parameters(parameters).bindVariables(null)));
+        } catch (UncheckedSqlTemplateException e) {
+            throw new PersistenceException(e.getCause());
+        }
+    }
+
+    @Override
+    public Query query() {
+        if (!parameterExtractors.isEmpty()) {
+            throw new PersistenceException("Cannot execute a plan with bind variables without a record. Use bind() instead.");
+        }
+        // Interceptors observe every executed statement, matching the observability of per-call processing.
+        return queryFactory.apply(intercept(sql));
+    }
+}

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryPlanImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryPlanImpl.java
@@ -75,20 +75,21 @@ final class QueryPlanImpl implements QueryPlan {
     }
 
     @Override
-    public Query bindValue(@Nonnull Object id) {
-        requireNonNull(id, "id");
+    public Query bindValue(@Nonnull Object value) {
+        requireNonNull(value, "value");
         if (parameterExtractors.isEmpty()) {
-            throw new PersistenceException("Cannot bind an id against a constant plan: the plan's template has no bind variables. Use query() instead.");
+            throw new PersistenceException("Cannot bind a value against a constant plan: the plan's template has no bind variables. Use query() instead.");
         }
-        if (valueParameterExtractors.size() != parameterExtractors.size()) {
-            throw new PersistenceException("Cannot bind an id: the plan's bind variables are not purely primary-key based. Use bind() with a record instead.");
+        // A single value can feed exactly one key; a plan with multiple bind variables segments would bind the same
+        // value through every segment, which is only correct for a record that supplies each segment's own values.
+        if (parameterExtractors.size() != 1 || valueParameterExtractors.size() != 1) {
+            throw new PersistenceException("Cannot bind a value: the plan's bind variables must consist of a single key-based WHERE clause. Use bind() with a record instead.");
         }
         try {
-            var parameters = new ArrayList<Parameter>(sql.parameters().size() + valueParameterExtractors.size());
+            var extracted = valueParameterExtractors.getFirst().apply(value);
+            var parameters = new ArrayList<Parameter>(sql.parameters().size() + extracted.size());
             parameters.addAll(sql.parameters());
-            for (var extractor : valueParameterExtractors) {
-                parameters.addAll(extractor.apply(id));
-            }
+            parameters.addAll(extracted);
             // Interceptors observe every bound statement, matching the observability of per-call processing.
             return queryFactory.apply(intercept(sql.parameters(parameters).bindVariables(null)));
         } catch (UncheckedSqlTemplateException e) {

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryPlanImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryPlanImpl.java
@@ -42,16 +42,16 @@ final class QueryPlanImpl implements QueryPlan {
 
     private final Sql sql;
     private final List<Function<Data, List<PositionalParameter>>> parameterExtractors;
-    private final List<Function<Object, List<PositionalParameter>>> idParameterExtractors;
+    private final List<Function<Object, List<PositionalParameter>>> valueParameterExtractors;
     private final Function<Sql, Query> queryFactory;
 
     QueryPlanImpl(@Nonnull Sql sql,
                   @Nonnull List<Function<Data, List<PositionalParameter>>> parameterExtractors,
-                  @Nonnull List<Function<Object, List<PositionalParameter>>> idParameterExtractors,
+                  @Nonnull List<Function<Object, List<PositionalParameter>>> valueParameterExtractors,
                   @Nonnull Function<Sql, Query> queryFactory) {
         this.sql = requireNonNull(sql, "sql");
         this.parameterExtractors = List.copyOf(parameterExtractors);
-        this.idParameterExtractors = List.copyOf(idParameterExtractors);
+        this.valueParameterExtractors = List.copyOf(valueParameterExtractors);
         this.queryFactory = requireNonNull(queryFactory, "queryFactory");
     }
 
@@ -75,18 +75,18 @@ final class QueryPlanImpl implements QueryPlan {
     }
 
     @Override
-    public Query bindId(@Nonnull Object id) {
+    public Query bindValue(@Nonnull Object id) {
         requireNonNull(id, "id");
         if (parameterExtractors.isEmpty()) {
             throw new PersistenceException("Cannot bind an id against a constant plan: the plan's template has no bind variables. Use query() instead.");
         }
-        if (idParameterExtractors.size() != parameterExtractors.size()) {
+        if (valueParameterExtractors.size() != parameterExtractors.size()) {
             throw new PersistenceException("Cannot bind an id: the plan's bind variables are not purely primary-key based. Use bind() with a record instead.");
         }
         try {
-            var parameters = new ArrayList<Parameter>(sql.parameters().size() + idParameterExtractors.size());
+            var parameters = new ArrayList<Parameter>(sql.parameters().size() + valueParameterExtractors.size());
             parameters.addAll(sql.parameters());
-            for (var extractor : idParameterExtractors) {
+            for (var extractor : valueParameterExtractors) {
                 parameters.addAll(extractor.apply(id));
             }
             // Interceptors observe every bound statement, matching the observability of per-call processing.

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryPlanImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryPlanImpl.java
@@ -42,13 +42,16 @@ final class QueryPlanImpl implements QueryPlan {
 
     private final Sql sql;
     private final List<Function<Data, List<PositionalParameter>>> parameterExtractors;
+    private final List<Function<Object, List<PositionalParameter>>> idParameterExtractors;
     private final Function<Sql, Query> queryFactory;
 
     QueryPlanImpl(@Nonnull Sql sql,
                   @Nonnull List<Function<Data, List<PositionalParameter>>> parameterExtractors,
+                  @Nonnull List<Function<Object, List<PositionalParameter>>> idParameterExtractors,
                   @Nonnull Function<Sql, Query> queryFactory) {
         this.sql = requireNonNull(sql, "sql");
         this.parameterExtractors = List.copyOf(parameterExtractors);
+        this.idParameterExtractors = List.copyOf(idParameterExtractors);
         this.queryFactory = requireNonNull(queryFactory, "queryFactory");
     }
 
@@ -63,6 +66,28 @@ final class QueryPlanImpl implements QueryPlan {
             parameters.addAll(sql.parameters());
             for (var extractor : parameterExtractors) {
                 parameters.addAll(extractor.apply(record));
+            }
+            // Interceptors observe every bound statement, matching the observability of per-call processing.
+            return queryFactory.apply(intercept(sql.parameters(parameters).bindVariables(null)));
+        } catch (UncheckedSqlTemplateException e) {
+            throw new PersistenceException(e.getCause());
+        }
+    }
+
+    @Override
+    public Query bindId(@Nonnull Object id) {
+        requireNonNull(id, "id");
+        if (parameterExtractors.isEmpty()) {
+            throw new PersistenceException("Cannot bind an id against a constant plan: the plan's template has no bind variables. Use query() instead.");
+        }
+        if (idParameterExtractors.size() != parameterExtractors.size()) {
+            throw new PersistenceException("Cannot bind an id: the plan's bind variables are not purely primary-key based. Use bind() with a record instead.");
+        }
+        try {
+            var parameters = new ArrayList<Parameter>(sql.parameters().size() + idParameterExtractors.size());
+            parameters.addAll(sql.parameters());
+            for (var extractor : idParameterExtractors) {
+                parameters.addAll(extractor.apply(id));
             }
             // Interceptors observe every bound statement, matching the observability of per-call processing.
             return queryFactory.apply(intercept(sql.parameters(parameters).bindVariables(null)));

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryTemplateImpl.java
@@ -202,7 +202,10 @@ class QueryTemplateImpl implements QueryTemplate {
     /**
      * Compiles the specified query {@code template} into a reusable plan.
      *
-     * @param template the query template; must contain bind variables.
+     * <p>Variable parts are expressed as bind variables; templates without any parameters compile to constant
+     * plans, and templates with fixed parameter values are rejected.</p>
+     *
+     * @param template the query template.
      * @return a reusable plan for the template.
      */
     @Override

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryTemplateImpl.java
@@ -30,6 +30,7 @@ import st.orm.core.template.Model;
 import st.orm.core.template.PreparedQuery;
 import st.orm.core.template.Query;
 import st.orm.core.template.QueryBuilder;
+import st.orm.core.template.QueryPlan;
 import st.orm.core.template.QueryTemplate;
 import st.orm.core.template.SqlDialect;
 import st.orm.core.template.SqlTemplateException;
@@ -196,5 +197,16 @@ class QueryTemplateImpl implements QueryTemplate {
     @Override
     public Query query(@Nonnull TemplateString template) {
         return queryFactory.create(template);
+    }
+
+    /**
+     * Compiles the specified query {@code template} into a reusable plan.
+     *
+     * @param template the query template; must contain bind variables.
+     * @return a reusable plan for the template.
+     */
+    @Override
+    public QueryPlan plan(@Nonnull TemplateString template) {
+        return queryFactory.plan(template);
     }
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/SelectBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SelectBuilderImpl.java
@@ -33,6 +33,7 @@ import st.orm.Ref;
 import st.orm.core.template.Model;
 import st.orm.core.template.Query;
 import st.orm.core.template.QueryBuilder;
+import st.orm.core.template.QueryPlan;
 import st.orm.core.template.QueryTemplate;
 import st.orm.core.template.TemplateString;
 import st.orm.core.template.impl.Elements.Where;
@@ -319,6 +320,19 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
             throw new PersistenceException("Cannot build a query from a subquery.");
         }
         return queryTemplate.query(toTemplateString());
+    }
+
+    /**
+     * Compiles this query into a reusable plan.
+     *
+     * @return a reusable plan for this query.
+     */
+    @Override
+    public QueryPlan plan() {
+        if (subquery) {
+            throw new PersistenceException("Cannot compile a plan from a subquery.");
+        }
+        return queryTemplate.plan(toTemplateString());
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/SetProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SetProcessor.java
@@ -119,10 +119,11 @@ final class SetProcessor implements ElementProcessor<Set> {
                 var model = (Model<Data, ?>) binder.getModel(table.type());
                 var parameterFactory = binder.setBindVars(vars);
                 vars.addParameterExtractor(record -> {
+                    var round = parameterFactory.newRound();
                     try {
                         model.validateForeignKeys(columns, record);
-                        model.forEachValue(columns, record, (column, value) -> parameterFactory.bind(value));
-                        return parameterFactory.getParameters();
+                        model.forEachValue(columns, record, (column, value) -> round.bind(value));
+                        return round.getParameters();
                     } catch (SqlTemplateException ex) {
                         throw new UncheckedSqlTemplateException(ex);
                     }

--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlInterceptorManager.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlInterceptorManager.java
@@ -256,19 +256,6 @@ public final class SqlInterceptorManager {
     }
 
     /**
-     * Customizes the given SQL template using the current thread's scoped customizer, if available.
-     *
-     * <p>This method applies a customizer to the SQL template that is scoped to the current thread context.
-     * If no customizer is set, it returns the original template.</p>
-     *
-     * <p>This method is intended to be used internally within the ORM framework, or it's extensions, to ensure that
-     * SQL templates are adjusted according to the current thread's context, such as applying custom SQL dialects or
-     * other template modifications.</p>
-     *
-     * @param template the SQL template to customize.
-     * @return the customized SQL template, or the original template if no customizer is set.
-     */
-    /**
      * Returns whether a template customizer is active on the current thread's scope.
      *
      * <p>Artifacts cached from a processed template, such as query plans, are only valid for the template they were
@@ -287,6 +274,19 @@ public final class SqlInterceptorManager {
         return false;
     }
 
+    /**
+     * Customizes the given SQL template using the current thread's scoped customizer, if available.
+     *
+     * <p>This method applies a customizer to the SQL template that is scoped to the current thread context.
+     * If no customizer is set, it returns the original template.</p>
+     *
+     * <p>This method is intended to be used internally within the ORM framework, or it's extensions, to ensure that
+     * SQL templates are adjusted according to the current thread's context, such as applying custom SQL dialects or
+     * other template modifications.</p>
+     *
+     * @param template the SQL template to customize.
+     * @return the customized SQL template, or the original template if no customizer is set.
+     */
     public static SqlTemplate customize(@Nonnull SqlTemplate template) {
         // Apply the customizer to the template if it is set.
         SqlTemplate adjusted = template;

--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlInterceptorManager.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlInterceptorManager.java
@@ -41,9 +41,12 @@ import st.orm.core.template.SqlTemplate;
 @SuppressWarnings("ALL")
 public final class SqlInterceptorManager {
 
+    /** Shared identity customizer; lets callers recognize operators that do not customize the template. */
+    private static final UnaryOperator<SqlTemplate> IDENTITY_CUSTOMIZER = it -> it;
+
     record Operator(UnaryOperator<Sql> interceptor, UnaryOperator<SqlTemplate> customizer) {
         Operator(UnaryOperator<Sql> interceptor) {
-            this(interceptor, it -> it);
+            this(interceptor, IDENTITY_CUSTOMIZER);
         }
     }
 
@@ -265,6 +268,25 @@ public final class SqlInterceptorManager {
      * @param template the SQL template to customize.
      * @return the customized SQL template, or the original template if no customizer is set.
      */
+    /**
+     * Returns whether a template customizer is active on the current thread's scope.
+     *
+     * <p>Artifacts cached from a processed template, such as query plans, are only valid for the template they were
+     * processed with; callers holding such caches bypass them while a customizer is in scope so the customized
+     * template generates the statement.</p>
+     *
+     * @return {@code true} if a scoped template customizer is active.
+     * @since 1.13
+     */
+    public static boolean hasLocalCustomizers() {
+        for (var operator : LOCAL_OPERATORS.get()) {
+            if (operator.customizer() != IDENTITY_CUSTOMIZER) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static SqlTemplate customize(@Nonnull SqlTemplate template) {
         // Apply the customizer to the template if it is set.
         SqlTemplate adjusted = template;

--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlTemplateImpl.java
@@ -377,6 +377,22 @@ public final class SqlTemplateImpl implements SqlTemplate {
      */
     @Override
     public Sql process(@Nonnull TemplateString template) throws SqlTemplateException {
+        return process(template, true);
+    }
+
+    /**
+     * Processes the specified {@code template}, optionally without applying SQL interceptors.
+     *
+     * <p>Query plans process their template without interceptors: the stored statement must not bake in interceptor
+     * rewrites, and binding applies the interceptor chain instead, so every execution is intercepted exactly once
+     * and interceptors scoped around plan compilation do not leak into the cached plan.</p>
+     *
+     * @param template the string template to process.
+     * @param applyInterceptors whether to run the registered SQL interceptors on the result.
+     * @return the resulting SQL and parameters.
+     * @throws SqlTemplateException if an error occurs while processing the input.
+     */
+    Sql process(@Nonnull TemplateString template, boolean applyInterceptors) throws SqlTemplateException {
         BindingContext bindingContext;
         Object compilationKey;
         TemplateProcessor processor;
@@ -400,7 +416,10 @@ public final class SqlTemplateImpl implements SqlTemplate {
                     request.hit();
                 }
             }
-            Sql sql = intercept(processor.bind(bindingContext));
+            Sql sql = processor.bind(bindingContext);
+            if (applyInterceptors) {
+                sql = intercept(sql);
+            }
             if (LOGGER.isDebugEnabled()) {
                 String log = "SQL:\n%s".formatted(sql.statement());
                 if (LOGGER.isTraceEnabled()) {

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplateBinder.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplateBinder.java
@@ -130,34 +130,46 @@ interface TemplateBinder {
     /**
      * Produces positional parameters for a single {@link BindVars} segment during binding.
      *
-     * <p>A {@code ParameterFactory} is obtained from {@link TemplateBinder#setBindVars(BindVars)}. The caller binds values
-     * for the segment via {@link #bind(Object)} and then retrieves the resulting positional parameters via
-     * {@link #getParameters()}.</p>
-     *
-     * <p>Implementations typically enforce the expected arity recorded during compilation. Calling {@link #getParameters()}
-     * may validate that the number of bound values matches that expected arity.</p>
+     * <p>A {@code ParameterFactory} is obtained from {@link TemplateBinder#setBindVars(BindVars)}. Each extraction
+     * starts a fresh {@link Round}, binds the segment's values, and retrieves the resulting positional parameters.
+     * Rounds own their storage, so concurrent extractions do not interfere and an abandoned round, for example after
+     * a conversion failure, leaves no residue behind.</p>
      */
     interface ParameterFactory {
 
         /**
-         * Binds one value for the current bind vars segment.
+         * Starts a new extraction round for this bind vars segment.
          *
-         * <p>The value becomes a positional parameter in the order it is provided. Implementations may accept {@code null}
-         * values.</p>
-         *
-         * @param value the value to bind.
+         * @return a collector for one extraction.
          */
-        void bind(@Nullable Object value);
+        Round newRound();
 
         /**
-         * Returns the positional parameters produced for the current bind vars segment.
+         * Collects the positional parameters of a single extraction round.
          *
-         * <p>Implementations may validate arity and may reset internal temporary storage after this call.</p>
-         *
-         * @return the positional parameters for this segment.
-         * @throws IllegalStateException if the number of bound values does not match the expected arity.
+         * <p>Implementations typically enforce the expected arity recorded during compilation. Calling
+         * {@link #getParameters()} may validate that the number of bound values matches that expected arity.</p>
          */
-        List<PositionalParameter> getParameters();
+        interface Round {
+
+            /**
+             * Binds one value for the bind vars segment.
+             *
+             * <p>The value becomes a positional parameter in the order it is provided. Implementations may accept
+             * {@code null} values.</p>
+             *
+             * @param value the value to bind.
+             */
+            void bind(@Nullable Object value);
+
+            /**
+             * Returns the positional parameters produced for the bind vars segment.
+             *
+             * @return the positional parameters for this segment.
+             * @throws IllegalStateException if the number of bound values does not match the expected arity.
+             */
+            List<PositionalParameter> getParameters();
+        }
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplateProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplateProcessor.java
@@ -1208,7 +1208,9 @@ class TemplateProcessor {
                 throw new IllegalStateException("Not enough bind variables.");
             }
             return new ParameterFactory() {
-                final List<PositionalParameter> tmp = new ArrayList<>();
+                // Extraction rounds are confined to the calling thread: the factory outlives its binding session
+                // through the parameter extractors, which query plans invoke concurrently.
+                final ThreadLocal<List<PositionalParameter>> tmp = ThreadLocal.withInitial(ArrayList::new);
                 final int expectedBindVarCount = bindVarsCounts.get(bindVarsCursor++);
 
                 /**
@@ -1218,7 +1220,8 @@ class TemplateProcessor {
                  */
                 @Override
                 public void bind(@Nullable Object value) {
-                    tmp.add(new PositionalParameter(startPosition + tmp.size(), value));
+                    var round = tmp.get();
+                    round.add(new PositionalParameter(startPosition + round.size(), value));
                 }
 
                 /**
@@ -1229,12 +1232,15 @@ class TemplateProcessor {
                  */
                 @Override
                 public List<PositionalParameter> getParameters() {
-                    if (tmp.size() != expectedBindVarCount) {
-                        throw new IllegalStateException("Bind var count mismatch.");
+                    var round = tmp.get();
+                    try {
+                        if (round.size() != expectedBindVarCount) {
+                            throw new IllegalStateException("Bind var count mismatch.");
+                        }
+                        return List.copyOf(round);
+                    } finally {
+                        round.clear();
                     }
-                    var result = List.copyOf(tmp);
-                    tmp.clear();
-                    return result;
                 }
             };
         }

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplateProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplateProcessor.java
@@ -1207,40 +1207,23 @@ class TemplateProcessor {
             if (bindVarsCursor >= bindVarsCounts.size()) {
                 throw new IllegalStateException("Not enough bind variables.");
             }
-            return new ParameterFactory() {
-                // Extraction rounds are confined to the calling thread: the factory outlives its binding session
-                // through the parameter extractors, which query plans invoke concurrently.
-                final ThreadLocal<List<PositionalParameter>> tmp = ThreadLocal.withInitial(ArrayList::new);
-                final int expectedBindVarCount = bindVarsCounts.get(bindVarsCursor++);
+            // Each round owns its storage: the factory outlives its binding session through the parameter
+            // extractors, which query plans invoke concurrently, and an abandoned round leaves no residue behind.
+            final int expectedBindVarCount = bindVarsCounts.get(bindVarsCursor++);
+            return () -> new ParameterFactory.Round() {
+                final List<PositionalParameter> parameters = new ArrayList<>(expectedBindVarCount);
 
-                /**
-                 * Binds one value for the current bind vars segment.
-                 *
-                 * @param value the value to bind.
-                 */
                 @Override
                 public void bind(@Nullable Object value) {
-                    var round = tmp.get();
-                    round.add(new PositionalParameter(startPosition + round.size(), value));
+                    parameters.add(new PositionalParameter(startPosition + parameters.size(), value));
                 }
 
-                /**
-                 * Returns the parameters of the current bind vars segment and resets internal storage.
-                 *
-                 * @return the positional parameters for the bind vars segment.
-                 * @throws IllegalStateException if the number of bound values differs from the expected arity.
-                 */
                 @Override
                 public List<PositionalParameter> getParameters() {
-                    var round = tmp.get();
-                    try {
-                        if (round.size() != expectedBindVarCount) {
-                            throw new IllegalStateException("Bind var count mismatch.");
-                        }
-                        return List.copyOf(round);
-                    } finally {
-                        round.clear();
+                    if (parameters.size() != expectedBindVarCount) {
+                        throw new IllegalStateException("Bind var count mismatch.");
                     }
+                    return List.copyOf(parameters);
                 }
             };
         }

--- a/storm-core/src/main/java/st/orm/core/template/impl/ValuesProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/ValuesProcessor.java
@@ -117,19 +117,20 @@ final class ValuesProcessor implements ElementProcessor<Values> {
             if (values.bindVars() instanceof BindVarsImpl vars) {
                 var parameterFactory = binder.setBindVars(vars);
                 vars.addParameterExtractor(record -> {
+                    var round = parameterFactory.newRound();
                     try {
                         model.validateForeignKeys(columns, record);
                         model.forEachValue(columns, record, (column, value) -> {
                             switch (column.generation()) {
-                                case NONE -> parameterFactory.bind(value);
+                                case NONE -> round.bind(value);
                                 case IDENTITY, SEQUENCE -> {
                                     if (values.ignoreAutoGenerate()) {
-                                        parameterFactory.bind(value);
+                                        round.bind(value);
                                     }
                                 }
                             }
                         });
-                        return parameterFactory.getParameters();
+                        return round.getParameters();
                     } catch (SqlTemplateException ex) {
                         throw new UncheckedSqlTemplateException(ex);
                     }

--- a/storm-core/src/main/java/st/orm/core/template/impl/VarProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/VarProcessor.java
@@ -82,8 +82,9 @@ final class VarProcessor implements ElementProcessor<BindVar> {
         if (bindVar.bindVars() instanceof BindVarsImpl vars) {
             var parameterFactory = binder.setBindVars(vars);
             vars.addParameterExtractor(record -> {
-                parameterFactory.bind(bindVar.extractor().apply(record));
-                return parameterFactory.getParameters();
+                var round = parameterFactory.newRound();
+                round.bind(bindVar.extractor().apply(record));
+                return round.getParameters();
             });
         }
     }

--- a/storm-core/src/main/java/st/orm/core/template/impl/WhereProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/WhereProcessor.java
@@ -21,8 +21,8 @@ import static st.orm.core.template.impl.ElementRouter.getElementProcessor;
 import jakarta.annotation.Nonnull;
 import java.util.List;
 import java.util.function.Function;
-import st.orm.BindVars;
 import st.orm.Data;
+import st.orm.Metamodel;
 import st.orm.core.template.Column;
 import st.orm.core.template.Model;
 import st.orm.core.template.SqlTemplateException;
@@ -54,7 +54,7 @@ final class WhereProcessor implements ElementProcessor<Where> {
             return getElementProcessor(cacheable).getCompilationKey(cacheable, keyGenerator);
         }
         if (where.bindVars() != null) {
-            return new Where(null, null);
+            return new Where(null, null, where.bindVarsKey());
         }
         throw new SqlTemplateException("Invalid element in WHERE clause: %s. Expected a valid expression, entity, or bind variable.".formatted(where));
     }
@@ -77,7 +77,7 @@ final class WhereProcessor implements ElementProcessor<Where> {
                     new WhereBindHint(List.of()));
         }
         if (where.bindVars() != null) {
-            return compileWhereBindVars(where.bindVars(), compiler);
+            return compileWhereBindVars(where, compiler);
         }
         throw new SqlTemplateException("No expression or bind variables found for WHERE clause. Provide at least one filter condition.");
     }
@@ -114,11 +114,24 @@ final class WhereProcessor implements ElementProcessor<Where> {
                         throw new UncheckedSqlTemplateException(ex);
                     }
                 });
-                if (columns.stream().allMatch(Column::primaryKey)) {
+                if (where.bindVarsKey() != null) {
+                    // The WHERE clause is compiled for a specific key, so a raw value can supply every column;
+                    // query plans use this to bind key lookups without a full record.
+                    //noinspection unchecked
+                    var key = (Metamodel<Data, ?>) where.bindVarsKey();
+                    vars.addValueParameterExtractor(value -> {
+                        try {
+                            model.forEachValue(key, value, (column, columnValue) -> parameterFactory.bind(columnValue));
+                            return parameterFactory.getParameters();
+                        } catch (SqlTemplateException ex) {
+                            throw new UncheckedSqlTemplateException(ex);
+                        }
+                    });
+                } else if (columns.stream().allMatch(Column::primaryKey)) {
                     // The identifying columns are exactly the primary key, so a raw id can supply every value;
                     // query plans use this to bind by-id statements without a full record.
                     model.getPrimaryKeyMetamodel().ifPresent(primaryKeyMetamodel ->
-                            vars.addIdParameterExtractor(id -> {
+                            vars.addValueParameterExtractor(id -> {
                                 try {
                                     model.forEachValue(primaryKeyMetamodel, id,
                                             (column, value) -> parameterFactory.bind(value));
@@ -147,11 +160,13 @@ final class WhereProcessor implements ElementProcessor<Where> {
                 .toList();
     }
 
-    private CompiledElement compileWhereBindVars(@Nonnull BindVars bindVars,
+    private CompiledElement compileWhereBindVars(@Nonnull Where where,
                                                  @Nonnull TemplateCompiler compiler) throws SqlTemplateException {
-        if (bindVars instanceof BindVarsImpl) {
+        if (where.bindVars() instanceof BindVarsImpl) {
             var queryModel = compiler.getQueryModel();
-            var columns = getIdentifyingColumns(compiler);
+            var columns = where.bindVarsKey() != null
+                    ? getKeyColumns(where.bindVarsKey(), compiler)
+                    : getIdentifyingColumns(compiler);
             compiler.mapBindVars(columns.size());
             return new CompiledElement(columns.stream()
                     .map(queryModel::toColumnExpression)
@@ -159,5 +174,15 @@ final class WhereProcessor implements ElementProcessor<Where> {
                     .collect(joining(" AND ")), new WhereBindHint(columns));
         }
         throw new SqlTemplateException("Unsupported BindVars type in WHERE clause. Expected a standard BindVars implementation.");
+    }
+
+    private List<Column> getKeyColumns(@Nonnull Metamodel<?, ?> key, @Nonnull TemplateCompiler compiler)
+            throws SqlTemplateException {
+        var table = compiler.getQueryModel().getTable();
+        var columns = compiler.getModel(table.type()).getColumns(key);
+        if (columns.isEmpty()) {
+            throw new SqlTemplateException("No columns found for key %s on table %s.".formatted(key, table.type().getSimpleName()));
+        }
+        return columns;
     }
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/WhereProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/WhereProcessor.java
@@ -114,6 +114,20 @@ final class WhereProcessor implements ElementProcessor<Where> {
                         throw new UncheckedSqlTemplateException(ex);
                     }
                 });
+                if (columns.stream().allMatch(Column::primaryKey)) {
+                    // The identifying columns are exactly the primary key, so a raw id can supply every value;
+                    // query plans use this to bind by-id statements without a full record.
+                    model.getPrimaryKeyMetamodel().ifPresent(primaryKeyMetamodel ->
+                            vars.addIdParameterExtractor(id -> {
+                                try {
+                                    model.forEachValue(primaryKeyMetamodel, id,
+                                            (column, value) -> parameterFactory.bind(value));
+                                    return parameterFactory.getParameters();
+                                } catch (SqlTemplateException ex) {
+                                    throw new UncheckedSqlTemplateException(ex);
+                                }
+                            }));
+                }
             }
         } else {
             throw new IllegalStateException("Unexpected bind hint: %s.".formatted(bindHint.getClass().getSimpleName()));

--- a/storm-core/src/main/java/st/orm/core/template/impl/WhereProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/WhereProcessor.java
@@ -105,11 +105,10 @@ final class WhereProcessor implements ElementProcessor<Where> {
                 var model = (Model<Data, ?>) binder.getModel(table.type());
                 var parameterFactory = binder.setBindVars(where.bindVars());
                 vars.addParameterExtractor(record -> {
+                    var round = parameterFactory.newRound();
                     try {
-                        model
-                                .forEachValue(columns, record,
-                                        (column, value) -> parameterFactory.bind(value));
-                        return parameterFactory.getParameters();
+                        model.forEachValue(columns, record, (column, value) -> round.bind(value));
+                        return round.getParameters();
                     } catch (SqlTemplateException ex) {
                         throw new UncheckedSqlTemplateException(ex);
                     }
@@ -120,9 +119,10 @@ final class WhereProcessor implements ElementProcessor<Where> {
                     //noinspection unchecked
                     var key = (Metamodel<Data, ?>) where.bindVarsKey();
                     vars.addValueParameterExtractor(value -> {
+                        var round = parameterFactory.newRound();
                         try {
-                            model.forEachValue(key, value, (column, columnValue) -> parameterFactory.bind(columnValue));
-                            return parameterFactory.getParameters();
+                            model.forEachValue(key, value, (column, columnValue) -> round.bind(columnValue));
+                            return round.getParameters();
                         } catch (SqlTemplateException ex) {
                             throw new UncheckedSqlTemplateException(ex);
                         }
@@ -132,10 +132,11 @@ final class WhereProcessor implements ElementProcessor<Where> {
                     // query plans use this to bind by-id statements without a full record.
                     model.getPrimaryKeyMetamodel().ifPresent(primaryKeyMetamodel ->
                             vars.addValueParameterExtractor(id -> {
+                                var round = parameterFactory.newRound();
                                 try {
                                     model.forEachValue(primaryKeyMetamodel, id,
-                                            (column, value) -> parameterFactory.bind(value));
-                                    return parameterFactory.getParameters();
+                                            (column, value) -> round.bind(value));
+                                    return round.getParameters();
                                 } catch (SqlTemplateException ex) {
                                     throw new UncheckedSqlTemplateException(ex);
                                 }

--- a/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
@@ -149,20 +149,20 @@ public class QueryPlanIntegrationTest {
                 SELECT \0
                 FROM \0
                 WHERE \0""", PlanVisit.class, Templates.from(PlanVisit.class, true), bindVars));
-        var first = plan.bindId(1).getSingleResult(PlanVisit.class);
+        var first = plan.bindValue(1).getSingleResult(PlanVisit.class);
         assertEquals(1, first.id());
-        var second = plan.bindId(2).getSingleResult(PlanVisit.class);
+        var second = plan.bindValue(2).getSingleResult(PlanVisit.class);
         assertEquals(2, second.id());
     }
 
     @Test
-    void bindId_rejectsPlansThatAreNotPurelyPrimaryKeyBased() {
+    void bindValue_rejectsPlansThatAreNotPurelyPrimaryKeyBased() {
         var orm = orm();
         var boundByRecord = fullUpdatePlan(orm);
-        var onUpdatePlan = assertThrows(PersistenceException.class, () -> boundByRecord.bindId(1));
+        var onUpdatePlan = assertThrows(PersistenceException.class, () -> boundByRecord.bindValue(1));
         assertTrue(onUpdatePlan.getMessage().contains("bind()"));
         var constant = orm.selectFrom(PlanVisit.class).plan();
-        var onConstantPlan = assertThrows(PersistenceException.class, () -> constant.bindId(1));
+        var onConstantPlan = assertThrows(PersistenceException.class, () -> constant.bindValue(1));
         assertTrue(onConstantPlan.getMessage().contains("query()"));
     }
 
@@ -181,6 +181,14 @@ public class QueryPlanIntegrationTest {
         });
         assertEquals(1, plan.bind(updated).executeUpdate());
         assertEquals("parallel", repository.getById(1).description());
+    }
+
+    @Test
+    void repositoryByRefLookups_useCachedByIdPlan() {
+        var repository = orm().entity(PlanVisit.class);
+        assertEquals(1, repository.getByRef(repository.ref(1)).id());
+        // The second lookup binds against the plan cached by the first.
+        assertTrue(repository.findByRef(repository.ref(2)).isPresent());
     }
 
     @Test

--- a/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
@@ -142,6 +142,60 @@ public class QueryPlanIntegrationTest {
     }
 
     @Test
+    void plan_bindsById_acrossExecutions() {
+        var orm = orm();
+        var bindVars = orm.createBindVars();
+        var plan = orm.plan(TemplateString.raw("""
+                SELECT \0
+                FROM \0
+                WHERE \0""", PlanVisit.class, Templates.from(PlanVisit.class, true), bindVars));
+        var first = plan.bindId(1).getSingleResult(PlanVisit.class);
+        assertEquals(1, first.id());
+        var second = plan.bindId(2).getSingleResult(PlanVisit.class);
+        assertEquals(2, second.id());
+    }
+
+    @Test
+    void bindId_rejectsPlansThatAreNotPurelyPrimaryKeyBased() {
+        var orm = orm();
+        var boundByRecord = fullUpdatePlan(orm);
+        var onUpdatePlan = assertThrows(PersistenceException.class, () -> boundByRecord.bindId(1));
+        assertTrue(onUpdatePlan.getMessage().contains("bind()"));
+        var constant = orm.selectFrom(PlanVisit.class).plan();
+        var onConstantPlan = assertThrows(PersistenceException.class, () -> constant.bindId(1));
+        assertTrue(onConstantPlan.getMessage().contains("query()"));
+    }
+
+    @Test
+    void plan_bindIsThreadSafe() {
+        var orm = orm();
+        var repository = orm.entity(PlanVisit.class);
+        var plan = fullUpdatePlan(orm);
+        var visit = repository.getById(1);
+        var updated = new PlanVisit(visit.id(), visit.visitDate(), "parallel", visit.pet());
+        // Extraction runs concurrently against the shared plan; execution is intentionally left out since the
+        // transactional test connection is single-threaded.
+        java.util.stream.IntStream.range(0, 200).parallel().forEach(ignore -> {
+            var query = plan.bind(updated);
+            assertTrue(query != null);
+        });
+        assertEquals(1, plan.bind(updated).executeUpdate());
+        assertEquals("parallel", repository.getById(1).description());
+    }
+
+    @Test
+    void repositoryRemoveById_usesCachedPlan() {
+        var repository = orm().entity(PlanVisit.class);
+        var total = repository.count();
+        repository.removeById(1);
+        assertEquals(total - 1, repository.count());
+        // The second call binds against the plan cached by the first.
+        repository.removeById(2);
+        assertEquals(total - 2, repository.count());
+        assertTrue(repository.findById(1).isEmpty());
+    }
+
+    @Test
     void repositoryFindAllRefAndRemoveAll_useCachedConstantPlans() {
         var repository = orm().entity(PlanVisit.class);
         var refs = repository.findAllRef();

--- a/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
@@ -167,6 +167,20 @@ public class QueryPlanIntegrationTest {
     }
 
     @Test
+    void plan_rejectsMixedFixedAndBindVariables() {
+        var orm = orm();
+        var bindVars = orm.createBindVars();
+        // Mixing bind variables with a fixed value must be rejected: the fixed value would silently freeze into
+        // the plan while reading like a variable.
+        var exception = assertThrows(PersistenceException.class, () -> orm.plan(TemplateString.raw("""
+                SELECT \0
+                FROM \0
+                WHERE \0 AND description = \0""", PlanVisit.class, Templates.from(PlanVisit.class, true),
+                Templates.where(bindVars), "fixed")));
+        assertTrue(exception.getMessage().contains("fixed parameter values"));
+    }
+
+    @Test
     void bindValue_rejectsPlansWithMultipleBindVariablesSegments() {
         var orm = orm();
         var bindVars = orm.createBindVars();

--- a/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
@@ -1,0 +1,213 @@
+package st.orm.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static st.orm.core.template.SqlInterceptor.observe;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.DbTable;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+import st.orm.PersistenceException;
+import st.orm.core.model.Pet;
+import st.orm.core.template.ORMTemplate;
+import st.orm.core.template.QueryPlan;
+import st.orm.core.template.Sql;
+import st.orm.core.template.SqlInterceptor;
+import st.orm.core.template.SqlTemplate.PositionalParameter;
+import st.orm.core.template.TemplateString;
+import st.orm.core.template.Templates;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IntegrationConfig.class)
+@DataJpaTest(showSql = false)
+public class QueryPlanIntegrationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @DbTable("visit")
+    public record PlanVisit(
+            @PK Integer id,
+            @Nonnull LocalDate visitDate,
+            @Nullable String description,
+            @Nonnull @FK Pet pet
+    ) implements Entity<Integer> {}
+
+    private ORMTemplate orm() {
+        return ORMTemplate.of(dataSource);
+    }
+
+    private QueryPlan fullUpdatePlan(ORMTemplate orm) {
+        var bindVars = orm.createBindVars();
+        return orm.plan(TemplateString.raw("""
+                UPDATE \0
+                SET \0
+                WHERE \0""", PlanVisit.class, Templates.set(bindVars), bindVars));
+    }
+
+    @Test
+    void plan_bindsManyRecords_acrossExecutions() {
+        var orm = orm();
+        var repository = orm.entity(PlanVisit.class);
+        var plan = fullUpdatePlan(orm);
+
+        var first = repository.getById(1);
+        assertEquals(1, plan.bind(new PlanVisit(first.id(), first.visitDate(), "plan-a", first.pet())).executeUpdate());
+        assertEquals("plan-a", repository.getById(1).description());
+
+        var second = repository.getById(2);
+        assertEquals(1, plan.bind(new PlanVisit(second.id(), second.visitDate(), "plan-b", second.pet())).executeUpdate());
+        assertEquals("plan-b", repository.getById(2).description());
+    }
+
+    @Test
+    void plan_interceptorsObserveEveryBoundStatement() {
+        var orm = orm();
+        var repository = orm.entity(PlanVisit.class);
+        var plan = fullUpdatePlan(orm);
+        var first = repository.getById(1);
+        var second = repository.getById(2);
+
+        var observed = new ArrayList<Sql>();
+        observe(observed::add, () -> {
+            plan.bind(new PlanVisit(first.id(), first.visitDate(), "observed-a", first.pet())).executeUpdate();
+            plan.bind(new PlanVisit(second.id(), second.visitDate(), "observed-b", second.pet())).executeUpdate();
+        });
+        assertEquals(2, observed.size());
+        assertTrue(observed.getFirst().statement().startsWith("UPDATE"));
+        assertTrue(observed.getFirst().parameters().stream()
+                .anyMatch(parameter -> parameter instanceof PositionalParameter positional
+                        && "observed-a".equals(positional.dbValue())));
+        assertTrue(observed.getLast().parameters().stream()
+                .anyMatch(parameter -> parameter instanceof PositionalParameter positional
+                        && "observed-b".equals(positional.dbValue())));
+    }
+
+    @Test
+    void plan_rejectsFixedParameterValues() {
+        var orm = orm();
+        var visit = orm.entity(PlanVisit.class).getById(1);
+        var exception = assertThrows(PersistenceException.class, () -> orm.plan(TemplateString.raw("""
+                UPDATE \0
+                SET \0
+                WHERE \0""", PlanVisit.class, Templates.set(visit), visit)));
+        assertTrue(exception.getMessage().contains("fixed parameter values"));
+    }
+
+    @Test
+    void constantPlan_executesRepeatedly() {
+        var orm = orm();
+        var plan = orm.selectFrom(PlanVisit.class).plan();
+        var first = plan.query().getResultList(PlanVisit.class);
+        var second = plan.query().getResultList(PlanVisit.class);
+        assertFalse(first.isEmpty());
+        assertEquals(first.size(), second.size());
+    }
+
+    @Test
+    void constantPlan_andBoundPlan_rejectTheWrongExecutionStyle() {
+        var orm = orm();
+        var constant = orm.selectFrom(PlanVisit.class).plan();
+        var visit = orm.entity(PlanVisit.class).getById(1);
+        var bindOnConstant = assertThrows(PersistenceException.class, () -> constant.bind(visit));
+        assertTrue(bindOnConstant.getMessage().contains("query()"));
+        var bound = fullUpdatePlan(orm);
+        var queryOnBound = assertThrows(PersistenceException.class, bound::query);
+        assertTrue(queryOnBound.getMessage().contains("bind()"));
+    }
+
+    @Test
+    void repositoryFindAllAndCount_useCachedConstantPlans() {
+        var repository = orm().entity(PlanVisit.class);
+        var count = repository.count();
+        // The second calls bind against the plans cached by the first.
+        assertEquals(count, repository.count());
+        assertEquals(count, repository.findAll().size());
+        assertEquals(count, repository.findAll().size());
+    }
+
+    @Test
+    void repositoryFindAllRefAndRemoveAll_useCachedConstantPlans() {
+        var repository = orm().entity(PlanVisit.class);
+        var refs = repository.findAllRef();
+        assertEquals(repository.count(), refs.size());
+        assertEquals(refs.size(), repository.findAllRef().size());
+        repository.removeAll();
+        assertEquals(0, repository.count());
+        // The second call binds against the plan cached by the first.
+        repository.removeAll();
+        assertEquals(0, repository.count());
+    }
+
+    @Test
+    void plan_appliesInterceptorRewritesExactlyOncePerBind() {
+        var orm = orm();
+        var repository = orm.entity(PlanVisit.class);
+        var visit = repository.getById(1);
+        var marker = " -- plan-rewrite";
+
+        // Compiled inside a rewriting scope: the rewrite must not bake into the stored statement.
+        var plan = SqlInterceptor.intercept(sql -> sql.statement(sql.statement() + marker), () -> fullUpdatePlan(orm));
+        var observed = new ArrayList<Sql>();
+        observe(observed::add, () ->
+                plan.bind(new PlanVisit(visit.id(), visit.visitDate(), "clean", visit.pet())).executeUpdate());
+        assertFalse(observed.getFirst().statement().contains(marker));
+
+        // Executed inside a rewriting scope: the rewrite applies exactly once, so the interceptor never sees its
+        // own marker on the incoming statement.
+        var doubleApplied = new AtomicBoolean();
+        SqlInterceptor.intercept(sql -> {
+            if (sql.statement().contains(marker)) {
+                doubleApplied.set(true);
+            }
+            return sql.statement(sql.statement() + marker);
+        }, () -> plan.bind(new PlanVisit(visit.id(), visit.visitDate(), "rewritten", visit.pet())).executeUpdate());
+        assertFalse(doubleApplied.get());
+        assertEquals("rewritten", repository.getById(1).description());
+    }
+
+    @Test
+    void repositoryUpdate_underScopedCustomizer_bypassesCachedPlan() {
+        var repository = orm().entity(PlanVisit.class);
+        var visit = repository.getById(1);
+        // Populate the per-shape plan cache before the customizer scope starts.
+        repository.update(new PlanVisit(visit.id(), visit.visitDate(), "primed", visit.pet()));
+
+        var observed = new ArrayList<Sql>();
+        observe(template -> template.withInlineParameters(true), observed::add, () ->
+                repository.update(new PlanVisit(visit.id(), visit.visitDate(), "customized", visit.pet())));
+        var update = observed.stream()
+                .filter(sql -> sql.statement().startsWith("UPDATE"))
+                .findFirst()
+                .orElseThrow();
+        // The customized template inlines parameters into the statement; a cached plan would emit placeholders.
+        assertTrue(update.statement().contains("customized"));
+    }
+
+    @Test
+    void plan_repeatedRepositoryUpdates_reuseCachedPlan() {
+        // Exercises the repository's per-shape plan cache end to end: the second update binds against the plan
+        // created for the first.
+        var repository = orm().entity(PlanVisit.class);
+        var visit = repository.getById(1);
+        repository.update(new PlanVisit(visit.id(), visit.visitDate(), "first", visit.pet()));
+        assertEquals("first", repository.getById(1).description());
+        repository.update(new PlanVisit(visit.id(), visit.visitDate(), "second", visit.pet()));
+        assertEquals("second", repository.getById(1).description());
+    }
+}

--- a/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/QueryPlanIntegrationTest.java
@@ -156,7 +156,7 @@ public class QueryPlanIntegrationTest {
     }
 
     @Test
-    void bindValue_rejectsPlansThatAreNotPurelyPrimaryKeyBased() {
+    void bindValue_rejectsPlansThatAreNotSingleKeyBased() {
         var orm = orm();
         var boundByRecord = fullUpdatePlan(orm);
         var onUpdatePlan = assertThrows(PersistenceException.class, () -> boundByRecord.bindValue(1));
@@ -164,6 +164,21 @@ public class QueryPlanIntegrationTest {
         var constant = orm.selectFrom(PlanVisit.class).plan();
         var onConstantPlan = assertThrows(PersistenceException.class, () -> constant.bindValue(1));
         assertTrue(onConstantPlan.getMessage().contains("query()"));
+    }
+
+    @Test
+    void bindValue_rejectsPlansWithMultipleBindVariablesSegments() {
+        var orm = orm();
+        var bindVars = orm.createBindVars();
+        var plan = orm.plan(TemplateString.raw("""
+                SELECT \0
+                FROM \0
+                WHERE \0 AND \0""", PlanVisit.class, Templates.from(PlanVisit.class, true),
+                Templates.where(bindVars), Templates.where(bindVars)));
+        // A single value can feed exactly one segment; the same value bound through every segment would be silently
+        // wrong for distinct keys, so the plan insists on a record.
+        var exception = assertThrows(PersistenceException.class, () -> plan.bindValue(1));
+        assertTrue(exception.getMessage().contains("single key-based WHERE"));
     }
 
     @Test


### PR DESCRIPTION
Refs #320

## What

**`QueryPlan`** (new, `st.orm.core.template`): a compiled plan created via `QueryTemplate.plan(TemplateString)`. Template processing runs once at compilation; executions skip the per-call preprocess, compilation-key build, cache lookup, and bind walk that `query(TemplateString)` performs. Three execution styles, each rejecting the wrong one with an error naming the right one:

- **`bind(record)`**: the template expresses its variable parts as bind variables; binding runs the snapshotted value-independent parameter extractors. The single-use `BindVarsImpl` embedded in the processed SQL is never wired to a statement, so the plan binds any number of records on any connection.
- **`bindId(id)`**: available when the bind variables consist solely of a WHERE clause matching the primary key; the id, or its constituent values for composite keys, maps through the primary key metamodel.
- **`query()`**: constant plans compiled from templates without any parameters, such as unfiltered selects and counts.

Templates with fixed parameter values are rejected with a descriptive error: silently pinning a value that reads like a variable hides a likely mistake, and bind variables express the variable parts explicitly.

**Interception semantics.** Plans compile without applying Sql interceptors (`SqlTemplateImpl.process(template, false)`); the interceptor chain runs per execution at bind time. Rewriting interceptors therefore apply exactly once per executed statement, interceptors scoped around plan compilation do not leak into the cached plan, and observers such as `SqlCapture` see every execution with its concrete parameters. Scoped template customizers are honored: repositories bypass their cached plans while one is active (`SqlInterceptorManager.hasLocalCustomizers()`, backed by a shared identity customizer), and the public API documents that a plan is pinned to the template configuration it was compiled with.

**Thread safety.** The bind vars parameter factory confines extraction rounds to the calling thread; the factory outlives its binding session through the extractors, which plans invoke concurrently. A parallel bind test pins the behavior.

**`QueryBuilder.plan()`**: compiles the builder's assembled template. Select builders reject subqueries, mirroring `build()`; the delete builder carries its unsafe-warning suppression into every query the plan produces.

**Repository consumers**, each with per-call fallbacks for JPA templates (no bind variables support), scoped customizers, and shape overflow:

| Plan-served | Notes |
| --- | --- |
| `update` | cached per dirty shape, bounded by `maxShapes` plus the full-update shape |
| `insert` | both auto-generate variants |
| `remove` | single shape |
| `findById`, `getById` | by-id select plan; entity and projection repositories |
| `removeById`, `removeByRef` | versioned types keep the per-call path, since an id cannot supply the version value |
| `findByRef`, `getByRef` | reuse the by-id select plan through the ref's primary key |
| `findBy`, `getBy` | unique-key lookups, plans cached per key metamodel via Templates.where(key, bindVars) |
| `findAll`, `findAllRef`, `count`/`exists`, `removeAll` | constant plans; entity and projection repositories |

Remaining on #320: chunked WHERE IN shapes for the streaming by-id operations, and the language-layer surface.

## Testing

- `QueryPlanIntegrationTest` (new, 14 tests): plan reuse across executions for all three execution styles, per-bind interceptor observation with concrete parameters, exactly-once interceptor rewrites and no compilation-scope leak, customizer bypass through the repository, fixed-value rejection, wrong-execution-style errors, parallel bind thread safety, and cached plans for the repository consumers.
- Full storm-core suite: 2346/2346. findById/getById run through plans for virtually every test in the corpus, including the exact-SQL assertion suites.
- storm-java21, storm-kotlin, storm-spring compile against the new surface.