### PR TITLE
docs(gradle): document the plugin's public API completely

### DIFF
--- a/storm-gradle-plugin/src/main/java/st/orm/gradle/PreviewArgs.java
+++ b/storm-gradle-plugin/src/main/java/st/orm/gradle/PreviewArgs.java
@@ -32,6 +32,11 @@ public final class PreviewArgs implements CommandLineArgumentProvider {
         this.enabled = enabled;
     }
 
+    /**
+     * Whether the preview arguments are contributed to the task they are attached to.
+     *
+     * @return whether preview arguments are enabled.
+     */
     @Input
     public Provider<Boolean> getEnabled() {
         return enabled;

--- a/storm-gradle-plugin/src/main/java/st/orm/gradle/StormExtension.java
+++ b/storm-gradle-plugin/src/main/java/st/orm/gradle/StormExtension.java
@@ -32,27 +32,41 @@ import org.gradle.api.provider.Property;
 public abstract class StormExtension {
 
     /**
+     * Creates the extension. Gradle instantiates this type through its object factory.
+     */
+    public StormExtension() {
+    }
+
+    /**
      * Whether to wire the metamodel processor: {@code storm-metamodel-ksp} on the {@code ksp} configuration
      * for Kotlin projects, {@code storm-metamodel-processor} on {@code annotationProcessor} for Java
      * projects. Default {@code true}.
+     *
+     * @return whether the metamodel processor is wired.
      */
     public abstract Property<Boolean> getMetamodel();
 
     /**
      * Whether to add the Storm Kotlin compiler plugin, which makes string interpolations inside SQL template
      * lambdas injection-safe automatically. Kotlin projects only. Default {@code true}.
+     *
+     * @return whether the Kotlin compiler plugin is added.
      */
     public abstract Property<Boolean> getCompilerPlugin();
 
     /**
      * Overrides the auto-detected compiler-plugin variant (the Kotlin major.minor suffix, such as
      * {@code "2.4"}). Set this when the project uses a Kotlin version newer than the plugin knows about.
+     *
+     * @return the compiler-plugin variant to use instead of the auto-detected one.
      */
     public abstract Property<String> getCompilerPluginVariant();
 
     /**
      * Whether to add {@code --enable-preview} to Java compilation, tests, and execution, required by
      * storm-java21's String Templates on JDK 21. Java projects only. Default {@code true}.
+     *
+     * @return whether preview features are enabled for Java compilation, tests, and execution.
      */
     public abstract Property<Boolean> getJavaPreview();
 }

--- a/storm-gradle-plugin/src/main/java/st/orm/gradle/StormPlugin.java
+++ b/storm-gradle-plugin/src/main/java/st/orm/gradle/StormPlugin.java
@@ -41,6 +41,12 @@ import org.gradle.api.tasks.testing.Test;
  */
 public class StormPlugin implements Plugin<Project> {
 
+    /**
+     * Creates the plugin. Gradle instantiates this type when the plugin is applied.
+     */
+    public StormPlugin() {
+    }
+
     private static final String KOTLIN_JVM_PLUGIN_ID = "org.jetbrains.kotlin.jvm";
     private static final String KSP_PLUGIN_ID = "com.google.devtools.ksp";
 


### PR DESCRIPTION
The Gradle plugin build reported seven javadoc warnings, so the javadoc jar published to Maven Central shipped with gaps in the plugin's public API documentation.

- `StormExtension` property accessors (`getMetamodel`, `getCompilerPlugin`, `getCompilerPluginVariant`, `getJavaPreview`) documented what each option does but had no return tag.
- `StormExtension` and `StormPlugin` relied on an implicit constructor, which javadoc reports as undocumented. Both now declare one, noting that Gradle instantiates the type.
- `PreviewArgs.getEnabled()` had no comment at all.

No behavior changes; documentation only.

`./gradlew clean javadocJar` completes with no warnings.