### PR TITLE
fix(core): resolve a self-referencing table to the occurrence navigated to

### DIFF
--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -181,7 +181,7 @@ Short form uses the target table's metamodel directly:
 Country_.name eq "United States"
 ```
 
-Short form works **only when the table appears exactly once** in the entity graph. If `Country` is referenced in multiple places, Storm cannot determine which one you mean.
+Short form works when the entity graph holds **one occurrence of the table that you could mean**. If `Country` is referenced from two different places, Storm cannot determine which one you mean.
 
 **Example where short form works:**
 
@@ -295,8 +295,8 @@ val users = orm.entity<User>()
 When resolving a metamodel reference, Storm follows this order:
 
 1. **Nested path.** If a path is specified (e.g., `User_.city.country`), use the alias for that specific traversal.
-2. **Unique table lookup.** If short form (e.g., `Country_`), check if the table appears exactly once in the entity graph or registered joins.
-3. **Error.** If multiple paths exist, throw an exception indicating the ambiguity.
+2. **Unique table lookup.** If short form (e.g., `Country_`), check whether the entity graph or registered joins hold a single occurrence of the table that you could mean.
+3. **Error.** If more than one distinct occurrence exists, throw an exception indicating the ambiguity.
 
 ### Best Practices
 

--- a/storm-core/src/main/java/st/orm/core/template/impl/AliasMapper.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/AliasMapper.java
@@ -53,9 +53,9 @@ final class AliasMapper {
     record TableAlias(Class<? extends Data> table, String path, String alias) {}
 
     /**
-     * Alias entry with its nesting level: 0=current, 1=parent, etc.
+     * Alias entry with the path it was registered under and its nesting level: 0=current, 1=parent, etc.
      */
-    private record AliasEntry(String alias, int level) {}
+    private record AliasEntry(String alias, @Nullable String path, int level) {}
 
     AliasMapper(@Nonnull TableUse tableUse,
                 @Nonnull TableAliasResolver tableAliasResolver,
@@ -103,7 +103,7 @@ final class AliasMapper {
         // Current level matches.
         var local = aliasMap.getOrDefault(table, List.of()).stream()
                 .filter(ta -> path == null || Objects.equals(path, ta.path()))
-                .map(ta -> new AliasEntry(ta.alias(), level));
+                .map(ta -> new AliasEntry(ta.alias(), ta.path(), level));
         // Recurse to parent if present.
         var parentStream = parent == null
                 ? Stream.<AliasEntry>empty()
@@ -260,6 +260,101 @@ final class AliasMapper {
         return Optional.ofNullable(selected);
     }
 
+    /**
+     * Returns the only occurrence at {@code level} that was reached without passing the same table twice, or
+     * {@code null} when that does not single one out.
+     *
+     * <p>Going around a cycle registers an occurrence whose path revisits a table it already passed through, and such
+     * a repetition is never what a caller naming the table by type meant: it is only reachable by continuing past the
+     * occurrence that was navigated to. Occurrences reached along genuinely separate branches revisit nothing, so they
+     * all survive here and remain ambiguous, as do two occurrences registered under the same path.</p>
+     *
+     * @param entries the alias entries to consider.
+     * @param level the nesting level to resolve within.
+     * @return the single occurrence reached without repeating a table, or {@code null} when there is not exactly one.
+     */
+    @Nullable
+    private AliasEntry findOccurrenceWithoutRepeatedTable(@Nonnull List<AliasEntry> entries, int level) {
+        var pathToTable = mapperAtLevel(level).registeredTablesByPath();
+        AliasEntry found = null;
+        for (var candidate : entries) {
+            if (candidate.level() != level || revisitsTable(candidate.path(), pathToTable)) {
+                continue;
+            }
+            if (found != null) {
+                // More than one occurrence was reached without going around a cycle.
+                return null;
+            }
+            found = candidate;
+        }
+        return found;
+    }
+
+    /**
+     * Returns whether the given path passes the same table more than once, which is what a trip around a cycle in the
+     * table graph produces. A path that is absent or empty passes nothing and never repeats.
+     */
+    private static boolean revisitsTable(@Nullable String path,
+                                         @Nonnull Map<String, Class<? extends Data>> pathToTable) {
+        if (path == null || path.isEmpty()) {
+            return false;
+        }
+        var visited = new HashSet<Class<? extends Data>>();
+        // Every path starts at the root, which is registered under the empty path, so a path that arrives back at the
+        // root table has gone around a cycle just as one that returns to a table it joined along the way.
+        var rootTable = pathToTable.get("");
+        if (rootTable != null) {
+            visited.add(rootTable);
+        }
+        var prefix = new StringBuilder();
+        for (var component : path.split("\\.")) {
+            if (!prefix.isEmpty()) {
+                prefix.append('.');
+            }
+            prefix.append(component);
+            // Components that do not name a table of their own, such as inline records, register no alias and simply
+            // extend the path towards the table that follows them.
+            var table = pathToTable.get(prefix.toString());
+            if (table != null && !visited.add(table)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the table registered at each path at this level. A path carrying more than one table cannot place that
+     * path in the graph and is left out, which only makes {@link #revisitsTable} less willing to report a repeat.
+     */
+    private Map<String, Class<? extends Data>> registeredTablesByPath() {
+        var tablesByPath = new HashMap<String, Class<? extends Data>>();
+        var ambiguousPaths = new HashSet<String>();
+        for (var entry : aliasMap.entrySet()) {
+            for (var tableAlias : entry.getValue()) {
+                var registeredPath = tableAlias.path();
+                if (registeredPath == null) {
+                    continue;
+                }
+                var existing = tablesByPath.putIfAbsent(registeredPath, entry.getKey());
+                if (existing != null && !existing.equals(entry.getKey())) {
+                    ambiguousPaths.add(registeredPath);
+                }
+            }
+        }
+        tablesByPath.keySet().removeAll(ambiguousPaths);
+        return tablesByPath;
+    }
+
+    /** Returns the mapper {@code level} steps up the parent chain, or the outermost one when the chain is shorter. */
+    @Nonnull
+    private AliasMapper mapperAtLevel(int level) {
+        var mapper = this;
+        for (int step = 0; step < level && mapper.parent != null; step++) {
+            mapper = mapper.parent;
+        }
+        return mapper;
+    }
+
     public Optional<String> findAlias(@Nonnull Class<? extends Data> table,
                                       @Nullable String path,
                                       @Nonnull ResolveScope scope) throws SqlTemplateException {
@@ -277,8 +372,16 @@ final class AliasMapper {
         var entry = filtered.getFirst();
         if (filtered.size() > 1) {
             if (filtered.get(1).level() == entry.level()) {
-                // Multiple aliases found at the same level.
-                throw multipleFoundException(table, path, scope == INNER ? CASCADE : scope);
+                // A table reachable from itself registers one occurrence per hop around the cycle, for instance an
+                // entity holding a foreign key on a record that refers back to that entity. Resolving by type then
+                // yields the occurrence that was navigated to, since every other one is only reachable by passing
+                // that same table again. Occurrences that are genuinely distinct, such as two foreign keys onto the
+                // same table from different branches, pass nothing twice and stay ambiguous.
+                var withoutRepeat = findOccurrenceWithoutRepeatedTable(filtered, entry.level());
+                if (withoutRepeat == null) {
+                    throw multipleFoundException(table, path, scope == INNER ? CASCADE : scope);
+                }
+                entry = withoutRepeat;
             }
         }
         if (entry.level() == 0) {

--- a/storm-core/src/test/java/st/orm/core/SelfReferencingTableResolutionIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/SelfReferencingTableResolutionIntegrationTest.java
@@ -1,0 +1,109 @@
+package st.orm.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static st.orm.Operator.IN;
+import static st.orm.core.template.TemplateString.raw;
+
+import java.time.LocalDate;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.core.model.Country;
+import st.orm.core.model.User;
+import st.orm.core.model.UserScore;
+import st.orm.core.model.UserScore_;
+import st.orm.core.template.ORMTemplate;
+
+/**
+ * A table that is reachable from itself occurs more than once in the table graph: once where the query navigated to it,
+ * and once more for every trip around the cycle. Country is reachable from itself through its capital and its largest
+ * city, both of which refer back to the country they lie in, so a query rooted at a user's score sees country at
+ * {@code user.country}, at {@code user.country.capital.country} and at {@code user.country.largestCity.country}.
+ *
+ * <p>Selecting the country by type has to pick one of those. The occurrence the query navigated to is the only one the
+ * caller can have meant, since the others are only reachable by passing the country again.</p>
+ */
+@SuppressWarnings("ALL")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IntegrationConfig.class)
+@DataJpaTest(showSql = false)
+public class SelfReferencingTableResolutionIntegrationTest {
+
+    /** Aggregate over user scores, per country and date. */
+    public record CountryScoreRow(Country country, LocalDate scoreDate, long scoreCount, double averageScore) {}
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    public void testSelectSelfReferencingTableByTypeInAggregate() {
+        var orm = ORMTemplate.of(dataSource);
+        // Country is named by type in the select clause while the grouping names it by path. Both have to land on the
+        // occurrence at user.country rather than on one of the two reached by going around the cycle.
+        List<CountryScoreRow> rows = orm.entity(UserScore.class)
+                .select(CountryScoreRow.class,
+                        raw("\0, \0, COUNT(*), AVG(\0)", Country.class, UserScore_.scoreDate, UserScore_.score))
+                .where(UserScore_.scoreDate, IN, List.of(LocalDate.of(2026, 7, 25), LocalDate.of(2026, 7, 26)))
+                .groupBy(UserScore_.user.country, UserScore_.scoreDate)
+                .getResultList();
+        // Three (country, date) groups: the Netherlands on both dates, Belgium on the first.
+        assertEquals(3, rows.size());
+        rows.forEach(row -> assertNotNull(row.country()));
+        var netherlandsOnTheFirstDate = rows.stream()
+                .filter(row -> "Netherlands".equals(row.country().name()))
+                .filter(row -> LocalDate.of(2026, 7, 25).equals(row.scoreDate()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(2, netherlandsOnTheFirstDate.scoreCount());
+        assertEquals(0.30, netherlandsOnTheFirstDate.averageScore(), 1e-9);
+    }
+
+    @Test
+    public void testSelectedCountryIsTheOneTheUserLivesIn() {
+        var orm = ORMTemplate.of(dataSource);
+        // The country selected by type is the one the user lives in, not a country reached back through a city.
+        List<CountryScoreRow> rows = orm.entity(UserScore.class)
+                .select(CountryScoreRow.class,
+                        raw("\0, \0, COUNT(*), AVG(\0)", Country.class, UserScore_.scoreDate, UserScore_.score))
+                .groupBy(UserScore_.user.country, UserScore_.scoreDate)
+                .getResultList();
+        var userCountryIds = orm.entity(User.class).select().getResultList().stream()
+                .map(user -> user.country().id())
+                .distinct()
+                .sorted()
+                .toList();
+        var selectedCountryIds = rows.stream().map(row -> row.country().id()).distinct().sorted().toList();
+        assertFalse(selectedCountryIds.isEmpty());
+        assertTrue(userCountryIds.containsAll(selectedCountryIds));
+    }
+
+    @Test
+    public void testSelectSelfReferencingTableAsRoot() {
+        var orm = ORMTemplate.of(dataSource);
+        // Reading the country itself still works: the root occurrence is the one reached without passing it twice.
+        var countries = orm.entity(Country.class).select().getResultList();
+        assertEquals(2, countries.size());
+        countries.forEach(country -> {
+            assertNotNull(country.capital());
+            assertNotNull(country.largestCity());
+        });
+    }
+
+    @Test
+    public void testNavigatingBeyondTheCycleStillResolvesByPath() {
+        var orm = ORMTemplate.of(dataSource);
+        // Naming the far side of the cycle by path is unambiguous and keeps working.
+        var scores = orm.entity(UserScore.class).select()
+                .where(UserScore_.user.country.capital.name, st.orm.Operator.EQUALS, "Amsterdam")
+                .getResultList();
+        assertEquals(3, scores.size());
+    }
+}

--- a/storm-core/src/test/java/st/orm/core/model/CapitalCity.java
+++ b/storm-core/src/test/java/st/orm/core/model/CapitalCity.java
@@ -1,0 +1,19 @@
+package st.orm.core.model;
+
+import jakarta.annotation.Nonnull;
+import st.orm.DbTable;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+import st.orm.Ref;
+
+/**
+ * The city that is a country's capital, holding the country it lies in as a reference. Together with
+ * {@link LargestCity} it gives the country two separate ways back to itself.
+ */
+@DbTable("country_city")
+public record CapitalCity(
+        @PK Integer id,
+        @Nonnull String name,
+        @Nonnull @FK Ref<Country> country
+) implements Entity<Integer> {}

--- a/storm-core/src/test/java/st/orm/core/model/Country.java
+++ b/storm-core/src/test/java/st/orm/core/model/Country.java
@@ -1,0 +1,20 @@
+package st.orm.core.model;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+
+/**
+ * A country that is reachable from itself. Its capital and its largest city are ordinary foreign keys, so a read of a
+ * country brings them along, and each of them refers back to the country it lies in. Resolving the country table by
+ * type from a query that navigated to it therefore has to choose between the country itself and the two occurrences
+ * reached by continuing around the cycle.
+ */
+public record Country(
+        @PK Integer id,
+        @Nonnull String name,
+        @Nullable @FK CapitalCity capital,
+        @Nullable @FK LargestCity largestCity
+) implements Entity<Integer> {}

--- a/storm-core/src/test/java/st/orm/core/model/LargestCity.java
+++ b/storm-core/src/test/java/st/orm/core/model/LargestCity.java
@@ -1,0 +1,16 @@
+package st.orm.core.model;
+
+import jakarta.annotation.Nonnull;
+import st.orm.DbTable;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+import st.orm.Ref;
+
+/** The most populous city of a country, holding the country it lies in as a reference. */
+@DbTable("country_city")
+public record LargestCity(
+        @PK Integer id,
+        @Nonnull String name,
+        @Nonnull @FK Ref<Country> country
+) implements Entity<Integer> {}

--- a/storm-core/src/test/java/st/orm/core/model/User.java
+++ b/storm-core/src/test/java/st/orm/core/model/User.java
@@ -1,0 +1,15 @@
+package st.orm.core.model;
+
+import jakarta.annotation.Nonnull;
+import st.orm.DbTable;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+
+/** A user living in a country. Mapped to app_user because user is a reserved word in several databases. */
+@DbTable("app_user")
+public record User(
+        @PK Integer id,
+        @Nonnull String name,
+        @Nonnull @FK Country country
+) implements Entity<Integer> {}

--- a/storm-core/src/test/java/st/orm/core/model/UserScore.java
+++ b/storm-core/src/test/java/st/orm/core/model/UserScore.java
@@ -1,0 +1,18 @@
+package st.orm.core.model;
+
+import jakarta.annotation.Nonnull;
+import java.time.LocalDate;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+
+/**
+ * A dated score for a user. Aggregating these per country and date reaches the country table through the user, two
+ * foreign keys away from this record.
+ */
+public record UserScore(
+        @PK Integer id,
+        @Nonnull @FK User user,
+        @Nonnull LocalDate scoreDate,
+        double score
+) implements Entity<Integer> {}

--- a/storm-core/src/test/java/st/orm/core/template/impl/AliasMapperSelfReferenceTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/AliasMapperSelfReferenceTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.template.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static st.orm.ResolveScope.CASCADE;
+
+import org.junit.jupiter.api.Test;
+import st.orm.core.model.City;
+import st.orm.core.template.SqlTemplateException;
+import st.orm.core.template.TableAliasResolver;
+import st.orm.mapping.TableNameResolver;
+
+/**
+ * Resolving a table by type has to pick a single occurrence. A table that is reachable from itself registers one
+ * occurrence per hop around the cycle, which used to make resolution by type ambiguous even though the caller could
+ * only have meant the occurrence it navigated to.
+ */
+public class AliasMapperSelfReferenceTest {
+
+    private static AliasMapper aliasMapper() {
+        return new AliasMapper(new TableUse(), TableAliasResolver.DEFAULT, TableNameResolver.DEFAULT, null);
+    }
+
+    @Test
+    public void resolvesToTheOccurrenceReachedWithoutPassingTheTableTwice() throws SqlTemplateException {
+        var aliasMapper = aliasMapper();
+        // The shape a self-referencing graph produces: the occurrence that was navigated to, plus the occurrences
+        // reached by continuing around the cycle from it.
+        aliasMapper.setAlias(City.class, "c1", "user.country.city");
+        aliasMapper.setAlias(City.class, "c2", "user.country.city.capital.city");
+        aliasMapper.setAlias(City.class, "c3", "user.country.city.largestCity.city");
+        assertEquals("c1", aliasMapper.findAlias(City.class, null, CASCADE).orElseThrow());
+    }
+
+    @Test
+    public void resolvesToTheRootWhenTheRootIsTheOneReferredBackTo() throws SqlTemplateException {
+        var aliasMapper = aliasMapper();
+        aliasMapper.setAlias(City.class, "c1", "");
+        aliasMapper.setAlias(City.class, "c2", "capital.city");
+        assertEquals("c1", aliasMapper.findAlias(City.class, null, CASCADE).orElseThrow());
+    }
+
+    @Test
+    public void staysAmbiguousForOccurrencesOnSeparateBranches() {
+        var aliasMapper = aliasMapper();
+        // Neither path passes the city twice, so the caller genuinely has to say which one it means.
+        assertThrows(SqlTemplateException.class, () -> {
+            aliasMapper.setAlias(City.class, "c1", "survey.city");
+            aliasMapper.setAlias(City.class, "c2", "client.city");
+            aliasMapper.findAlias(City.class, null, CASCADE);
+        });
+    }
+
+    @Test
+    public void staysAmbiguousForOccurrencesRegisteredUnderTheSamePath() {
+        var aliasMapper = aliasMapper();
+        assertThrows(SqlTemplateException.class, () -> {
+            aliasMapper.setAlias(City.class, "c1", "user.city");
+            aliasMapper.setAlias(City.class, "c2", "user.city");
+            aliasMapper.findAlias(City.class, null, CASCADE);
+        });
+    }
+
+    @Test
+    public void staysAmbiguousWhenAnOccurrenceCarriesNoPath() {
+        var aliasMapper = aliasMapper();
+        // A registration without a path cannot be placed in the graph, so it cannot be shown to repeat a table.
+        assertThrows(SqlTemplateException.class, () -> {
+            aliasMapper.setAlias(City.class, "c1", null);
+            aliasMapper.setAlias(City.class, "c2", "user.city");
+            aliasMapper.findAlias(City.class, null, CASCADE);
+        });
+    }
+
+    @Test
+    public void resolvingByPathIsUnaffected() throws SqlTemplateException {
+        var aliasMapper = aliasMapper();
+        aliasMapper.setAlias(City.class, "c1", "user.country.city");
+        aliasMapper.setAlias(City.class, "c2", "user.country.city.capital.city");
+        assertEquals("c2",
+                aliasMapper.findAlias(City.class, "user.country.city.capital.city", CASCADE).orElseThrow());
+    }
+
+    @Test
+    public void singleOccurrenceIsUnaffected() throws SqlTemplateException {
+        var aliasMapper = aliasMapper();
+        aliasMapper.setAlias(City.class, "c1", "user.city");
+        assertTrue(aliasMapper.findAlias(City.class, null, CASCADE).isPresent());
+    }
+}

--- a/storm-core/src/test/resources/data.sql
+++ b/storm-core/src/test/resources/data.sql
@@ -16,6 +16,10 @@ drop table if exists visit CASCADE;
 drop table if exists self_ref_node CASCADE;
 drop table if exists cross_package_holder CASCADE;
 drop table if exists cross_package_owner CASCADE;
+drop table if exists user_score CASCADE;
+drop table if exists app_user CASCADE;
+drop table if exists country CASCADE;
+drop table if exists country_city CASCADE;
 
 create table city (id integer auto_increment, name varchar(255), primary key (id));
 create table owner (id integer auto_increment, first_name varchar(255), last_name varchar(255), address varchar(255), city_id integer, telephone varchar(255), primary key (id), version integer default 0);
@@ -53,6 +57,18 @@ alter table self_ref_node add constraint self_ref_node_parent_fk foreign key (pa
 create table cross_package_owner (id integer auto_increment, label varchar(255), score integer, primary key (id));
 create table cross_package_holder (id integer auto_increment, label varchar(255), score integer, owner_id integer, primary key (id));
 alter table cross_package_holder add constraint cross_package_holder_owner_fk foreign key (owner_id) references cross_package_owner (id);
+-- The country table is reachable from itself: it refers to its capital and its largest city, and a city refers back to
+-- the country it lies in. The foreign keys point both ways, so the constraints are added once both tables exist.
+create table country_city (id integer auto_increment, name varchar(255), country_id integer not null, primary key (id));
+create table country (id integer auto_increment, name varchar(255), capital_id integer, largest_city_id integer, primary key (id));
+alter table country add constraint country_capital_fk foreign key (capital_id) references country_city (id);
+alter table country add constraint country_largest_city_fk foreign key (largest_city_id) references country_city (id);
+alter table country_city add constraint country_city_country_fk foreign key (country_id) references country (id);
+create table app_user (id integer auto_increment, name varchar(255), country_id integer not null, primary key (id));
+alter table app_user add constraint app_user_country_fk foreign key (country_id) references country (id);
+create table user_score (id integer auto_increment, user_id integer not null, score_date date, score double, primary key (id));
+alter table user_score add constraint user_score_user_fk foreign key (user_id) references app_user (id);
+
 create view owner_view as select * from owner;
 create view visit_view as select visit_date, description, pet_id, "timestamp" from visit;
 
@@ -244,3 +260,23 @@ INSERT INTO self_ref_node (name, parent_id) VALUES ('root', NULL);
 INSERT INTO self_ref_node (name, parent_id) VALUES ('mid', 1);
 INSERT INTO self_ref_node (name, parent_id) VALUES ('leaf', 2);
 INSERT INTO self_ref_node (name, parent_id) VALUES ('other', NULL);
+
+-- Countries that lead back to themselves through their capital and largest city. Inserted country-first so the cities
+-- have a country to point at, then linked up once those cities exist.
+INSERT INTO country (name, capital_id, largest_city_id) VALUES ('Netherlands', NULL, NULL);
+INSERT INTO country (name, capital_id, largest_city_id) VALUES ('Belgium', NULL, NULL);
+INSERT INTO country_city (name, country_id) VALUES ('Amsterdam', 1);
+INSERT INTO country_city (name, country_id) VALUES ('Rotterdam', 1);
+INSERT INTO country_city (name, country_id) VALUES ('Brussels', 2);
+INSERT INTO country_city (name, country_id) VALUES ('Antwerp', 2);
+UPDATE country SET capital_id = 1, largest_city_id = 2 WHERE id = 1;
+UPDATE country SET capital_id = 3, largest_city_id = 4 WHERE id = 2;
+
+INSERT INTO app_user (name, country_id) VALUES ('Anna', 1);
+INSERT INTO app_user (name, country_id) VALUES ('Bram', 2);
+
+-- Two dates for the first user so an aggregate grouped by country and date returns one row per combination.
+INSERT INTO user_score (user_id, score_date, score) VALUES (1, DATE '2026-07-25', 0.20);
+INSERT INTO user_score (user_id, score_date, score) VALUES (1, DATE '2026-07-25', 0.40);
+INSERT INTO user_score (user_id, score_date, score) VALUES (1, DATE '2026-07-26', 0.60);
+INSERT INTO user_score (user_id, score_date, score) VALUES (2, DATE '2026-07-25', 0.80);


### PR DESCRIPTION
## Problem

Naming a table by type resolves it against the query's table graph, which requires a single occurrence. A table that is reachable from itself registers one occurrence per hop around the cycle, so such a query failed with `Multiple aliases found for: <Table>` even though only one occurrence could have been meant.

The shape that triggers it: an entity holds an ordinary foreign key on a record that refers back to that entity. Selecting the entity by type from a query that navigated to it then sees the occurrence it navigated to plus one per return path.

```java
orm.entity(UserScore.class)
   .select(CountryScoreRow.class,
           raw("\0, \0, COUNT(*), AVG(\0)", Country.class, UserScore_.scoreDate, UserScore_.score))
   .groupBy(UserScore_.user.country, UserScore_.scoreDate)
   .getResultList();
