### PR TITLE
fix(core): render plan and per-call WHERE through one shared path

### DIFF
--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -40,6 +40,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import st.orm.BindVars;
+import st.orm.Data;
 import st.orm.Entity;
 import st.orm.EntityCallback;
 import st.orm.GenerationStrategy;
@@ -1182,27 +1184,14 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
             return;
         }
         if (!versionedEntity && usePlans()) {
-            var plan = removeByIdPlan;
-            if (plan == null) {
-                plan = createPlanQuietly(() -> {
-                    var bindVars = ormTemplate.createBindVars();
-                    return ormTemplate.plan(TemplateString.raw("""
-                            DELETE FROM \0
-                            WHERE \0""", model.type(), bindVars));
-                });
-                removeByIdPlan = plan;
-            }
+            var plan = deleteByKeyPlan();
             if (plan != null) {
                 plan.bindValue(id).managed().executeUpdate();
                 return;
             }
         }
         // Don't use query builder to prevent WHERE IN clause.
-        ormTemplate.query(TemplateString.raw("""
-                DELETE FROM \0
-                WHERE \0""", model.type(), id))
-                .managed()
-                .executeUpdate();
+        ormTemplate.query(deleteByKeyStatement(id)).managed().executeUpdate();
     }
 
     /**
@@ -1220,27 +1209,14 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         //noinspection unchecked
         entityCache().ifPresent(cache -> cache.remove((ID) ref.id()));
         if (!versionedEntity && !model.isJoinedInheritance() && usePlans()) {
-            var plan = removeByIdPlan;
-            if (plan == null) {
-                plan = createPlanQuietly(() -> {
-                    var bindVars = ormTemplate.createBindVars();
-                    return ormTemplate.plan(TemplateString.raw("""
-                            DELETE FROM \0
-                            WHERE \0""", model.type(), bindVars));
-                });
-                removeByIdPlan = plan;
-            }
+            var plan = deleteByKeyPlan();
             if (plan != null) {
                 plan.bindValue(ref.id()).managed().executeUpdate();
                 return;
             }
         }
         // Don't use query builder to prevent WHERE IN clause.
-        ormTemplate.query(TemplateString.raw("""
-                DELETE FROM \0
-                WHERE \0""", model.type(), ref))
-                .managed()
-                .executeUpdate();
+        ormTemplate.query(deleteByKeyStatement(ref)).managed().executeUpdate();
     }
 
     /**
@@ -1813,12 +1789,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
     }
 
     protected PreparedQuery prepareInsertQuery(boolean ignoreAutoGenerate) {
-        var bindVars = ormTemplate.createBindVars();
-        return ormTemplate.query(raw("""
-                INSERT INTO \0
-                VALUES \0""",
-                Templates.insert(model.type(), ignoreAutoGenerate),
-                Templates.values(bindVars, ignoreAutoGenerate))).managed().prepare();
+        return ormTemplate.query(insertStatement(ormTemplate.createBindVars(), ignoreAutoGenerate)).managed().prepare();
     }
 
     protected void insert(@Nonnull List<E> batch, @Nonnull PreparedQuery query) {
@@ -1976,6 +1947,35 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         return dirtySupport.getMaxShapes();
     }
 
+    // Single definition of each statement's template, parameterized only by the value source: a Data instance or
+    // id/ref for the per-call path, or BindVars for a plan or a prepared batch. Every plan, per-call fallback, and
+    // batch path builds its template here, so a plan cannot structurally diverge from the statement it replaces.
+
+    private TemplateString updateStatement(@Nonnull Object valueSource, @Nonnull Set<Metamodel<?, ?>> fields) {
+        var set = valueSource instanceof BindVars bindVars
+                ? Templates.set(bindVars, fields)
+                : Templates.set((Data) valueSource, fields);
+        return TemplateString.raw("""
+                UPDATE \0
+                SET \0
+                WHERE \0""", model.type(), set, valueSource);
+    }
+
+    private TemplateString insertStatement(@Nonnull Object valueSource, boolean ignoreAutoGenerate) {
+        var values = valueSource instanceof BindVars bindVars
+                ? Templates.values(bindVars, ignoreAutoGenerate)
+                : Templates.values((Data) valueSource, ignoreAutoGenerate);
+        return TemplateString.raw("""
+                INSERT INTO \0
+                VALUES \0""", Templates.insert(model.type(), ignoreAutoGenerate), values);
+    }
+
+    private TemplateString deleteByKeyStatement(@Nonnull Object valueSource) {
+        return TemplateString.raw("""
+                DELETE FROM \0
+                WHERE \0""", model.type(), valueSource);
+    }
+
     /**
      * Returns a managed query that updates the given entity's dirty {@code fields}.
      *
@@ -1993,21 +1993,11 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
                 return plan.bind(entity).managed();
             }
         }
-        return ormTemplate.query(TemplateString.raw("""
-                UPDATE \0
-                SET \0
-                WHERE \0""", model.type(), Templates.set(entity, fields), entity))
-                .managed();
+        return ormTemplate.query(updateStatement(entity, fields)).managed();
     }
 
     private QueryPlan createUpdatePlan(@Nonnull Set<Metamodel<?, ?>> fields) {
-        var plan = createPlanQuietly(() -> {
-            var bindVars = ormTemplate.createBindVars();
-            return ormTemplate.plan(TemplateString.raw("""
-                    UPDATE \0
-                    SET \0
-                    WHERE \0""", model.type(), Templates.set(bindVars, fields), bindVars));
-        });
+        var plan = createPlanQuietly(() -> ormTemplate.plan(updateStatement(ormTemplate.createBindVars(), fields)));
         if (plan == null) {
             return null;
         }
@@ -2024,14 +2014,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         if (usePlans()) {
             var plan = ignoreAutoGenerate ? insertIgnoringAutoGeneratePlan : insertPlan;
             if (plan == null) {
-                plan = createPlanQuietly(() -> {
-                    var bindVars = ormTemplate.createBindVars();
-                    return ormTemplate.plan(TemplateString.raw("""
-                            INSERT INTO \0
-                            VALUES \0""",
-                            Templates.insert(model.type(), ignoreAutoGenerate),
-                            Templates.values(bindVars, ignoreAutoGenerate)));
-                });
+                plan = createPlanQuietly(() -> ormTemplate.plan(insertStatement(ormTemplate.createBindVars(), ignoreAutoGenerate)));
                 if (ignoreAutoGenerate) {
                     insertIgnoringAutoGeneratePlan = plan;
                 } else {
@@ -2042,12 +2025,7 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
                 return plan.bind(entity).managed();
             }
         }
-        return ormTemplate.query(TemplateString.raw("""
-                INSERT INTO \0
-                VALUES \0""",
-                Templates.insert(model.type(), ignoreAutoGenerate),
-                Templates.values(entity, ignoreAutoGenerate)))
-                .managed();
+        return ormTemplate.query(insertStatement(entity, ignoreAutoGenerate)).managed();
     }
 
     /**
@@ -2059,31 +2037,31 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         if (usePlans()) {
             var plan = removePlan;
             if (plan == null) {
-                plan = createPlanQuietly(() -> {
-                    var bindVars = ormTemplate.createBindVars();
-                    return ormTemplate.plan(TemplateString.raw("""
-                            DELETE FROM \0
-                            WHERE \0""", model.type(), bindVars));
-                });
+                plan = createPlanQuietly(() -> ormTemplate.plan(deleteByKeyStatement(ormTemplate.createBindVars())));
                 removePlan = plan;
             }
             if (plan != null) {
                 return plan.bind(entity).managed();
             }
         }
-        return ormTemplate.query(TemplateString.raw("""
-                DELETE FROM \0
-                WHERE \0""", model.type(), entity))
-                .managed();
+        return ormTemplate.query(deleteByKeyStatement(entity)).managed();
+    }
+
+    /**
+     * Returns the cached plan that deletes a row by its identifying columns, or {@code null} when plans are
+     * unavailable. Shared by {@link #removeById(Object)} and {@link #removeByRef(Ref)}, which bind an id or ref.
+     */
+    private @Nullable QueryPlan deleteByKeyPlan() {
+        var plan = removeByIdPlan;
+        if (plan == null) {
+            plan = createPlanQuietly(() -> ormTemplate.plan(deleteByKeyStatement(ormTemplate.createBindVars())));
+            removeByIdPlan = plan;
+        }
+        return plan;
     }
 
     protected PreparedQuery prepareUpdateQuery(@Nonnull Set<Metamodel<?, ?>> fields) {
-        var bindVars = ormTemplate.createBindVars();
-        return ormTemplate.query(TemplateString.raw("""
-                UPDATE \0
-                SET \0
-                WHERE \0""", model.type(), Templates.set(bindVars, fields), bindVars))
-                .managed().prepare();
+        return ormTemplate.query(updateStatement(ormTemplate.createBindVars(), fields)).managed().prepare();
     }
 
     protected void update(@Nonnull List<E> batch, @Nonnull PreparedQuery query, @Nullable EntityCache<E, ID> cache) {

--- a/storm-core/src/main/java/st/orm/core/template/impl/ColumnComparison.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/ColumnComparison.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.template.impl;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
+import java.util.SequencedMap;
+import java.util.function.Function;
+import st.orm.Operator;
+import st.orm.core.template.SqlDialect;
+import st.orm.core.template.SqlTemplateException;
+
+/**
+ * The single source of truth for rendering a column comparison in a WHERE clause. One column renders as the plain
+ * {@code column OP (?...)} form; multiple columns render through the dialect's multi-column form, which is a tuple
+ * comparison on dialects that support one and an {@code AND} expansion otherwise.
+ *
+ * <p>Both the value-based WHERE (values known at compile time) and the bind-variables WHERE (values bound per
+ * execution) render their comparisons here. Routing them through one decision is what keeps a compiled
+ * {@link st.orm.core.template.QueryPlan} from diverging from the per-call statement it replaces: a plan reuses the
+ * bind-variables WHERE, so were this single-versus-multi-column decision duplicated across the two paths, they could
+ * drift and a plan could emit different SQL, for example {@code (id) = (?)} where the per-call path emits
+ * {@code id = ?}. There is nothing to keep in sync because there is one renderer.</p>
+ */
+final class ColumnComparison {
+
+    private ColumnComparison() {
+    }
+
+    /**
+     * Renders a comparison over one or more columns.
+     *
+     * <p>The comparison is rendered from one of two inputs. When {@code rows} is empty the caller supplies the
+     * column and its already rendered placeholders directly, and the comparison renders as
+     * {@code column OP (placeholders)}. When {@code rows} is non-empty each row maps columns to values: rows that
+     * all resolve to a single column render as {@code column OP (?...)}, while rows spanning multiple columns render
+     * through the dialect's multi-column form. In both non-empty cases {@code parameterFunction} produces each
+     * placeholder; the value-based path passes a function that binds the value and returns a placeholder, the
+     * bind-variables path passes one that returns a placeholder without binding.</p>
+     *
+     * @param operator the comparison operator.
+     * @param singleColumn the column for the {@code rows}-empty form, or {@code null} otherwise.
+     * @param singleColumnPlaceholders the rendered placeholders for the {@code rows}-empty form.
+     * @param rows the column-to-value rows, empty when the column and placeholders are supplied directly.
+     * @param parameterFunction renders a parameter for each value in {@code rows}.
+     * @param dialect the SQL dialect.
+     * @return the rendered comparison.
+     * @throws SqlTemplateException if the dialect cannot render the comparison.
+     */
+    static String render(@Nonnull Operator operator,
+                         @Nullable String singleColumn,
+                         @Nonnull List<String> singleColumnPlaceholders,
+                         @Nonnull List<SequencedMap<String, Object>> rows,
+                         @Nonnull Function<Object, String> parameterFunction,
+                         @Nonnull SqlDialect dialect) throws SqlTemplateException {
+        if (rows.isEmpty()) {
+            // The value-based path supplies its single column and already rendered placeholders directly.
+            return operator.format(singleColumn, singleColumnPlaceholders.toArray(new String[0]));
+        }
+        if (rows.stream().allMatch(row -> row.size() == 1)) {
+            // One column across the rows renders plain; routing it through the dialect's multi-column form would
+            // wrap a single column in a tuple, e.g. "(id) = (?)".
+            String column = rows.getFirst().firstEntry().getKey();
+            String[] placeholders = rows.stream()
+                    .map(row -> parameterFunction.apply(row.firstEntry().getValue()))
+                    .toArray(String[]::new);
+            return operator.format(column, placeholders);
+        }
+        return dialect.multiColumnExpression(operator, rows, parameterFunction);
+    }
+}

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryModelImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryModelImpl.java
@@ -394,14 +394,11 @@ final class QueryModelImpl implements QueryModel {
                 multiValues.add(valueMap);
             }
         }
