### PR TITLE
fix(metamodel): qualify generated navigation metamodel names by package

### DIFF
--- a/storm-core/src/test/java/st/orm/core/CrossPackageMetamodelTest.java
+++ b/storm-core/src/test/java/st/orm/core/CrossPackageMetamodelTest.java
@@ -2,7 +2,6 @@ package st.orm.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import st.orm.Metamodel;
@@ -24,10 +23,9 @@ public class CrossPackageMetamodelTest {
 
     @Test
     public void navigatesPastAReferenceIntoAnInlineRecordFromAnotherPackage() {
+        // Holding the node as a Navigable is the contract; what remains to check is that it is not a value metamodel.
         Navigable<?, String> label = CrossPackageHolder_.owner.details.label;
         assertEquals("owner.details.label", label.fieldPath());
-        // Beyond a reference the node is navigation-only, matching every other reference.
-        assertTrue(label instanceof Navigable);
         assertFalse(label instanceof Metamodel);
     }
 }

--- a/storm-core/src/test/java/st/orm/core/CrossPackageMetamodelTest.java
+++ b/storm-core/src/test/java/st/orm/core/CrossPackageMetamodelTest.java
@@ -1,0 +1,33 @@
+package st.orm.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import st.orm.Metamodel;
+import st.orm.Navigable;
+import st.orm.core.model.CrossPackageHolder_;
+
+/**
+ * A record declared outside the package of the entity that embeds it is referred to by its qualified name in the
+ * generated metamodels. Navigating into such a record, and past a reference into one, therefore exercises how the
+ * generated class names are qualified.
+ */
+public class CrossPackageMetamodelTest {
+
+    @Test
+    public void navigatesIntoAnInlineRecordFromAnotherPackage() {
+        assertEquals("details.label", CrossPackageHolder_.details.label.fieldPath());
+        assertEquals("details.score", CrossPackageHolder_.details.score.fieldPath());
+    }
+
+    @Test
+    public void navigatesPastAReferenceIntoAnInlineRecordFromAnotherPackage() {
+        Navigable<?, String> label = CrossPackageHolder_.owner.details.label;
+        assertEquals("owner.details.label", label.fieldPath());
+        // Beyond a reference the node is navigation-only, matching every other reference.
+        assertTrue(label instanceof Navigable);
+        assertFalse(label instanceof Metamodel);
+    }
+}

--- a/storm-core/src/test/java/st/orm/core/model/CrossPackageHolder.java
+++ b/storm-core/src/test/java/st/orm/core/model/CrossPackageHolder.java
@@ -1,0 +1,20 @@
+package st.orm.core.model;
+
+import jakarta.annotation.Nullable;
+import st.orm.DbTable;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+import st.orm.Ref;
+import st.orm.core.model.crosspackage.CrossPackageDetails;
+
+/**
+ * Embeds an inline record from another package, and references an entity that does the same, so the generated
+ * navigation metamodels have to qualify those types.
+ */
+@DbTable("cross_package_holder")
+public record CrossPackageHolder(
+        @PK Integer id,
+        @Nullable CrossPackageDetails details,
+        @Nullable @FK Ref<CrossPackageOwner> owner
+) implements Entity<Integer> {}

--- a/storm-core/src/test/java/st/orm/core/model/CrossPackageOwner.java
+++ b/storm-core/src/test/java/st/orm/core/model/CrossPackageOwner.java
@@ -1,0 +1,16 @@
+package st.orm.core.model;
+
+import jakarta.annotation.Nullable;
+import st.orm.DbTable;
+import st.orm.Entity;
+import st.orm.PK;
+import st.orm.core.model.crosspackage.CrossPackageDetails;
+
+/**
+ * Reached through a reference, so its own cross-package inline record is expanded into navigation metamodels.
+ */
+@DbTable("cross_package_owner")
+public record CrossPackageOwner(
+        @PK Integer id,
+        @Nullable CrossPackageDetails details
+) implements Entity<Integer> {}

--- a/storm-core/src/test/java/st/orm/core/model/crosspackage/CrossPackageDetails.java
+++ b/storm-core/src/test/java/st/orm/core/model/crosspackage/CrossPackageDetails.java
@@ -1,0 +1,12 @@
+package st.orm.core.model.crosspackage;
+
+import jakarta.annotation.Nullable;
+
+/**
+ * An inline record declared outside the package of the entity that embeds it, so the generated metamodels refer to it
+ * by its qualified name.
+ */
+public record CrossPackageDetails(
+        @Nullable String label,
+        @Nullable Integer score
+) {}

--- a/storm-core/src/test/resources/data.sql
+++ b/storm-core/src/test/resources/data.sql
@@ -14,6 +14,8 @@ drop table if exists vet_badge CASCADE;
 drop table if exists vet_specialty CASCADE;
 drop table if exists visit CASCADE;
 drop table if exists self_ref_node CASCADE;
+drop table if exists cross_package_holder CASCADE;
+drop table if exists cross_package_owner CASCADE;
 
 create table city (id integer auto_increment, name varchar(255), primary key (id));
 create table owner (id integer auto_increment, first_name varchar(255), last_name varchar(255), address varchar(255), city_id integer, telephone varchar(255), primary key (id), version integer default 0);
@@ -48,6 +50,9 @@ alter table appointment_report add constraint appointment_report_appointment_fk 
 alter table appointment_report_review add constraint appointment_report_review_report_fk foreign key (appointment_report_id) references appointment_report (appointment_id);
 create table self_ref_node (id integer auto_increment, name varchar(255), parent_id integer, primary key (id));
 alter table self_ref_node add constraint self_ref_node_parent_fk foreign key (parent_id) references self_ref_node (id);