```

`Country` refers to its capital and its largest city; each city refers back to the country it lies in. Country therefore occurs at `user.country`, `user.country.capital.country` and `user.country.largestCity.country`. The grouping names a path and is unambiguous; the select clause names the type and was not.

The ambiguity also recurs one level down. Expanding the selected country into its columns needs `country_city`, which occurs at `user.country.capital` and at `user.country.largestCity.country.capital`, so a rule based only on one path enclosing the others does not settle it.

## Change

Resolution by type now discards occurrences whose path revisits a table it already passed through, and takes the single one that remains. Revisiting a table is exactly what a trip around a cycle produces, and such a repetition is only reachable by passing the occurrence that was navigated to.

Occurrences reached along genuinely separate branches, for instance two foreign keys onto the same table, pass nothing twice. They all survive and keep reporting the ambiguity, so callers are still told to name a path where they genuinely have to choose. Two occurrences registered under the same path, and registrations carrying no path, stay ambiguous as well.

`AliasEntry` now carries the path it was registered under so occurrences can be placed in the graph. The prefix walk is seeded with the root registration, so a path arriving back at the root counts as a cycle just like one returning to a table joined along the way.

## Tests

`AliasMapperSelfReferenceTest` drives the resolver directly, covering the cycle cases and the three that must keep failing: separate branches, duplicate paths, and a registration without a path.

`SelfReferencingTableResolutionIntegrationTest` runs the query above end to end against a new `UserScore -> User -> Country -> CapitalCity/LargestCity -> Ref<Country>` model, added to the test model and schema. `CapitalCity` and `LargestCity` map the same `country_city` table so the two return paths are distinct types, which is what produces the second-level ambiguity.

Full reactor build passes.