### PR TITLE
build(ktor): bump storm-ktor to Ktor 3.4.3 on Kotlin 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,10 @@
         <kotlin.ksp.version>2.0.21-1.0.25</kotlin.ksp.version>
         <kotlin.coroutines.version>1.9.0</kotlin.coroutines.version>
         <kotlinx.serialization.version>1.7.3</kotlinx.serialization.version>
-        <ktor.version>3.2.3</ktor.version>
+        <!-- storm-ktor and storm-ktor-test track the Ktor ecosystem's toolchain independently of the core
+             framework: Ktor 3.4 requires Kotlin 2.3, which those two leaf modules override locally (see their
+             poms). The rest of the framework stays on Kotlin 2.0. -->
+        <ktor.version>3.4.3</ktor.version>
         <graalvm.version>24.2.2</graalvm.version>
         <micrometer.version>1.15.4</micrometer.version>
         <micrometer-tracing.version>1.5.4</micrometer-tracing.version>

--- a/storm-ktor-test/pom.xml
+++ b/storm-ktor-test/pom.xml
@@ -30,6 +30,11 @@
         <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
         <url>https://github.com/storm-repo/storm-framework/</url>
     </scm>
+    <!-- Matches storm-ktor's toolchain (Ktor 3.4 / Kotlin 2.3 / coroutines 1.10); see storm-ktor/pom.xml. -->
+    <properties>
+        <kotlin.version>2.3.10</kotlin.version>
+        <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
+    </properties>
     <build>
         <plugins>
             <plugin>
@@ -152,6 +157,28 @@
             </plugin>
         </plugins>
     </build>
+    <!-- Pin every transitive Kotlin artifact to this module's 2.3 version so the 2.3 stdlib required by
+         kotlinx-coroutines 1.10 (via Ktor 3.4) wins over the 2.0 stdlib pulled in by storm-kotlin. See
+         storm-ktor/pom.xml for the full rationale. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Align every transitive Ktor artifact to this module's Ktor version; see storm-ktor/pom.xml. -->
+            <dependency>
+                <groupId>io.ktor</groupId>
+                <artifactId>ktor-bom</artifactId>
+                <version>${ktor.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>st.orm</groupId>

--- a/storm-ktor/pom.xml
+++ b/storm-ktor/pom.xml
@@ -30,6 +30,13 @@
         <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
         <url>https://github.com/storm-repo/storm-framework/</url>
     </scm>
+    <!-- Ktor 3.4 requires Kotlin 2.3 and kotlinx-coroutines 1.10; this module tracks Ktor's toolchain while
+         the rest of the framework stays on Kotlin 2.0. As a leaf module (only storm-ktor-test consumes it, and
+         it overrides the same versions) this does not force the newer toolchain onto any other module. -->
+    <properties>
+        <kotlin.version>2.3.10</kotlin.version>
+        <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
+    </properties>
     <build>
         <plugins>
             <plugin>
@@ -173,7 +180,42 @@
             </plugin>
         </plugins>
     </build>
+    <!-- This module runs on Kotlin 2.3 (required by Ktor 3.4) while depending on storm-core/storm-kotlin, which
+         are built on Kotlin 2.0. The Kotlin BOM pins every transitive Kotlin artifact (stdlib, reflect, ...) to
+         this module's version so the 2.3 stdlib wins on the runtime classpath: kotlinx-coroutines 1.10 (pulled by
+         Ktor 3.4) needs the 2.3 stdlib, and a 2.0 stdlib leaking in from storm-kotlin fails at runtime with
+         NoClassDefFoundError. The 2.3 stdlib is backward compatible, so the 2.0-compiled dependencies run on it. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Align every transitive Ktor artifact (ktor-io, ktor-utils, ...) to this module's Ktor version.
+                 Without it, a transitive dependency can drag in an older Ktor module, producing a runtime skew
+                 (e.g. NoClassDefFoundError for classes added in the newer Ktor). -->
+            <dependency>
+                <groupId>io.ktor</groupId>
+                <artifactId>ktor-bom</artifactId>
+                <version>${ktor.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
+        <!-- Declare the Kotlin 2.3 stdlib explicitly so it propagates to consumers (the BOM above is build-only
+             and is not inherited). A Ktor application on Ktor 3.4 is already on Kotlin 2.3, but this guarantees the
+             2.3 stdlib required by kotlinx-coroutines 1.10 wins over the 2.0 stdlib pulled in transitively through
+             storm-kotlin, even for consumers that do not pin it themselves. -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
         <dependency>
             <groupId>st.orm</groupId>
             <artifactId>storm-kotlin</artifactId>


### PR DESCRIPTION
## Why

Ktor's DI plugin logged a benign `Exception during cleanup for st.orm.repository.Repository; continuing` warning at every application shutdown, because two or more repositories share the covariant `Repository` supertype key and the old cleanup loop resolved it (ambiguously) per key. **Ktor 3.4 fixes this** — its cleanup skips `Ambiguous`/`Missing` initializers (verified in the 3.4.3 source; the changelog doesn't document it). So the fix is simply to move the Ktor integration to Ktor 3.4.3.

## What

Ktor 3.4 requires Kotlin 2.3. Rather than move the whole framework, the two **leaf** Ktor modules track the Ktor ecosystem's toolchain independently:

- `storm-ktor` and `storm-ktor-test` override `kotlin.version` → **2.3.10** and `kotlin.coroutines.version` → **1.10.2** locally. Everything else stays on **Kotlin 2.0.21**.
- `ktor.version` → **3.4.3** parent-wide (only these two modules consume it).
- Each module imports the **Kotlin BOM** and **Ktor BOM** to align all transitive Kotlin/Ktor artifacts to its version. Two build-internal skews made this necessary: the 2.0 `kotlin-stdlib` pulled in through `storm-kotlin` is too old for coroutines 1.10 (`NoClassDefFoundError: SpillingKt`), and mixed transitive Ktor artifacts fail similarly (`IODispatcher_jvmKt`).
- `storm-ktor` also declares `kotlin-stdlib` at compile scope so the 2.3 stdlib **propagates to consumers** (a `dependencyManagement` import is build-only and not inherited).

Every change carries an explanatory comment in the pom.

## Blast radius

- **Non-Ktor modules and their consumers: unaffected.** The core stays on Kotlin 2.0.21 and never pulls Ktor 3.4 / coroutines 1.10 / Kotlin 2.3.
- **Ktor consumers: unaffected in practice.** A Ktor 3.4 application is uniformly on Kotlin 2.3, so its own direct `kotlin-stdlib` 2.3 wins over anything transitive (Gradle highest-wins, Maven nearest-wins); the explicit stdlib declaration covers even an unusual Maven setup.

## Testing

- `storm-ktor`: 57/57, **0 cleanup warnings** (were present before), no class-loading errors.
- `storm-ktor-test`: 4/4.

The rest of the framework is structurally untouched (no other module references Ktor).