+create table cross_package_owner (id integer auto_increment, label varchar(255), score integer, primary key (id));
+create table cross_package_holder (id integer auto_increment, label varchar(255), score integer, owner_id integer, primary key (id));
+alter table cross_package_holder add constraint cross_package_holder_owner_fk foreign key (owner_id) references cross_package_owner (id);
 create view owner_view as select * from owner;
 create view visit_view as select visit_date, description, pet_id, "timestamp" from visit;
 

--- a/storm-metamodel-ksp/src/main/kotlin/st/orm/metamodel/MetamodelProcessor.kt
+++ b/storm-metamodel-ksp/src/main/kotlin/st/orm/metamodel/MetamodelProcessor.kt
@@ -1053,7 +1053,7 @@ class MetamodelProcessor(
             builder.append("    /** Represents navigation to $className.$fieldName. */\n")
             if ((record || ref) && !isCyclicNavChild(typeRef)) {
                 val simpleTypeName = getSimpleTypeName(typeRef, packageName)
-                builder.append("    val $fieldName: Navigable${simpleTypeName}Metamodel<T>\n")
+                builder.append("    val $fieldName: ${navClassName(simpleTypeName)}<T>\n")
             } else {
                 // Scalar column, or a cyclic navigation edge broken to a leaf.
                 val kotlinTypeName = getKotlinTypeName(typeRef, packageName)
@@ -1075,7 +1075,7 @@ class MetamodelProcessor(
                 val simpleTypeName = getSimpleTypeName(typeRef, packageName)
                 val inlineFlag = if (record && !isDataType(prop)) "true" else "false"
                 builder.append(
-                    "        this.$fieldName = Navigable${simpleTypeName}Metamodel(subPath, fieldBase + \"$fieldName\", $inlineFlag, this)\n",
+                    "        this.$fieldName = ${navClassName(simpleTypeName)}(subPath, fieldBase + \"$fieldName\", $inlineFlag, this)\n",
                 )
             } else {
                 // Scalar column, or a cyclic navigation edge broken to a leaf so eager construction terminates.
@@ -1091,6 +1091,19 @@ class MetamodelProcessor(
         return builder.toString()
     }
 
+    /**
+     * Returns the navigation metamodel class name for a type name. The type name is qualified when the type is
+     * declared in another package, and the navigation metamodel is generated into that same package, so the prefix
+     * applies to the simple name and the qualifier is preserved.
+     */
+    private fun navClassName(typeName: String): String {
+        val lastDot = typeName.lastIndexOf('.')
+        return if (lastDot < 0) {
+            "Navigable${typeName}Metamodel"
+        } else {
+            typeName.substring(0, lastDot + 1) + "Navigable" + typeName.substring(lastDot + 1) + "Metamodel"
+        }
+    }
     private fun generateNavigableMetamodelClass(classDeclaration: KSClassDeclaration) {
         val packageName = classDeclaration.packageName.asString()
         val className = classDeclaration.simpleName.asString()

--- a/storm-metamodel-processor/src/main/java/st/orm/metamodel/MetamodelProcessor.java
+++ b/storm-metamodel-processor/src/main/java/st/orm/metamodel/MetamodelProcessor.java
@@ -1319,8 +1319,16 @@ public final class MetamodelProcessor extends AbstractProcessor {
         return recordName + "RefMetamodel";
     }
 
+    /**
+     * Returns the navigation metamodel class name for a record name. The record name is qualified when the record is
+     * declared in another package, and the navigation metamodel is generated into that same package, so the prefix
+     * applies to the simple name and the qualifier is preserved.
+     */
     private static String navClassName(@Nonnull String recordName) {
-        return "Navigable" + recordName + "Metamodel";
+        int lastDot = recordName.lastIndexOf('.');
+        return lastDot < 0
+                ? "Navigable" + recordName + "Metamodel"
+                : recordName.substring(0, lastDot + 1) + "Navigable" + recordName.substring(lastDot + 1) + "Metamodel";
     }
 
     private static TypeMirror unwrapRefType(@Nonnull TypeMirror fieldType) {


### PR DESCRIPTION
The navigation metamodels introduced in #332 do not compile when a model spans more than one package, which makes the generated metamodel unusable for most real projects.

## What happens

The navigation metamodel name is built by prefixing a type name with `Navigable`. That type name is fully qualified whenever the type is declared in another package, so the prefix lands in front of the qualifier:

```
Navigable + com.example.model.detail.Details + Metamodel
= Navigablecom.example.model.detail.DetailsMetamodel
```

which fails to compile:

```
e: NavigableUserMetamodel.kt:39:32 Unresolved reference 'Navigablecom'.
e: UserRefMetamodel.kt:46:32 Unresolved reference 'Navigablecom'.
```

The navigation metamodel is generated into the referenced type's own package, so the prefix belongs on the simple name and the qualifier has to be preserved: `com.example.model.detail.NavigableDetailsMetamodel`.

Both the annotation processor and KSP built the name this way. The reference metamodel name is a *suffix*, so `com.example.User` + `RefMetamodel` already produced a valid name and was unaffected.

## Why no test caught it

Every test model is declared in one package, so no test ever referred to a type from another package and the qualified form was never generated. This adds a holder that embeds an inline record from a sibling package, covered both directly (`CrossPackageHolder_.details.label`) and through a reference (`CrossPackageHolder_.owner.details.label`), which is where the failure showed up first.

A generated metamodel that does not compile cannot be caught by a test that never generates it, so the fixtures now include a cross-package model permanently.

## Verification

storm-core 2376, storm-kotlin 1640, zero failures, Spotless clean.

Beyond the repository's own tests, a downstream Kotlin project with a multi-package model now compiles its KSP-generated metamodels successfully; before this change its build failed on the errors above.