### PR TITLE
chore(examples): link templates and sync their pinned version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,3 +184,41 @@ jobs:
           git add .
           git commit -m "docs: snapshot version ${{ steps.version.outputs.VERSION }}"
           git push
+
+  # The storm-example-* repos are GitHub templates (issue #213). Keep the Storm
+  # version they pin current so "Use this template" always starts on the release.
+  sync-example-templates:
+    runs-on: ubuntu-latest
+    needs: publish-gradle-plugin
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      # The example build files pin the st.orm Gradle plugin version; the Storm
+      # artifacts themselves are managed by the plugin's BOM, so only that
+      # coordinate needs bumping. Toolchain versions (Kotlin, Ktor) track their
+      # own upstreams and are left untouched. RELEASE_TOKEN must have write access
+      # to the storm-orm example repositories.
+      - name: Bump the st.orm plugin version in each template
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          V="${{ steps.version.outputs.VERSION }}"
+          for repo in \
+            storm-example-java-spring-boot-4 \
+            storm-example-kotlin-spring-boot-4 \
+            storm-example-kotlin-spring-boot-4-graalvm \
+            storm-example-kotlin-ktor \
+            storm-example-kotlin-ktor-graalvm; do
+            git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/storm-orm/${repo}.git" "$repo"
+            sed -i -E "s/(id\(\"st\.orm\"\) version \")[0-9]+\.[0-9]+\.[0-9]+/\1${V}/g" "$repo/build.gradle.kts"
+            git -C "$repo" config user.name "github-actions[bot]"
+            git -C "$repo" config user.email "github-actions[bot]@users.noreply.github.com"
+            if git -C "$repo" diff --quiet; then
+              echo "${repo}: already on ${V}"
+            else
+              git -C "$repo" commit -aqm "chore: bump Storm to ${V}"
+              git -C "$repo" push
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,9 @@ jobs:
   sync-example-templates:
     runs-on: ubuntu-latest
     needs: publish-gradle-plugin
+    # Pushes go through RELEASE_TOKEN, not the default GITHUB_TOKEN, so this job
+    # needs no permissions on its own repository.
+    permissions: {}
     steps:
       - name: Extract version from tag
         id: version
@@ -212,7 +215,9 @@ jobs:
             storm-example-kotlin-ktor \
             storm-example-kotlin-ktor-graalvm; do
             git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/storm-orm/${repo}.git" "$repo"
-            sed -i -E "s/(id\(\"st\.orm\"\) version \")[0-9]+\.[0-9]+\.[0-9]+/\1${V}/g" "$repo/build.gradle.kts"
+            # Replace the whole quoted version so any -SNAPSHOT/-rc suffix is dropped
+            # and the template pins the exact release.
+            sed -i -E "s/(id\(\"st\.orm\"\) version \")[^\"]*(\")/\1${V}\2/g" "$repo/build.gradle.kts"
             git -C "$repo" config user.name "github-actions[bot]"
             git -C "$repo" config user.email "github-actions[bot]@users.noreply.github.com"
             if git -C "$repo" diff --quiet; then

--- a/README.md
+++ b/README.md
@@ -179,9 +179,11 @@ Three complete, runnable **Storm Movies** applications, each importing the publi
 
 | Example | Stack | Repository |
 |---------|-------|------------|
-| [Kotlin + Ktor](https://orm.st/examples/kotlin-ktor) | Kotlin, Ktor 3, Koin, PostgreSQL | [storm-example-kotlin-ktor](https://github.com/storm-orm/storm-example-kotlin-ktor) |
+| [Kotlin + Ktor](https://orm.st/examples/kotlin-ktor) | Kotlin, Ktor 3, Ktor DI, PostgreSQL | [storm-example-kotlin-ktor](https://github.com/storm-orm/storm-example-kotlin-ktor) |
 | [Kotlin + Spring Boot](https://orm.st/examples/kotlin-spring-boot) | Kotlin, Spring Boot 4, PostgreSQL | [storm-example-kotlin-spring-boot-4](https://github.com/storm-orm/storm-example-kotlin-spring-boot-4) |
 | [Java + Spring Boot](https://orm.st/examples/java-spring-boot) | Java 21, Spring Boot 4, PostgreSQL | [storm-example-java-spring-boot-4](https://github.com/storm-orm/storm-example-java-spring-boot-4) |
+
+Each repository is a GitHub template. Click **Use this template** to start your own project: [Kotlin + Ktor](https://github.com/storm-orm/storm-example-kotlin-ktor/generate) · [Kotlin + Spring Boot](https://github.com/storm-orm/storm-example-kotlin-spring-boot-4/generate) · [Java + Spring Boot](https://github.com/storm-orm/storm-example-java-spring-boot-4/generate).
 
 ## Documentation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,8 @@ Storm is a modern SQL Template and ORM framework for Kotlin 2.0+ and Java 21+. I
 
 ## Choose Your Path
 
+> **Fastest start:** each example app is a GitHub template. Click **Use this template** to generate a runnable project, then replace the sample entities with your own: [Kotlin + Ktor](https://github.com/storm-orm/storm-example-kotlin-ktor/generate) · [Kotlin + Spring Boot](https://github.com/storm-orm/storm-example-kotlin-spring-boot-4/generate) · [Java + Spring Boot](https://github.com/storm-orm/storm-example-java-spring-boot-4/generate).
+
 Two ways to get started, and both reach the same working setup: follow the guides by hand, or let your AI coding tool do it. Pick whichever fits your workflow.
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
Finishes the template half of #213. The `storm new` CLI scaffolder is split out into #326.

## Changes

- **README / docs:** "Use this template" links (with `/generate`) to the three starter templates, in the examples table and the getting-started guide. Also fixes a stale stack fact for the Ktor example (Ktor DI, not Koin).
- **release.yml:** new `sync-example-templates` job that rewrites only the `id("st.orm") version` line pinned in each of the five example repos on release, so "Use this template" always starts on the current version. Kotlin / KSP / Ktor toolchain versions are left untouched.

## Notes

- The new job needs `RELEASE_TOKEN` to have write access to the `storm-orm/storm-example-*` repos; today it only pushes the framework docs snapshot. Confirm the token scope (or swap in a token/App that can push to those repos) before relying on it.
- The `getting-started.md` change surfaces at `/docs/next`; live `/docs/*` picks it up at the next release snapshot.

Fixes #213