-        if (!multiValues.isEmpty()) {
-            return compileMultiValues(operator, multiValues, compiler);
-        }
-        if (column == null) {
+        if (multiValues.isEmpty() && column == null) {
             column = toFullyQualifiedColumn(model.getSingleColumn(metamodel));
         }
         try {
-            return operator.format(column, placeholders.toArray(new String[0]));
+            return ColumnComparison.render(operator, column, placeholders, multiValues, compiler::mapParameter, compiler.dialect());
         } catch (IllegalArgumentException e) {
             throw new SqlTemplateException(e);
         }
@@ -506,21 +503,6 @@ final class QueryModelImpl implements QueryModel {
             }
         }
         throw new NoSuchElementException("No value present");
-    }
-
-    /**
-     * Compiles a multi-column, multi-row value set into a dialect-specific SQL fragment.
-     *
-     * @param operator    the operator to apply.
-     * @param multiValues the list of column-to-value mappings.
-     * @param compiler    the compiler used to map parameters.
-     * @return the compiled SQL fragment.
-     * @throws SqlTemplateException if the dialect cannot handle the value set.
-     */
-    private String compileMultiValues(@Nonnull Operator operator,
-                                      @Nonnull List<SequencedMap<String, Object>> multiValues,
-                                      @Nonnull TemplateCompiler compiler) throws SqlTemplateException {
-        return compiler.dialect().multiColumnExpression(operator, multiValues, compiler::mapParameter);
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/SetProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SetProcessor.java
@@ -15,8 +15,6 @@
  */
 package st.orm.core.template.impl;
 
-import static java.util.stream.Collectors.joining;
-
 import jakarta.annotation.Nonnull;
 import java.math.BigInteger;
 import java.sql.Timestamp;
@@ -26,7 +24,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import st.orm.BindVars;
 import st.orm.Data;
 import st.orm.Metamodel;
@@ -142,10 +140,11 @@ final class SetProcessor implements ElementProcessor<Set> {
     }
 
     /**
-     * Returns the SQL string for the specified record.
+     * Compiles the SET clause for the specified record. Clause structure is shared with the bindVars variant via
+     * {@link #renderSet}; each non-version column renders an immediately bound value.
      *
      * @param record the record to process.
-     * @return the SQL string for the specified record.
+     * @return the compiled SET clause.
      * @throws SqlTemplateException if the template does not comply to the specification.
      */
     private CompiledElement compileSet(@Nonnull Data record, @Nonnull Collection<Metamodel<?, ?>> fields, @Nonnull TemplateCompiler compiler) throws SqlTemplateException {
@@ -155,35 +154,15 @@ final class SetProcessor implements ElementProcessor<Set> {
         var model = (Model<Data, ?>) compiler.getModel(table.type());
         var columns = getColumns(model, fields);
         var mapped = model.values(columns, record);
-        var dialect = compiler.dialect();
-        List<String> args = new ArrayList<>();
-        for (var entry : mapped.entrySet()) {
-            var column = entry.getKey();
-            if (!column.version()) {
-                args.add("%s%s = %s".formatted(table.alias().isEmpty()
-                        ? ""
-                        : table.alias() + ".",
-                        column.qualifiedName(compiler.dialect()), compiler.mapParameter(entry.getValue())));
-                args.add(", ");
-            } else {
-                compiler.setVersionAware();
-                var versionString = compileVersion(column.qualifiedName(dialect), column.type(), table.alias(), dialect);
-                args.add(versionString);
-                args.add(", ");
-            }
-        }
-        if (!args.isEmpty()) {
-            args.removeLast();
-        }
-        return new CompiledElement(String.join("", args),
-                new SetBindHint(columns.stream().filter(column -> !column.version()).toList()));
+        return renderSet(columns, table.alias(), compiler, column -> compiler.mapParameter(mapped.get(column)));
     }
 
     /**
-     * Returns the SQL string for the specified bindVars.
+     * Compiles the SET clause for the specified bindVars. Clause structure is shared with {@link #compileSet} via
+     * {@link #renderSet}; each non-version column renders a bind placeholder bound per record.
      *
      * @param bindVars the bindVars to process.
-     * @return the SQL string for the specified bindVars.
+     * @return the compiled SET clause.
      * @throws SqlTemplateException if the template does not comply to the specification.
      */
     private CompiledElement compileSetBindVars(@Nonnull BindVars bindVars, @Nonnull Collection<Metamodel<?, ?>> fields, @Nonnull TemplateCompiler compiler) throws SqlTemplateException {
@@ -193,25 +172,40 @@ final class SetProcessor implements ElementProcessor<Set> {
             //noinspection unchecked
             var model = (Model<Data, ?>) compiler.getModel(table.type());
             var columns = getColumns(model, fields);
-            AtomicInteger bindVarsCount = new AtomicInteger();
-            String bindVarsString = columns.stream()
-                    .map(column -> {
-                        if (!column.version()) {
-                            bindVarsCount.incrementAndGet();
-                            return "%s%s = ?".formatted(
-                                    table.alias().isEmpty() ? "" : table.alias() + ".",
-                                    column.qualifiedName(compiler.dialect())
-                            );
-                        }
-                        compiler.setVersionAware();
-                        return compileVersion(column.qualifiedName(compiler.dialect()), column.type(), table.alias(), compiler.dialect());
-                    })
-                    .collect(joining(", "));
-            compiler.mapBindVars(bindVarsCount.getPlain());
-            return new CompiledElement(bindVarsString,
-                    new SetBindHint(columns.stream().filter(column -> !column.version()).toList()));
+            compiler.mapBindVars((int) columns.stream().filter(column -> !column.version()).count());
+            return renderSet(columns, table.alias(), compiler, column -> "?");
         }
         throw new SqlTemplateException("Unsupported BindVars type in SET clause. Expected a standard BindVars implementation.");
+    }
+
+    /**
+     * Renders the SET clause body once, regardless of parameter source. The version increment and column quoting
+     * are produced here; {@code parameterSql} supplies each non-version column's parameter fragment, either an
+     * immediately bound value or a deferred bind placeholder. Sharing this keeps the value and bindVars paths from
+     * drifting on dialect-specific rendering.
+     *
+     * @param columns the columns to assign, in model order.
+     * @param alias the table alias, or an empty string when unaliased.
+     * @param compiler the active compiler context.
+     * @param parameterSql renders the parameter fragment for a non-version column.
+     * @return the compiled SET clause.
+     */
+    private CompiledElement renderSet(@Nonnull List<Column> columns, @Nonnull String alias,
+                                      @Nonnull TemplateCompiler compiler,
+                                      @Nonnull Function<Column, String> parameterSql) {
+        var dialect = compiler.dialect();
+        String prefix = alias.isEmpty() ? "" : alias + ".";
+        List<String> assignments = new ArrayList<>();
+        for (var column : columns) {
+            if (column.version()) {
+                compiler.setVersionAware();
+                assignments.add(compileVersion(column.qualifiedName(dialect), column.type(), alias, dialect));
+            } else {
+                assignments.add("%s%s = %s".formatted(prefix, column.qualifiedName(dialect), parameterSql.apply(column)));
+            }
+        }
+        return new CompiledElement(String.join(", ", assignments),
+                new SetBindHint(columns.stream().filter(column -> !column.version()).toList()));
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/ValuesProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/ValuesProcessor.java
@@ -19,6 +19,7 @@ import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
 import st.orm.Data;
 import st.orm.core.template.Column;
 import st.orm.core.template.Model;
@@ -156,10 +157,8 @@ final class ValuesProcessor implements ElementProcessor<Values> {
         var table = queryModel.getTable();
         //noinspection unchecked
         var model = (Model<Data, ?>) compiler.getModel(table.type());
-        var columns = model.declaredColumns().stream()
-                .filter(Column::insertable)
-                .toList();
-        List<String> args = new ArrayList<>();
+        var columns = insertableColumns(model);
+        List<String> rows = new ArrayList<>();
         for (var record : values.records()) {
             if (record == null) {
                 throw new SqlTemplateException("Cannot generate VALUES clause: the record is null. Ensure a non-null entity is provided for insert operations.");
@@ -167,35 +166,10 @@ final class ValuesProcessor implements ElementProcessor<Values> {
             if (!table.type().isInstance(record)) {
                 throw new SqlTemplateException("Record type %s does not match the target entity type %s. Ensure the record passed to values() matches the entity type specified in the INSERT INTO clause.".formatted(record.getClass().getSimpleName(), table.type().getSimpleName()));
             }
-            List<String> placeholders = new ArrayList<>();
-            model.forEachValue(columns, record, (column, value) -> {
-                switch (column.generation()) {
-                    case NONE -> placeholders.add(compiler.mapParameter(value));
-                    case IDENTITY -> {
-                        if (values.ignoreAutoGenerate()) {
-                            placeholders.add(compiler.mapParameter(value));
-                        }
-                    }
-                    case SEQUENCE -> {
-                        if (values.ignoreAutoGenerate()) {
-                            placeholders.add(compiler.mapParameter(value));
-                        } else {
-                            String sequenceName = column.sequence();
-                            if (!sequenceName.isEmpty()) {
-                                // Do NOT bind a value; emit sequence retrieval instead.
-                                placeholders.add(compiler.dialect().sequenceNextVal(sequenceName));
-                            }
-                        }
-                    }
-                }
-            });
-            args.add("(%s)".formatted(String.join(", ", placeholders)));
-            args.add(", ");
+            var mapped = model.values(columns, record);
+            rows.add(renderRow(columns, values.ignoreAutoGenerate(), compiler, column -> compiler.mapParameter(mapped.get(column))));
         }
-        if (!args.isEmpty()) {
-            args.removeLast();
-        }
-        return new CompiledElement(String.join("", args), new ValuesBindHint(columns));
+        return new CompiledElement(String.join(", ", rows), new ValuesBindHint(columns));
     }
 
     private CompiledElement compileValuesBindVars(@Nonnull Values values, @Nonnull TemplateCompiler compiler)
@@ -206,43 +180,59 @@ final class ValuesProcessor implements ElementProcessor<Values> {
             var table = queryModel.getTable();
             //noinspection unchecked
             var model = (Model<Data, ?>) compiler.getModel(table.type());
-            var columns = model.declaredColumns().stream()
-                    .filter(Column::insertable)
-                    .toList();
-            var bindsVarCount = (int) model.declaredColumns().stream()
-                    .filter(Column::insertable)
+            var columns = insertableColumns(model);
+            compiler.mapBindVars((int) columns.stream()
                     .filter(column -> switch (column.generation()) {
                         case NONE -> true;
                         case IDENTITY, SEQUENCE -> values.ignoreAutoGenerate();
                     })
-                    .count();
-            StringBuilder bindVarsString = new StringBuilder();
-            for (var column : columns) {
-                switch (column.generation()) {
-                    case NONE -> bindVarsString.append("?, ");
-                    case IDENTITY -> {
-                        if (values.ignoreAutoGenerate()) {
-                            bindVarsString.append("?, ");
-                        }
+                    .count());
+            return new CompiledElement(renderRow(columns, values.ignoreAutoGenerate(), compiler, column -> "?"),
+                    new ValuesBindHint(columns));
+        }
+        throw new SqlTemplateException("Unsupported BindVars type in VALUES clause. Expected a standard BindVars implementation.");
+    }
+
+    private static List<Column> insertableColumns(@Nonnull Model<Data, ?> model) {
+        return model.declaredColumns().stream().filter(Column::insertable).toList();
+    }
+
+    /**
+     * Renders one VALUES row once, regardless of parameter source. The generation switch and sequence-retrieval
+     * are produced here; {@code parameterSql} supplies each bound column's parameter fragment, either an immediately
+     * bound value or a deferred bind placeholder. Sharing this keeps the value and bindVars paths from drifting on
+     * dialect-specific rendering such as sequence next-value.
+     *
+     * @param columns the insertable columns, in model order.
+     * @param ignoreAutoGenerate whether database-generated columns are supplied explicitly.
+     * @param compiler the active compiler context.
+     * @param parameterSql renders the parameter fragment for a bound column.
+     * @return the rendered row, parenthesized.
+     */
+    private String renderRow(@Nonnull List<Column> columns, boolean ignoreAutoGenerate,
+                             @Nonnull TemplateCompiler compiler, @Nonnull Function<Column, String> parameterSql) {
+        List<String> placeholders = new ArrayList<>();
+        for (var column : columns) {
+            switch (column.generation()) {
+                case NONE -> placeholders.add(parameterSql.apply(column));
+                case IDENTITY -> {
+                    if (ignoreAutoGenerate) {
+                        placeholders.add(parameterSql.apply(column));
                     }
-                    case SEQUENCE -> {
-                        if (values.ignoreAutoGenerate()) {
-                            bindVarsString.append("?, ");
-                        } else {
-                            String sequenceName = column.sequence();
-                            if (!sequenceName.isEmpty()) {
-                                bindVarsString.append(compiler.dialect().sequenceNextVal(sequenceName)).append(", ");
-                            }
+                }
+                case SEQUENCE -> {
+                    if (ignoreAutoGenerate) {
+                        placeholders.add(parameterSql.apply(column));
+                    } else {
+                        String sequenceName = column.sequence();
+                        if (!sequenceName.isEmpty()) {
+                            // Do NOT bind a value; emit sequence retrieval instead.
+                            placeholders.add(compiler.dialect().sequenceNextVal(sequenceName));
                         }
                     }
                 }
             }
-            compiler.mapBindVars(bindsVarCount);
-            if (!bindVarsString.isEmpty()) {
-                bindVarsString.delete(bindVarsString.length() - ", ".length(), bindVarsString.length());
-            }
-            return new CompiledElement("(%s)".formatted(bindVarsString), new ValuesBindHint(columns));
         }
-        throw new SqlTemplateException("Unsupported BindVars type in VALUES clause. Expected a standard BindVars implementation.");
+        return "(%s)".formatted(String.join(", ", placeholders));
     }
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/WhereProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/WhereProcessor.java
@@ -15,11 +15,13 @@
  */
 package st.orm.core.template.impl;
 
-import static java.util.stream.Collectors.joining;
+import static st.orm.Operator.EQUALS;
 import static st.orm.core.template.impl.ElementRouter.getElementProcessor;
 
 import jakarta.annotation.Nonnull;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.SequencedMap;
 import java.util.function.Function;
 import st.orm.Data;
 import st.orm.Metamodel;
@@ -31,6 +33,9 @@ import st.orm.core.template.impl.Elements.Where;
 
 final class WhereProcessor implements ElementProcessor<Where> {
     record WhereBindHint(@Nonnull List<Column> columns) implements BindHint {}
+
+    /** Marker passed as the placeholder value; the dialect reads only column names and the parameter function. */
+    private static final Object PLACEHOLDER = new Object();
 
     /**
      * Returns a key that represents the compiled shape of the given element.
@@ -169,10 +174,16 @@ final class WhereProcessor implements ElementProcessor<Where> {
                     ? getKeyColumns(where.bindVarsKey(), compiler)
                     : getIdentifyingColumns(compiler);
             compiler.mapBindVars(columns.size());
-            return new CompiledElement(columns.stream()
-                    .map(queryModel::toColumnExpression)
-                    .map(column -> column.toSql() + " = ?")
-                    .collect(joining(" AND ")), new WhereBindHint(columns));
+            // Hand the key columns to the shared comparison renderer without deciding single-versus-multi here: the
+            // renderer owns that decision, so the bindVars WHERE cannot diverge from the value-based WHERE. The
+            // placeholder values are markers; the renderer reads only the column names and the parameter function,
+            // which emits "?". EQUALS lists the columns in map order, matching the extractors' column-order binding.
+            SequencedMap<String, Object> row = new LinkedHashMap<>();
+            for (var column : columns) {
+                row.put(queryModel.toColumnExpression(column).toSql(), PLACEHOLDER);
+            }
+            String sql = ColumnComparison.render(EQUALS, null, List.of(), List.of(row), value -> "?", compiler.dialect());
+            return new CompiledElement(sql, new WhereBindHint(columns));
         }
         throw new SqlTemplateException("Unsupported BindVars type in WHERE clause. Expected a standard BindVars implementation.");
     }

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBEntityRepositoryTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBEntityRepositoryTest.java
@@ -323,7 +323,7 @@ public class MariaDBEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE id = ? AND version = ?""";
+                WHERE (id, version) = (?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);
@@ -537,7 +537,7 @@ public class MariaDBEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE id = ? AND version = ?""";
+                WHERE (id, version) = (?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);

--- a/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLEntityRepositoryTest.java
+++ b/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLEntityRepositoryTest.java
@@ -318,7 +318,7 @@ public class MySQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE id = ? AND version = ?""";
+                WHERE (id, version) = (?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);
@@ -532,7 +532,7 @@ public class MySQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE id = ? AND version = ?""";
+                WHERE (id, version) = (?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);

--- a/storm-oracle/src/test/java/st/orm/spi/oracle/OracleEntityRepositoryTest.java
+++ b/storm-oracle/src/test/java/st/orm/spi/oracle/OracleEntityRepositoryTest.java
@@ -335,7 +335,7 @@ public class OracleEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE id = ? AND version = ?""";
+                WHERE (id, version) = (?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);
@@ -546,7 +546,7 @@ public class OracleEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE id = ? AND version = ?""";
+                WHERE (id, version) = (?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
@@ -322,7 +322,7 @@ public class PostgreSQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE id = ? AND version = ?""";
+                WHERE (id, version) = (?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);
@@ -554,7 +554,7 @@ public class PostgreSQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE id = ? AND version = ?""";
+                WHERE (id, version) = (?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);


### PR DESCRIPTION
## Problem

Compiled query plans (#320/#321) reuse the bind-variables WHERE clause, which rendered a multi-column key comparison as a hardcoded `col = ? AND col = ?` instead of going through the dialect. On dialects with row-value tuple comparison (Oracle, MySQL, MariaDB, PostgreSQL), the per-call path emits `(id, version) = (?, ?)` while a plan emitted `id = ? AND version = ?` for the same versioned or composite-key statement. So a plan produced different SQL than the statement it was supposed to replace — surfaced by failing `...InlineVersion` assertions in the dialect test modules.

The root cause is structural: the value-based WHERE and the bind-variables WHERE were two separate rendering implementations that had to agree by hand, and they drifted.

## Fix — prevent divergence by construction

**One WHERE renderer.** Both paths now render through `ColumnComparison.render`: a single column renders plain `col = ?`; multiple columns go through `dialect.multiColumnExpression(...)` (tuple form where supported, `AND` expansion otherwise). A single column never passes through the dialect's multi-column form, which would wrap it as `(id) = (?)`. The value-path change is a faithful extraction — its behavior is unchanged.

**One SET/VALUES renderer each.** `SetProcessor` and `ValuesProcessor` render their value and bind-variables forms through one method with the parameter source injected, so those clauses cannot drift either.

**One template per statement.** The repository single-entity statements (update, insert, remove, delete by id and ref) are each built from one template definition parameterized by the value source; the plan, its per-call fallback, and the batch path share it rather than repeating it (the update template went from written 3x to 1x, delete-by-key ~6x to 1x).

Together, a plan and its per-call equivalent are formed from the same template through the same renderers, so they land on identical SQL for every dialect.

## Behavior change

On tuple-capable dialects, **batch** updates of versioned/composite-key entities now emit the tuple form `(id, version) = (?, ?)` instead of `id = ? AND version = ?`, matching what single-entity updates already emitted. The two forms are semantically identical for equality; this removes a pre-existing single-vs-batch inconsistency. The batch-update WHERE assertions in the four dialect test modules are updated accordingly. The default dialect and SQL Server are unaffected (they emit `AND` for both).

## Performance

No impact on the execution path. All rendering runs at compile time, which is cached per plan and per statement shape; the bind path is unchanged and binds the same parameters in the same order (the tuple form binds the same two parameters as the `AND` form).

## Testing

Full suites green on every dialect: storm-core 2349, MySQL 175, MariaDB 158, PostgreSQL 179, Oracle 174, SQL Server 176.