### PR TITLE
fix(core): keep value extraction rejected for a primary key reached through a reference

### DIFF
--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -652,7 +652,9 @@ data class Category(
 ) : Entity<Int>
 ```
 
-A `Ref` removes the join from every read but keeps the relationship queryable: you can still filter, order, and select through it with the metamodel (`Category_.parent.name`), and Storm adds the join only for the query that navigates beyond the foreign key. This makes `Ref` the primary tool for keeping wide or deep graphs' reads narrow without giving up type-safe traversal. See [Refs](refs.md) and [Querying Through Refs](refs.md#querying-through-refs) for details.
+A `Ref` removes the join from every read but keeps the relationship queryable: you can still filter, order, and select through it with the metamodel (`Product_.category.name`, where `category` is a `Ref<Category>`), and Storm adds the join only for the query that navigates beyond the foreign key. This makes `Ref` the primary tool for keeping wide or deep graphs' reads narrow without giving up type-safe traversal.
+
+The self-reference above is the one exception. `Category.parent` points back at `Category`, and a table repeated on one path is not given a distinct alias per occurrence, so no navigation is generated past it: `Category_.parent` selects the foreign key column, while `Category_.parent.name` does not compile. Resolve the reference with `fetch()` to walk the chain. See [Refs](refs.md), [Querying Through Refs](refs.md#querying-through-refs) and [Cyclic References](metamodel.md#cyclic-references) for details.
 
 ## Tips
 

--- a/storm-core/src/main/java/st/orm/core/template/impl/MetamodelFactory.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/MetamodelFactory.java
@@ -250,6 +250,7 @@ public final class MetamodelFactory {
         StringBuilder effectiveField;
         boolean inline = false;
         boolean isColumn = false;
+        boolean primaryKeyThroughReference = false;
         Class<?> declaringType;
         boolean fieldNullable;
         boolean fieldIsUnique;
@@ -297,12 +298,17 @@ public final class MetamodelFactory {
             // path means the same thing whether the relationship is declared as an entity or as a reference. Matching
             // on the key therefore does not require the referenced row to exist; join the referenced table explicitly
             // to require that.
+            //
+            // Only the column the query resolves to is rewritten. Value extraction keeps following the requested path,
+            // which still crosses the reference, so reading a value beyond a reference stays rejected for every path
+            // alike instead of handing back the reference itself.
             if (!effectivePath.isEmpty()) {
                 RecordField referenceField = getRecordField(fieldResolutionClass, effectivePath);
                 if (Ref.class.isAssignableFrom(referenceField.type())
                         && isPrimaryKeyName(getRefDataType(referenceField), effectiveField.toString())) {
                     effectiveField = new StringBuilder(referenceField.name());
                     effectivePath = stripLast(effectivePath);
+                    primaryKeyThroughReference = true;
                 }
             }
         } catch (SqlTemplateException e) {
@@ -338,7 +344,9 @@ public final class MetamodelFactory {
         String fullPath = effectivePath.isEmpty()
                 ? effectiveField.toString()
                 : effectivePath + "." + effectiveField;
-        MethodHandle handle = buildGetterHandle(rootTable, fullPath);
+        // The requested path is used for value extraction so that a path crossing a reference keeps its query-only
+        // behavior, even when the column it resolves to was rewritten to the foreign key.
+        MethodHandle handle = buildGetterHandle(rootTable, primaryKeyThroughReference ? path : fullPath);
         // Determine if this field should be a Key metamodel with isNullable() support.
         boolean useKey = false;
         boolean keyNullable = false;

--- a/storm-core/src/test/java/st/orm/core/RefGraphTraversalIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/RefGraphTraversalIntegrationTest.java
@@ -155,10 +155,11 @@ public class RefGraphTraversalIntegrationTest {
         // The reference node itself is a value metamodel (getValue returns the Ref, so getResultGroupedByRef works),
         // but nodes beyond the reference are navigation-only: not TypedMetamodel, so value operations like
         // getResultGroupedBy do not compile against them. This asserts that contract at the type level.
-        assertTrue(PetOwnerRef_.owner instanceof TypedMetamodel);
-        assertTrue(PetOwnerRef_.owner instanceof Navigable);
-        // Assigning to Navigable is itself the proof that the node is navigable; what matters is that it is not a
-        // value metamodel.
+        // The assignments are the contract: the reference node is value-extractable, so it can be held as a
+        // TypedMetamodel, while a node beyond the reference can only be held as a Navigable. The runtime checks then
+        // confirm the beyond-reference node is not a value metamodel.
+        TypedMetamodel<PetOwnerRef, Owner, Ref<Owner>> referenceNode = PetOwnerRef_.owner;
+        assertNotNull(referenceNode);
         Navigable<PetOwnerRef, String> beyond = PetOwnerRef_.owner.address.city.name;
         assertFalse(beyond instanceof Metamodel);
         assertFalse(beyond instanceof TypedMetamodel);
@@ -282,6 +283,21 @@ public class RefGraphTraversalIntegrationTest {
     }
 
     @Test
+    public void testValueExtractionAcrossRefIsRejectedForEveryPath() {
+        var orm = ORMTemplate.of(dataSource);
+        PetOwnerRef pet = orm.entity(PetOwnerRef.class).select()
+                .where(PetOwnerRef_.owner.id, EQUALS, 1).getResultList().getFirst();
+        // The primary key resolves to the foreign key column for querying, but reading a value still follows the
+        // requested path, which crosses the reference. Every path beyond a reference is rejected alike, so the
+        // declared field type is never contradicted by handing back the reference itself.
+        Metamodel<PetOwnerRef, Integer> primaryKey = Metamodel.of(PetOwnerRef.class, "owner.id");
+        assertEquals(Integer.class, primaryKey.fieldType());
+        assertThrows(UnsupportedOperationException.class, () -> primaryKey.getValue(pet));
+        Metamodel<PetOwnerRef, String> otherColumn = Metamodel.of(PetOwnerRef.class, "owner.firstName");
+        assertThrows(UnsupportedOperationException.class, () -> otherColumn.getValue(pet));
+    }
+
+    @Test
     public void testNavigationPastSelfReferentialRefIsRejected() {
         // Navigating past a self-referential reference would join the table to itself, which resolves against the
         // earlier occurrence and yields the wrong row. The path is rejected instead of returning wrong results.
@@ -306,8 +322,4 @@ public class RefGraphTraversalIntegrationTest {
                 .getResultList().stream().map(SelfRefNode::id).sorted().toList();
         assertEquals(List.of(2), ids);
     }
-
-
-
-
 }

--- a/storm-foundation/src/main/java/st/orm/Navigable.java
+++ b/storm-foundation/src/main/java/st/orm/Navigable.java
@@ -117,9 +117,10 @@ public interface Navigable<T extends Data, E> {
     }
 
     /**
-     * Returns a flat list of leaf metamodels for this navigable. If this navigable is not an inline record, it returns a
-     * singleton list containing the canonical column metamodel; if it is an inline record, it recursively expands all
-     * nested inline records into their individual column metamodels.
+     * Returns a flat list of leaf metamodels for this navigable. If this navigable is not an inline record, it returns
+     * a singleton list containing the column metamodel for this path; if it is an inline record, it recursively expands
+     * all nested inline records into their individual column metamodels. The returned metamodels keep their position in
+     * the graph, so they are not canonical.
      *
      * <p>Useful for ORDER BY and GROUP BY, where inline records must be expanded into their individual columns.</p>
      *

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -18,7 +18,7 @@
 > GitHub: https://github.com/storm-orm/storm-framework
 > License: Apache 2.0
 
-# Generated: 2026-07-26T18:13:43Z
+# Generated: 2026-07-26T19:08:29Z
 
 ========================================
 ## Source: index.md
@@ -3069,7 +3069,9 @@ data class Category(
 ) : Entity<Int>
 ```
 
