### PR TITLE
test(h2): expect tuple-form WHERE for batch version update

### DIFF
--- a/storm-h2/src/test/java/st/orm/spi/h2/H2EntityRepositoryTest.java
+++ b/storm-h2/src/test/java/st/orm/spi/h2/H2EntityRepositoryTest.java
@@ -295,7 +295,7 @@ public class H2EntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE id = ? AND version = ?""";
+                WHERE (id, version) = (?, ?)""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);


### PR DESCRIPTION
Follow-up to #322.

H2 supports row-value tuple comparison (`H2SqlDialect.supportsMultiValueTuples() == true`), so after #322 unified plan and per-call rendering, the batch update of a versioned entity emits `(id, version) = (?, ?)` — matching what single-entity updates already emitted. The H2 dialect test module's batch assertion still expected the `AND` form and was missed when the mysql, mariadb, oracle and postgresql modules were updated in #322.

`storm-sqlite` and `storm-mssqlserver` both have `supportsMultiValueTuples() == false` and emit the `AND` form, so their assertions are correct and unchanged (both suites verified green: sqlite 131, mssqlserver 176).

## Testing

storm-h2 full suite: 158/158.