-A `Ref` removes the join from every read but keeps the relationship queryable: you can still filter, order, and select through it with the metamodel (`Category_.parent.name`), and Storm adds the join only for the query that navigates beyond the foreign key. This makes `Ref` the primary tool for keeping wide or deep graphs' reads narrow without giving up type-safe traversal. See [Refs](refs.md) and [Querying Through Refs](refs.md#querying-through-refs) for details.
+A `Ref` removes the join from every read but keeps the relationship queryable: you can still filter, order, and select through it with the metamodel (`Product_.category.name`, where `category` is a `Ref<Category>`), and Storm adds the join only for the query that navigates beyond the foreign key. This makes `Ref` the primary tool for keeping wide or deep graphs' reads narrow without giving up type-safe traversal.
+
+The self-reference above is the one exception. `Category.parent` points back at `Category`, and a table repeated on one path is not given a distinct alias per occurrence, so no navigation is generated past it: `Category_.parent` selects the foreign key column, while `Category_.parent.name` does not compile. Resolve the reference with `fetch()` to walk the chain. See [Refs](refs.md), [Querying Through Refs](refs.md#querying-through-refs) and [Cyclic References](metamodel.md#cyclic-references) for details.
 
 ## Tips
 

--- a/website/static/skills/storm-entity-java.md
+++ b/website/static/skills/storm-entity-java.md
@@ -42,7 +42,7 @@ Generation rules:
 4. Foreign keys (\`@FK\`):
    - **Every column with a FK constraint in the database must be modeled with `@FK` in the entity.** Without `@FK`, Storm has no FK metadata and cannot resolve joins automatically — forcing template-based joins that defeat the QueryBuilder.
    - Prefer full entity types (`@FK City city`) over `Ref<T>` (`@FK Ref<City> city`) for small graphs the reads generally need loaded. Full entities load the related data in one query with automatic JOINs.
-   - Use `Ref<T>` when the entity hierarchy gets too deep or wide, or when loading the full related entity is overkill for most reads. A `Ref` removes the eager join from every query but stays queryable: filter, order, and select through it with the metamodel (`City_.country.name`), and Storm adds the join only for the query that navigates beyond the foreign key. Choosing `Ref` therefore prevents join fan-out without giving up type-safe traversal.
+   - Use `Ref<T>` when the entity hierarchy gets too deep or wide, or when loading the full related entity is overkill for most reads. A `Ref` removes the eager join from every query but stays queryable: filter, order, and select through it with the metamodel from the owning entity (`User_.city.country.name`, where `city` is a `Ref<City>`), and Storm adds the join only for the query that navigates beyond the foreign key. Choosing `Ref` therefore prevents join fan-out without giving up type-safe traversal.
    - Non-nullable: \`@FK City city\` produces INNER JOIN (non-null is the default).
    - Nullable: \`@Nullable @FK City city\` produces LEFT JOIN.
    - **A bare \`@FK City city\` is non-null and produces an INNER JOIN.**

--- a/website/static/skills/storm-entity-kotlin.md
+++ b/website/static/skills/storm-entity-kotlin.md
@@ -32,7 +32,7 @@ Generation rules:
 3. Foreign keys (\`@FK\`):
    - **Every column with a FK constraint in the database must be modeled with `@FK` in the entity.** Without `@FK`, Storm has no FK metadata and cannot resolve joins automatically — forcing template-based joins that defeat the QueryBuilder.
    - Prefer full entity types (`@FK val city: City`) over `Ref<T>` (`@FK val city: Ref<City>`) for small graphs the reads generally need loaded. Full entities load the related data in one query with automatic JOINs.
-   - Use `Ref<T>` when the entity hierarchy gets too deep or wide, or when loading the full related entity is overkill for most reads. A `Ref` removes the eager join from every query but stays queryable: filter, order, and select through it with the metamodel (`City_.country.name`), and Storm adds the join only for the query that navigates beyond the foreign key. Choosing `Ref` therefore prevents join fan-out without giving up type-safe traversal.
+   - Use `Ref<T>` when the entity hierarchy gets too deep or wide, or when loading the full related entity is overkill for most reads. A `Ref` removes the eager join from every query but stays queryable: filter, order, and select through it with the metamodel from the owning entity (`User_.city.country.name`, where `city` is a `Ref<City>`), and Storm adds the join only for the query that navigates beyond the foreign key. Choosing `Ref` therefore prevents join fan-out without giving up type-safe traversal.
    - Non-nullable \`@FK val city: City\` produces INNER JOIN.
    - Nullable \`@FK val city: City?\` produces LEFT JOIN.
    - For entities with `Ref<T>` FK fields, add a secondary constructor that accepts the entities and converts them — client code then never constructs refs by hand:


### PR DESCRIPTION
Follow-up to #332, addressing review feedback that arrived on that pull request.

## Value extraction contradicted the declared type

The primary key reached through a reference resolves to the foreign key column, so querying it needs no join. That rewrite also reached the getter, so the metamodel declared the key type while `getValue` handed back the reference:

```java
Metamodel.of(PetOwnerRef.class, "owner.id")   // fieldType() == Integer.class
    .getValue(pet)                            // returned a Ref, not an Integer
```

Any caller assigning that to the declared type gets a `ClassCastException`. Every other path beyond a reference already rejected value extraction, so this was the one inconsistency.

Value extraction now follows the requested path, which still crosses the reference, so `owner.id` is rejected exactly like `owner.firstName`. Column resolution is untouched, so the no-join behavior for the key is unchanged. A test pins both halves: `fieldType()` stays the key type, and `getValue` throws for the key path and for any other column of the target.

## Documentation that did not match the implementation

- `docs/relationships.md` navigated `Category_.parent.name`, but `parent` is a self-referential `Ref` and those generate no navigation children, so that path does not compile. The example now navigates a reference to a different table and states the self-reference exception explicitly.
- Both entity skills illustrated reference navigation with `City_.country.name`, which starts from `City_` and does not demonstrate the feature. They now start from the entity that declares the foreign key.
- `Navigable.flatten()` claimed to return the canonical metamodel; the returned metamodels keep their position in the graph.

## Not changed

The scanner also flagged `case Navigable<?, ?> ignore ->` as an unread variable, suggesting the unnamed `_` pattern. `ignore` is the convention here, used in 56 places, and that line already read `ignore` before it was widened. Switching one instance would make it inconsistent; adopting `_` is a repository-wide decision for its own change.

## Validation

storm-core 2369, storm-kotlin 1639, zero failures, Spotless clean.