### PR TITLE
fix(core): render a keyed comparison as the form every planner indexes

### DIFF
--- a/storm-core/src/main/java/st/orm/core/spi/DefaultSqlDialect.java
+++ b/storm-core/src/main/java/st/orm/core/spi/DefaultSqlDialect.java
@@ -18,6 +18,9 @@ package st.orm.core.spi;
 
 import static java.util.stream.Collectors.joining;
 import static st.orm.Operator.EQUALS;
+import static st.orm.Operator.IN;
+import static st.orm.Operator.NOT_EQUALS;
+import static st.orm.Operator.NOT_IN;
 import static st.orm.StormConfig.ANSI_ESCAPING;
 import static st.orm.core.spi.StormConfigHelper.getBoolean;
 
@@ -260,14 +263,88 @@ public class DefaultSqlDialect implements SqlDialect {
     }
 
     /**
+     * Builds a multi-column expression, rendering it as a row value tuple where {@link #rendersTupleComparison}
+     * allows and as the {@code AND} expansion otherwise.
+     *
+     * @param operator the comparison operator to apply.
+     * @param values the multi-row values. Each map represents a single row of column-name-to-value mappings.
+     * @param parameterFunction the function responsible for binding the parameters.
+     * @return the SQL fragment representing the multi-column expression.
+     * @throws SqlTemplateException if the operator is not supported for multi-column expressions.
+     * @since 1.13
+     */
+    @Override
+    public String multiColumnExpression(@Nonnull Operator operator,
+                                        @Nonnull List<SequencedMap<String, Object>> values,
+                                        @Nonnull Function<Object, String> parameterFunction)
+            throws SqlTemplateException {
+        if (rendersTupleComparison(operator, values.size())) {
+            return tupleExpression(operator, values, parameterFunction);
+        }
+        return SqlDialect.super.multiColumnExpression(operator, values, parameterFunction);
+    }
+
+    /**
+     * Returns whether a multi-column comparison renders as a row value tuple rather than as the {@code AND}
+     * expansion.
+     *
+     * <p>Rendering a tuple is a question of what the optimizer does with one, not of what the grammar accepts. A
+     * dialect answers {@code true} only where the tuple earns its place, because the two forms are not
+     * interchangeable to a planner:</p>
+     *
+     * <ul>
+     *   <li><strong>A single row of equality</strong> never renders as a tuple. The expansion
+     *   {@code a = ? AND b = ?} is the shape an optimizer resolves to an index lookup, while a row value
+     *   comparison is not reduced to that shape everywhere, and a planner that leaves it alone in an UPDATE or a
+     *   DELETE scans the table instead. The tuple gains nothing here on any dialect, so the identifying
+     *   comparison that every keyed update, delete and lookup is built from takes the form that is safe
+     *   throughout.</li>
+     *   <li><strong>A multi-row list</strong> is where the tuple pays: {@code (a, b) IN ((?, ?), ...)} states the
+     *   set once, and a planner that resolves it against the index handles it far better than the equivalent
+     *   chain of ORs.</li>
+     *   <li><strong>An ordering comparison</strong> divides the dialects. Some use the index for
+     *   {@code (a, b) > (?, ?)} and cannot use it for the lexicographic expansion; others do the reverse. This is
+     *   the keyset pagination path, so each dialect answers for itself.</li>
+     * </ul>
+     *
+     * <p>The default never renders a tuple, which suits dialects without row value comparison and is a safe answer
+     * for any dialect whose planner has not been measured.</p>
+     *
+     * @param operator the comparison operator to apply.
+     * @param rowCount the number of value rows in the comparison.
+     * @return {@code true} to render a row value tuple, {@code false} to render the {@code AND} expansion.
+     * @since 1.13
+     */
+    protected boolean rendersTupleComparison(@Nonnull Operator operator, int rowCount) {
+        return false;
+    }
+
+    /**
+     * Returns whether a multi-column comparison of the equality family renders as a row value tuple, which is the
+     * case only for a list of more than one row.
+     *
+     * <p>Provided for dialects that render tuples, so the single-row rule that holds for all of them is stated
+     * once.</p>
+     *
+     * @param operator the comparison operator to apply.
+     * @param rowCount the number of value rows in the comparison.
+     * @return {@code true} if the operator is of the equality family and the comparison spans multiple rows.
+     * @since 1.13
+     */
+    protected final boolean isMultiRowEquality(@Nonnull Operator operator, int rowCount) {
+        return (operator == EQUALS || operator == NOT_EQUALS || operator == IN || operator == NOT_IN)
+                && rowCount > 1;
+    }
+
+    /**
      * Builds a tuple expression by composing column names and values into row value constructor syntax.
      *
      * <p>The {@link Operator#format} method is used to produce the final SQL, which allows all operators to work
      * naturally with tuple syntax. For example, {@code GREATER_THAN.format("(a, b)", "(?, ?)")} produces
      * {@code (a, b) > (?, ?)}.</p>
      *
-     * <p>Subclasses that support multi-value tuples (e.g., PostgreSQL, MySQL, Oracle) can call this method from their
-     * {@link #multiColumnExpression} override to produce compact row value comparison SQL.</p>
+     * <p>Called for a subclass that answers {@link #rendersTupleComparison} affirmatively, which is how a dialect
+     * supporting row value comparison opts into the compact form for the shapes its planner handles well.</p>
      *
      * @param operator the comparison operator.
      * @param values the column-to-value mappings for each row.

--- a/storm-h2/src/main/java/st/orm/spi/h2/H2SqlDialect.java
+++ b/storm-h2/src/main/java/st/orm/spi/h2/H2SqlDialect.java
@@ -17,30 +17,22 @@ package st.orm.spi.h2;
 
 import static java.util.stream.Collectors.toSet;
 import static st.orm.Operator.BETWEEN;
-import static st.orm.Operator.EQUALS;
 import static st.orm.Operator.GREATER_THAN;
 import static st.orm.Operator.GREATER_THAN_OR_EQUAL;
-import static st.orm.Operator.IN;
 import static st.orm.Operator.LESS_THAN;
 import static st.orm.Operator.LESS_THAN_OR_EQUAL;
-import static st.orm.Operator.NOT_EQUALS;
-import static st.orm.Operator.NOT_IN;
 
 import jakarta.annotation.Nonnull;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.List;
-import java.util.SequencedMap;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import st.orm.Operator;
 import st.orm.StormConfig;
 import st.orm.core.spi.DefaultSqlDialect;
 import st.orm.core.template.SqlDialect;
-import st.orm.core.template.SqlTemplateException;
 
 public class H2SqlDialect extends DefaultSqlDialect implements SqlDialect {
 
@@ -155,34 +147,41 @@ public class H2SqlDialect extends DefaultSqlDialect implements SqlDialect {
     }
 
     /**
-     * Builds a multi-column expression using row value constructor syntax.
+     * Returns whether a multi-column comparison renders as a row value tuple, which for H2 is the case for an
+     * ordering comparison and for a multi-row list.
      *
-     * <p>H2 supports tuple comparison syntax for all comparison operators, producing compact SQL like
-     * {@code (a, b) > (?, ?)} instead of the lexicographic expansion used by the default implementation.</p>
+     * <p>Measured on 2.2.220 against a 100k-row table keyed on {@code (a, b)}, reading the index H2 names in its
+     * plan comment:</p>
      *
-     * <p>Operators without clear tuple semantics ({@code IS_NULL}, {@code IS_NOT_NULL}, {@code LIKE}, etc.) fall back
-     * to the {@link SqlDialect} default implementation.</p>
+     * <table border="1">
+     *   <caption>H2 2.2 plan for each comparison shape</caption>
+     *   <tr><th>Shape</th><th>As a tuple</th><th>As the expansion</th><th>Rendered as</th></tr>
+     *   <tr><td>Single row of equality, SELECT / UPDATE / DELETE</td>
+     *       <td>Primary key, {@code A = ? AND B = ?}</td>
+     *       <td>Primary key, same condition</td><td>Expansion</td></tr>
+     *   <tr><td>Ordering comparison</td><td>Primary key range, {@code A &gt;= ?}</td>
+     *       <td>Table scan</td><td><strong>Tuple</strong></td></tr>
+     * </table>
+     *
+     * <p>H2 rewrites a row value equality into its conjunction and reaches the primary key either way, in reads
+     * and writes alike, so equality takes the expansion: the form that is safe on every dialect, at no cost here.
+     * The ordering comparison is the shape where the choice matters, and H2 only derives an index range from the
+     * tuple; the lexicographic expansion of the same predicate falls through to a table scan.</p>
+     *
+     * <p>The multi-row list follows the ordering comparison in keeping the tuple, on the compactness argument
+     * rather than a measured plan difference.</p>
      *
      * @param operator the comparison operator to apply.
-     * @param values the multi-row values. Each map represents a single row of column-name-to-value mappings.
-     * @param parameterFunction the function responsible for binding the parameters.
-     * @return the SQL fragment representing the multi-column expression.
-     * @throws SqlTemplateException if the operator is not supported for multi-column expressions.
-     * @since 1.11
+     * @param rowCount the number of value rows in the comparison.
+     * @return {@code true} to render a row value tuple, {@code false} to render the {@code AND} expansion.
+     * @since 1.13
      */
     @Override
-    public String multiColumnExpression(@Nonnull Operator operator,
-                                         @Nonnull List<SequencedMap<String, Object>> values,
-                                         @Nonnull Function<Object, String> parameterFunction)
-            throws SqlTemplateException {
-        if (operator == EQUALS || operator == NOT_EQUALS
-                || operator == IN || operator == NOT_IN
+    protected boolean rendersTupleComparison(@Nonnull Operator operator, int rowCount) {
+        return isMultiRowEquality(operator, rowCount)
                 || operator == GREATER_THAN || operator == GREATER_THAN_OR_EQUAL
                 || operator == LESS_THAN || operator == LESS_THAN_OR_EQUAL
-                || operator == BETWEEN) {
-            return tupleExpression(operator, values, parameterFunction);
-        }
-        return super.multiColumnExpression(operator, values, parameterFunction);
+                || operator == BETWEEN;
     }
 
     /**

--- a/storm-h2/src/test/java/st/orm/spi/h2/H2EntityRepositoryTest.java
+++ b/storm-h2/src/test/java/st/orm/spi/h2/H2EntityRepositoryTest.java
@@ -262,7 +262,7 @@ public class H2EntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -295,7 +295,7 @@ public class H2EntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);

--- a/storm-h2/src/test/java/st/orm/spi/h2/H2MultiColumnExpressionTest.java
+++ b/storm-h2/src/test/java/st/orm/spi/h2/H2MultiColumnExpressionTest.java
@@ -36,21 +36,21 @@ public class H2MultiColumnExpressionTest {
     void equals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b) = (?, ?)", sql);
+        assertEquals("a = ? AND b = ?", sql);
     }
 
     @Test
     void equals_threeColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2, "c", 3));
         String sql = DIALECT.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b, c) = (?, ?, ?)", sql);
+        assertEquals("a = ? AND b = ? AND c = ?", sql);
     }
 
     @Test
     void notEquals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.NOT_EQUALS, values, v -> "?");
-        assertEquals("(a, b) <> (?, ?)", sql);
+        assertEquals("NOT (a = ? AND b = ?)", sql);
     }
 
     @Test

--- a/storm-h2/src/test/java/st/orm/spi/h2/H2SqlDialectTest.java
+++ b/storm-h2/src/test/java/st/orm/spi/h2/H2SqlDialectTest.java
@@ -274,10 +274,10 @@ class H2SqlDialectTest {
     }
 
     @Test
-    void multiColumnExpressionShouldUseTupleSyntaxForEquals() throws Exception {
+    void multiColumnExpressionShouldExpandEquals() throws Exception {
         var values = List.of(row("a", 1, "b", 2));
         var result = dialect.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b) = (?, ?)", result);
+        assertEquals("a = ? AND b = ?", result);
     }
 
     @Test
@@ -288,10 +288,10 @@ class H2SqlDialectTest {
     }
 
     @Test
-    void multiColumnExpressionShouldUseTupleSyntaxForNotEquals() throws Exception {
+    void multiColumnExpressionShouldExpandNotEquals() throws Exception {
         var values = List.of(row("a", 1, "b", 2));
         var result = dialect.multiColumnExpression(Operator.NOT_EQUALS, values, v -> "?");
-        assertEquals("(a, b) <> (?, ?)", result);
+        assertEquals("NOT (a = ? AND b = ?)", result);
     }
 
     @Test

--- a/storm-mariadb/src/main/java/st/orm/spi/mariadb/MariaDBSqlDialect.java
+++ b/storm-mariadb/src/main/java/st/orm/spi/mariadb/MariaDBSqlDialect.java
@@ -19,6 +19,41 @@ import jakarta.annotation.Nonnull;
 import st.orm.StormConfig;
 import st.orm.spi.mysql.MySQLSqlDialect;
 
+/**
+ * The MariaDB dialect.
+ *
+ * <h2>Row value comparison</h2>
+ *
+ * <p>MariaDB inherits {@link MySQLSqlDialect#rendersTupleComparison} unchanged: a row value tuple is rendered for
+ * a multi-row list and nowhere else. MariaDB is the dialect that makes that choice necessary rather than merely
+ * tidy, because its optimizer treats a row value comparison differently depending on the statement it sits in.
+ * Measured on 10.5.22 and confirmed on 11.4.12, against a 118k-row table keyed on {@code (study_id, user_id)}:</p>
+ *
+ * <table border="1">
+ *   <caption>MariaDB plan for each comparison shape</caption>
+ *   <tr><th>Shape</th><th>As a tuple</th><th>As the expansion</th><th>Rendered as</th></tr>
+ *   <tr><td>Single row of equality, SELECT</td><td>{@code const}, primary key, 1 row</td>
+ *       <td>{@code const}, primary key, 1 row</td><td>Expansion</td></tr>
+ *   <tr><td>Single row of equality, UPDATE</td>
+ *       <td>{@code index}, <em>no candidate key</em>, all rows — <strong>~7500x slower</strong></td>
+ *       <td>{@code range}, 1 row</td><td>Expansion</td></tr>
+ *   <tr><td>Single row of equality, DELETE</td><td>{@code ALL}, all rows</td>
+ *       <td>{@code range}, 1 row</td><td>Expansion</td></tr>
+ *   <tr><td>Multi-row list (500 keys)</td>
+ *       <td>Materialized semi-join on {@code distinct_key} — <strong>~150x faster</strong></td>
+ *       <td>500-branch OR</td><td><strong>Tuple</strong></td></tr>
+ *   <tr><td>Ordering comparison</td><td>{@code ALL}, all rows</td>
+ *       <td>{@code range}, primary key</td><td>Expansion</td></tr>
+ * </table>
+ *
+ * <p>The SELECT row is what makes this easy to miss: the read path reduces the row value comparison to its
+ * conjunction and takes the index, so the tuple looks harmless until it reaches a write. In an UPDATE or a DELETE
+ * the reduction does not happen, no index is even considered, and every identified row costs a scan of the whole
+ * table. A batch of keyed updates is then quadratic in the table, and because a scanning statement locks what it
+ * examines, two such batches against one table deadlock rather than merely running slowly.</p>
+ *
+ * <p>The list row is the mirror image and the reason the tuple is kept for it.</p>
+ */
 public class MariaDBSqlDialect extends MySQLSqlDialect {
 
     public MariaDBSqlDialect() {

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBEntityRepositoryTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBEntityRepositoryTest.java
@@ -290,7 +290,7 @@ public class MariaDBEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -323,7 +323,7 @@ public class MariaDBEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);
@@ -435,7 +435,7 @@ public class MariaDBEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -469,7 +469,7 @@ public class MariaDBEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -537,7 +537,7 @@ public class MariaDBEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);
@@ -733,6 +733,29 @@ public class MariaDBEntityRepositoryTest {
             assertEquals(1, entity.id().vetId());
             assertEquals(2, entity.id().specialtyId());
         });
+    }
+
+    @Test
+    public void testRemoveByCompoundPkExpandsWhere() {
+        // The compound key expands rather than rendering as the row value tuple the dialect is otherwise willing
+        // to emit. MariaDB does not resolve (vet_id, specialty_id) = (?, ?) against the primary key in a DELETE or
+        // an UPDATE and scans the table for every row it identifies.
+        String expectedSql = """
+                DELETE FROM vet_specialty
+                WHERE vet_id = ? AND specialty_id = ?""";
+        var repo = PreparedStatementTemplate.ORM(dataSource).entity(VetSpecialty.class);
+        var pk = VetSpecialtyPK.builder().vetId(1).specialtyId(2).build();
+        repo.insert(VetSpecialty.builder().id(pk).build());
+        var observed = new AtomicBoolean(false);
+        observe(sql -> {
+            if (sql.statement().startsWith("DELETE") && !observed.getAndSet(true)) {
+                assertEquals(expectedSql, sql.statement());
+                assertEquals(1, sql.parameters().get(0).dbValue());
+                assertEquals(2, sql.parameters().get(1).dbValue());
+            }
+        }, () -> repo.removeById(pk));
+        assertTrue(observed.get());
+        assertTrue(repo.findById(pk).isEmpty());
     }
 
     @Test

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBMultiColumnExpressionTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBMultiColumnExpressionTest.java
@@ -43,14 +43,14 @@ public class MariaDBMultiColumnExpressionTest {
     void equals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b) = (?, ?)", sql);
+        assertEquals("a = ? AND b = ?", sql);
     }
 
     @Test
     void notEquals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.NOT_EQUALS, values, v -> "?");
-        assertEquals("(a, b) <> (?, ?)", sql);
+        assertEquals("NOT (a = ? AND b = ?)", sql);
     }
 
     @Test
@@ -66,28 +66,28 @@ public class MariaDBMultiColumnExpressionTest {
     void greaterThan_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.GREATER_THAN, values, v -> "?");
-        assertEquals("(a, b) > (?, ?)", sql);
+        assertEquals("(a > ? OR (a = ? AND b > ?))", sql);
     }
 
     @Test
     void greaterThanOrEqual_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.GREATER_THAN_OR_EQUAL, values, v -> "?");
-        assertEquals("(a, b) >= (?, ?)", sql);
+        assertEquals("(a > ? OR (a = ? AND b >= ?))", sql);
     }
 
     @Test
     void lessThan_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.LESS_THAN, values, v -> "?");
-        assertEquals("(a, b) < (?, ?)", sql);
+        assertEquals("(a < ? OR (a = ? AND b < ?))", sql);
     }
 
     @Test
     void lessThanOrEqual_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.LESS_THAN_OR_EQUAL, values, v -> "?");
-        assertEquals("(a, b) <= (?, ?)", sql);
+        assertEquals("(a < ? OR (a = ? AND b <= ?))", sql);
     }
 
     @Test
@@ -96,7 +96,7 @@ public class MariaDBMultiColumnExpressionTest {
                 row("a", 1, "b", 2),
                 row("a", 5, "b", 6));
         String sql = DIALECT.multiColumnExpression(Operator.BETWEEN, values, v -> "?");
-        assertEquals("(a, b) BETWEEN (?, ?) AND (?, ?)", sql);
+        assertEquals("((a > ? OR (a = ? AND b >= ?)) AND (a < ? OR (a = ? AND b <= ?)))", sql);
     }
 
     @Test

--- a/storm-mysql/src/main/java/st/orm/spi/mysql/MySQLSqlDialect.java
+++ b/storm-mysql/src/main/java/st/orm/spi/mysql/MySQLSqlDialect.java
@@ -16,21 +16,9 @@
 package st.orm.spi.mysql;
 
 import static java.util.stream.Collectors.toSet;
-import static st.orm.Operator.BETWEEN;
-import static st.orm.Operator.EQUALS;
-import static st.orm.Operator.GREATER_THAN;
-import static st.orm.Operator.GREATER_THAN_OR_EQUAL;
-import static st.orm.Operator.IN;
-import static st.orm.Operator.LESS_THAN;
-import static st.orm.Operator.LESS_THAN_OR_EQUAL;
-import static st.orm.Operator.NOT_EQUALS;
-import static st.orm.Operator.NOT_IN;
 
 import jakarta.annotation.Nonnull;
-import java.util.List;
-import java.util.SequencedMap;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import st.orm.Operator;
@@ -38,7 +26,6 @@ import st.orm.PersistenceException;
 import st.orm.StormConfig;
 import st.orm.core.spi.DefaultSqlDialect;
 import st.orm.core.template.SqlDialect;
-import st.orm.core.template.SqlTemplateException;
 
 public class MySQLSqlDialect extends DefaultSqlDialect implements SqlDialect {
 
@@ -171,34 +158,39 @@ public class MySQLSqlDialect extends DefaultSqlDialect implements SqlDialect {
     }
 
     /**
-     * Builds a multi-column expression using row value constructor syntax.
+     * Returns whether a multi-column comparison renders as a row value tuple, which for MySQL is the case for a
+     * multi-row list only.
      *
-     * <p>MySQL (8.0.19+) supports tuple comparison syntax for all comparison operators, producing compact SQL like
-     * {@code (a, b) > (?, ?)} instead of the lexicographic expansion used by the default implementation.</p>
+     * <p>MySQL accepts a row value comparison for every operator, but accepting one and planning it well are
+     * different things. Measured on MySQL 8.4 against a 100k-row table keyed on {@code (a, b)}:</p>
      *
-     * <p>Operators without clear tuple semantics ({@code IS_NULL}, {@code IS_NOT_NULL}, {@code LIKE}, etc.) fall back
-     * to the {@link SqlDialect} default implementation.</p>
+     * <table border="1">
+     *   <caption>MySQL 8.4 plan for each comparison shape</caption>
+     *   <tr><th>Shape</th><th>As a tuple</th><th>As the expansion</th><th>Rendered as</th></tr>
+     *   <tr><td>Single row of equality, SELECT</td><td>{@code const}, primary key</td>
+     *       <td>{@code const}, primary key</td><td>Expansion</td></tr>
+     *   <tr><td>Single row of equality, UPDATE / DELETE</td><td>{@code range}, primary key</td>
+     *       <td>{@code range}, primary key</td><td>Expansion</td></tr>
+     *   <tr><td>Multi-row list (500 keys)</td><td>{@code range}, primary key — <strong>~4x faster</strong></td>
+     *       <td>{@code range}, primary key</td><td><strong>Tuple</strong></td></tr>
+     *   <tr><td>Ordering comparison</td><td>{@code ALL}, all rows</td>
+     *       <td>{@code range}, primary key</td><td>Expansion</td></tr>
+     * </table>
+     *
+     * <p>Equality plans identically either way, so it takes the expansion, which is the form that is safe on every
+     * dialect. The list is the one shape the tuple wins: same plan, but the optimizer is spared a 500-branch OR
+     * tree. The ordering comparison is the shape it loses outright, so that renders lexicographically.</p>
+     *
+     * <p>{@link st.orm.spi.mariadb.MariaDBSqlDialect} inherits this and measures the same way, more sharply.</p>
      *
      * @param operator the comparison operator to apply.
-     * @param values the multi-row values. Each map represents a single row of column-name-to-value mappings.
-     * @param parameterFunction the function responsible for binding the parameters.
-     * @return the SQL fragment representing the multi-column expression.
-     * @throws SqlTemplateException if the operator is not supported for multi-column expressions.
-     * @since 1.9
+     * @param rowCount the number of value rows in the comparison.
+     * @return {@code true} to render a row value tuple, {@code false} to render the {@code AND} expansion.
+     * @since 1.13
      */
     @Override
-    public String multiColumnExpression(@Nonnull Operator operator,
-                                         @Nonnull List<SequencedMap<String, Object>> values,
-                                         @Nonnull Function<Object, String> parameterFunction)
-            throws SqlTemplateException {
-        if (operator == EQUALS || operator == NOT_EQUALS
-                || operator == IN || operator == NOT_IN
-                || operator == GREATER_THAN || operator == GREATER_THAN_OR_EQUAL
-                || operator == LESS_THAN || operator == LESS_THAN_OR_EQUAL
-                || operator == BETWEEN) {
-            return tupleExpression(operator, values, parameterFunction);
-        }
-        return super.multiColumnExpression(operator, values, parameterFunction);
+    protected boolean rendersTupleComparison(@Nonnull Operator operator, int rowCount) {
+        return isMultiRowEquality(operator, rowCount);
     }
 
     /**

--- a/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLEntityRepositoryTest.java
+++ b/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLEntityRepositoryTest.java
@@ -285,7 +285,7 @@ public class MySQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -318,7 +318,7 @@ public class MySQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);
@@ -430,7 +430,7 @@ public class MySQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -464,7 +464,7 @@ public class MySQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -532,7 +532,7 @@ public class MySQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);

--- a/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLMultiColumnExpressionTest.java
+++ b/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLMultiColumnExpressionTest.java
@@ -42,21 +42,21 @@ public class MySQLMultiColumnExpressionTest {
     void equals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b) = (?, ?)", sql);
+        assertEquals("a = ? AND b = ?", sql);
     }
 
     @Test
     void equals_threeColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2, "c", 3));
         String sql = DIALECT.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b, c) = (?, ?, ?)", sql);
+        assertEquals("a = ? AND b = ? AND c = ?", sql);
     }
 
     @Test
     void notEquals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.NOT_EQUALS, values, v -> "?");
-        assertEquals("(a, b) <> (?, ?)", sql);
+        assertEquals("NOT (a = ? AND b = ?)", sql);
     }
 
     @Test
@@ -81,35 +81,35 @@ public class MySQLMultiColumnExpressionTest {
     void greaterThan_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.GREATER_THAN, values, v -> "?");
-        assertEquals("(a, b) > (?, ?)", sql);
+        assertEquals("(a > ? OR (a = ? AND b > ?))", sql);
     }
 
     @Test
     void greaterThan_threeColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2, "c", 3));
         String sql = DIALECT.multiColumnExpression(Operator.GREATER_THAN, values, v -> "?");
-        assertEquals("(a, b, c) > (?, ?, ?)", sql);
+        assertEquals("(a > ? OR (a = ? AND b > ?) OR (a = ? AND b = ? AND c > ?))", sql);
     }
 
     @Test
     void greaterThanOrEqual_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.GREATER_THAN_OR_EQUAL, values, v -> "?");
-        assertEquals("(a, b) >= (?, ?)", sql);
+        assertEquals("(a > ? OR (a = ? AND b >= ?))", sql);
     }
 
     @Test
     void lessThan_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.LESS_THAN, values, v -> "?");
-        assertEquals("(a, b) < (?, ?)", sql);
+        assertEquals("(a < ? OR (a = ? AND b < ?))", sql);
     }
 
     @Test
     void lessThanOrEqual_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.LESS_THAN_OR_EQUAL, values, v -> "?");
-        assertEquals("(a, b) <= (?, ?)", sql);
+        assertEquals("(a < ? OR (a = ? AND b <= ?))", sql);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class MySQLMultiColumnExpressionTest {
                 row("a", 1, "b", 2),
                 row("a", 5, "b", 6));
         String sql = DIALECT.multiColumnExpression(Operator.BETWEEN, values, v -> "?");
-        assertEquals("(a, b) BETWEEN (?, ?) AND (?, ?)", sql);
+        assertEquals("((a > ? OR (a = ? AND b >= ?)) AND (a < ? OR (a = ? AND b <= ?)))", sql);
     }
 
     @Test
@@ -150,7 +150,7 @@ public class MySQLMultiColumnExpressionTest {
             bindOrder.append(v).append(",");
             return "?";
         });
-        assertEquals("v1,v2,", bindOrder.toString());
+        assertEquals("v1,v1,v2,", bindOrder.toString());
     }
 
     @Test

--- a/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLSqlDialectTest.java
+++ b/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLSqlDialectTest.java
@@ -335,10 +335,10 @@ class MySQLSqlDialectTest {
     }
 
     @Test
-    void multiColumnExpressionShouldUseTupleSyntaxForEquals() throws Exception {
+    void multiColumnExpressionShouldExpandEquals() throws Exception {
         var values = List.of(row("a", 1, "b", 2));
         var result = dialect.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b) = (?, ?)", result);
+        assertEquals("a = ? AND b = ?", result);
     }
 
     @Test
@@ -350,23 +350,23 @@ class MySQLSqlDialectTest {
 
     @Test
     void multiColumnExpressionShouldUseTupleSyntaxForNotIn() throws Exception {
-        var values = List.of(row("a", 1, "b", 2));
+        var values = List.of(row("a", 1, "b", 2), row("a", 3, "b", 4));
         var result = dialect.multiColumnExpression(Operator.NOT_IN, values, v -> "?");
-        assertEquals("(a, b) NOT IN ((?, ?))", result);
+        assertEquals("(a, b) NOT IN ((?, ?), (?, ?))", result);
     }
 
     @Test
-    void multiColumnExpressionShouldUseTupleSyntaxForGreaterThanOrEqual() throws Exception {
+    void multiColumnExpressionShouldExpandGreaterThanOrEqual() throws Exception {
         var values = List.of(row("a", 1, "b", 2));
         var result = dialect.multiColumnExpression(Operator.GREATER_THAN_OR_EQUAL, values, v -> "?");
-        assertEquals("(a, b) >= (?, ?)", result);
+        assertEquals("(a > ? OR (a = ? AND b >= ?))", result);
     }
 
     @Test
-    void multiColumnExpressionShouldUseTupleSyntaxForLessThan() throws Exception {
+    void multiColumnExpressionShouldExpandLessThan() throws Exception {
         var values = List.of(row("a", 1, "b", 2));
         var result = dialect.multiColumnExpression(Operator.LESS_THAN, values, v -> "?");
-        assertEquals("(a, b) < (?, ?)", result);
+        assertEquals("(a < ? OR (a = ? AND b < ?))", result);
     }
 
     @Test

--- a/storm-oracle/src/main/java/st/orm/spi/oracle/OracleSqlDialect.java
+++ b/storm-oracle/src/main/java/st/orm/spi/oracle/OracleSqlDialect.java
@@ -17,27 +17,19 @@ package st.orm.spi.oracle;
 
 import static java.util.stream.Collectors.toSet;
 import static st.orm.Operator.BETWEEN;
-import static st.orm.Operator.EQUALS;
 import static st.orm.Operator.GREATER_THAN;
 import static st.orm.Operator.GREATER_THAN_OR_EQUAL;
-import static st.orm.Operator.IN;
 import static st.orm.Operator.LESS_THAN;
 import static st.orm.Operator.LESS_THAN_OR_EQUAL;
-import static st.orm.Operator.NOT_EQUALS;
-import static st.orm.Operator.NOT_IN;
 
 import jakarta.annotation.Nonnull;
-import java.util.List;
-import java.util.SequencedMap;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import st.orm.Operator;
 import st.orm.StormConfig;
 import st.orm.core.spi.DefaultSqlDialect;
 import st.orm.core.template.SqlDialect;
-import st.orm.core.template.SqlTemplateException;
 
 public class OracleSqlDialect extends DefaultSqlDialect implements SqlDialect {
 
@@ -145,34 +137,32 @@ public class OracleSqlDialect extends DefaultSqlDialect implements SqlDialect {
     }
 
     /**
-     * Builds a multi-column expression using row value constructor syntax.
+     * Returns whether a multi-column comparison renders as a row value tuple, which for Oracle is the case for an
+     * ordering comparison and for a multi-row list.
      *
-     * <p>Oracle supports tuple comparison syntax for all comparison operators, producing compact SQL like
-     * {@code (a, b) > (?, ?)} instead of the lexicographic expansion used by the default implementation.</p>
+     * <p>Unlike the other tuple-rendering dialects, Oracle's plans have not been measured here, so this answer is
+     * reasoned rather than observed and the table other dialects carry is deliberately absent.</p>
      *
-     * <p>Operators without clear tuple semantics ({@code IS_NULL}, {@code IS_NOT_NULL}, {@code LIKE}, etc.) fall back
-     * to the {@link SqlDialect} default implementation.</p>
+     * <p>A single row of equality renders as the {@code AND} expansion. Across every dialect that has been
+     * measured the expansion ties the tuple or beats it for that shape, and the shape is the identifying
+     * comparison behind every keyed update, delete and lookup, so it takes the form known to be safe rather than
+     * one resting on an assumption about how this planner rewrites a row value comparison.</p>
+     *
+     * <p>The ordering comparison and the multi-row list keep the tuple, which is the behaviour that predates this
+     * distinction; Oracle documents row value comparison for both. Should the plans be measured and disagree,
+     * this is the one method to revisit.</p>
      *
      * @param operator the comparison operator to apply.
-     * @param values the multi-row values. Each map represents a single row of column-name-to-value mappings.
-     * @param parameterFunction the function responsible for binding the parameters.
-     * @return the SQL fragment representing the multi-column expression.
-     * @throws SqlTemplateException if the operator is not supported for multi-column expressions.
-     * @since 1.9
+     * @param rowCount the number of value rows in the comparison.
+     * @return {@code true} to render a row value tuple, {@code false} to render the {@code AND} expansion.
+     * @since 1.13
      */
     @Override
-    public String multiColumnExpression(@Nonnull Operator operator,
-                                         @Nonnull List<SequencedMap<String, Object>> values,
-                                         @Nonnull Function<Object, String> parameterFunction)
-            throws SqlTemplateException {
-        if (operator == EQUALS || operator == NOT_EQUALS
-                || operator == IN || operator == NOT_IN
+    protected boolean rendersTupleComparison(@Nonnull Operator operator, int rowCount) {
+        return isMultiRowEquality(operator, rowCount)
                 || operator == GREATER_THAN || operator == GREATER_THAN_OR_EQUAL
                 || operator == LESS_THAN || operator == LESS_THAN_OR_EQUAL
-                || operator == BETWEEN) {
-            return tupleExpression(operator, values, parameterFunction);
-        }
-        return super.multiColumnExpression(operator, values, parameterFunction);
+                || operator == BETWEEN;
     }
 
     /**

--- a/storm-oracle/src/test/java/st/orm/spi/oracle/OracleEntityRepositoryTest.java
+++ b/storm-oracle/src/test/java/st/orm/spi/oracle/OracleEntityRepositoryTest.java
@@ -302,7 +302,7 @@ public class OracleEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -335,7 +335,7 @@ public class OracleEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);
@@ -445,7 +445,7 @@ public class OracleEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -479,7 +479,7 @@ public class OracleEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -546,7 +546,7 @@ public class OracleEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);

--- a/storm-oracle/src/test/java/st/orm/spi/oracle/OracleMultiColumnExpressionTest.java
+++ b/storm-oracle/src/test/java/st/orm/spi/oracle/OracleMultiColumnExpressionTest.java
@@ -42,21 +42,21 @@ public class OracleMultiColumnExpressionTest {
     void equals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b) = (?, ?)", sql);
+        assertEquals("a = ? AND b = ?", sql);
     }
 
     @Test
     void equals_threeColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2, "c", 3));
         String sql = DIALECT.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b, c) = (?, ?, ?)", sql);
+        assertEquals("a = ? AND b = ? AND c = ?", sql);
     }
 
     @Test
     void notEquals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.NOT_EQUALS, values, v -> "?");
-        assertEquals("(a, b) <> (?, ?)", sql);
+        assertEquals("NOT (a = ? AND b = ?)", sql);
     }
 
     @Test

--- a/storm-oracle/src/test/java/st/orm/spi/oracle/OracleSqlDialectTest.java
+++ b/storm-oracle/src/test/java/st/orm/spi/oracle/OracleSqlDialectTest.java
@@ -305,10 +305,10 @@ class OracleSqlDialectTest {
     }
 
     @Test
-    void multiColumnExpressionShouldUseTupleSyntaxForEquals() throws Exception {
+    void multiColumnExpressionShouldExpandEquals() throws Exception {
         var values = List.of(row("a", 1, "b", 2));
         var result = dialect.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b) = (?, ?)", result);
+        assertEquals("a = ? AND b = ?", result);
     }
 
     @Test
@@ -319,10 +319,10 @@ class OracleSqlDialectTest {
     }
 
     @Test
-    void multiColumnExpressionShouldUseTupleSyntaxForNotEquals() throws Exception {
+    void multiColumnExpressionShouldExpandNotEquals() throws Exception {
         var values = List.of(row("a", 1, "b", 2));
         var result = dialect.multiColumnExpression(Operator.NOT_EQUALS, values, v -> "?");
-        assertEquals("(a, b) <> (?, ?)", result);
+        assertEquals("NOT (a = ? AND b = ?)", result);
     }
 
     @Test

--- a/storm-postgresql/src/main/java/st/orm/spi/postgresql/PostgreSQLSqlDialect.java
+++ b/storm-postgresql/src/main/java/st/orm/spi/postgresql/PostgreSQLSqlDialect.java
@@ -17,24 +17,17 @@ package st.orm.spi.postgresql;
 
 import static java.util.stream.Collectors.toSet;
 import static st.orm.Operator.BETWEEN;
-import static st.orm.Operator.EQUALS;
 import static st.orm.Operator.GREATER_THAN;
 import static st.orm.Operator.GREATER_THAN_OR_EQUAL;
-import static st.orm.Operator.IN;
 import static st.orm.Operator.LESS_THAN;
 import static st.orm.Operator.LESS_THAN_OR_EQUAL;
-import static st.orm.Operator.NOT_EQUALS;
-import static st.orm.Operator.NOT_IN;
 
 import jakarta.annotation.Nonnull;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.List;
-import java.util.SequencedMap;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import st.orm.Operator;
@@ -42,7 +35,6 @@ import st.orm.StormConfig;
 import st.orm.core.spi.DefaultSqlDialect;
 import st.orm.core.spi.JsonString;
 import st.orm.core.template.SqlDialect;
-import st.orm.core.template.SqlTemplateException;
 
 public class PostgreSQLSqlDialect extends DefaultSqlDialect implements SqlDialect {
 
@@ -156,34 +148,47 @@ public class PostgreSQLSqlDialect extends DefaultSqlDialect implements SqlDialec
     }
 
     /**
-     * Builds a multi-column expression using row value constructor syntax.
+     * Returns whether a multi-column comparison renders as a row value tuple, which for PostgreSQL is the case for
+     * an ordering comparison and for a multi-row list.
      *
-     * <p>PostgreSQL supports tuple comparison syntax for all comparison operators, producing compact SQL like
-     * {@code (a, b) > (?, ?)} instead of the lexicographic expansion used by the default implementation.</p>
+     * <p>PostgreSQL is the dialect that gets the most out of a row value comparison, and the only measured one
+     * where the lexicographic expansion is the worse plan. Measured on 17.9 against a 100k-row table keyed on
+     * {@code (a, b)}:</p>
      *
-     * <p>Operators without clear tuple semantics ({@code IS_NULL}, {@code IS_NOT_NULL}, {@code LIKE}, etc.) fall back
-     * to the {@link SqlDialect} default implementation.</p>
+     * <table border="1">
+     *   <caption>PostgreSQL 17 plan for each comparison shape</caption>
+     *   <tr><th>Shape</th><th>As a tuple</th><th>As the expansion</th><th>Rendered as</th></tr>
+     *   <tr><td>Single row of equality, UPDATE / DELETE</td>
+     *       <td>Index scan, {@code Index Cond: ((a = ?) AND (b = ?))}</td>
+     *       <td>Index scan, same condition</td><td>Expansion</td></tr>
+     *   <tr><td>Multi-row list (500 keys)</td><td>Bitmap scan over a 500-way {@code BitmapOr}</td>
+     *       <td>Identical plan</td><td><strong>Tuple</strong></td></tr>
+     *   <tr><td>Ordering comparison (selective bound)</td>
+     *       <td>Index scan, {@code Index Cond: (ROW(a, b) &gt; ROW(?, ?))}</td>
+     *       <td>Bitmap heap scan — <strong>~40x the estimated cost</strong></td>
+     *       <td><strong>Tuple</strong></td></tr>
+     * </table>
+     *
+     * <p>Equality and the list are decided in the planner's favour either way: it rewrites a row value equality
+     * into its conjunction and a row value list into the same {@code BitmapOr} the expansion produces, so the
+     * plans are indistinguishable. Equality therefore takes the expansion, the form that is safe on every dialect,
+     * and the list keeps the tuple for the compactness.</p>
+     *
+     * <p>The ordering comparison is the one shape where the choice changes the plan, and it favours the tuple
+     * decisively: the row value comparison drives the index directly, where the expansion has to be reassembled
+     * from a bitmap. This is the keyset pagination path, so it renders as a tuple.</p>
      *
      * @param operator the comparison operator to apply.
-     * @param values the multi-row values. Each map represents a single row of column-name-to-value mappings.
-     * @param parameterFunction the function responsible for binding the parameters.
-     * @return the SQL fragment representing the multi-column expression.
-     * @throws SqlTemplateException if the operator is not supported for multi-column expressions.
-     * @since 1.9
+     * @param rowCount the number of value rows in the comparison.
+     * @return {@code true} to render a row value tuple, {@code false} to render the {@code AND} expansion.
+     * @since 1.13
      */
     @Override
-    public String multiColumnExpression(@Nonnull Operator operator,
-                                         @Nonnull List<SequencedMap<String, Object>> values,
-                                         @Nonnull Function<Object, String> parameterFunction)
-            throws SqlTemplateException {
-        if (operator == EQUALS || operator == NOT_EQUALS
-                || operator == IN || operator == NOT_IN
+    protected boolean rendersTupleComparison(@Nonnull Operator operator, int rowCount) {
+        return isMultiRowEquality(operator, rowCount)
                 || operator == GREATER_THAN || operator == GREATER_THAN_OR_EQUAL
                 || operator == LESS_THAN || operator == LESS_THAN_OR_EQUAL
-                || operator == BETWEEN) {
-            return tupleExpression(operator, values, parameterFunction);
-        }
-        return super.multiColumnExpression(operator, values, parameterFunction);
+                || operator == BETWEEN;
     }
 
     /**

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
@@ -289,7 +289,7 @@ public class PostgreSQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -322,7 +322,7 @@ public class PostgreSQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);
@@ -432,7 +432,7 @@ public class PostgreSQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -487,7 +487,7 @@ public class PostgreSQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entity = repo.getById(1);
         var first = new AtomicBoolean(false);
@@ -554,7 +554,7 @@ public class PostgreSQLEntityRepositoryTest {
         String expectedSql = """
                 UPDATE owner
                 SET first_name = ?, last_name = ?, address = ?, city = ?, telephone = ?, version = version + 1
-                WHERE (id, version) = (?, ?)""";
+                WHERE id = ? AND version = ?""";
         var repo = PreparedStatementTemplate.ORM(dataSource).entity(Owner.class);
         var entities = repo.findAllById(List.of(1, 2));
         var first = new AtomicBoolean(false);

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLMultiColumnExpressionTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLMultiColumnExpressionTest.java
@@ -42,21 +42,21 @@ public class PostgreSQLMultiColumnExpressionTest {
     void equals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b) = (?, ?)", sql);
+        assertEquals("a = ? AND b = ?", sql);
     }
 
     @Test
     void equals_threeColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2, "c", 3));
         String sql = DIALECT.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b, c) = (?, ?, ?)", sql);
+        assertEquals("a = ? AND b = ? AND c = ?", sql);
     }
 
     @Test
     void notEquals_twoColumns() throws SqlTemplateException {
         var values = List.of(row("a", 1, "b", 2));
         String sql = DIALECT.multiColumnExpression(Operator.NOT_EQUALS, values, v -> "?");
-        assertEquals("(a, b) <> (?, ?)", sql);
+        assertEquals("NOT (a = ? AND b = ?)", sql);
     }
 
     @Test

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLSqlDialectTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLSqlDialectTest.java
@@ -276,10 +276,10 @@ class PostgreSQLSqlDialectTest {
     }
 
     @Test
-    void multiColumnExpressionShouldUseTupleSyntaxForEquals() throws Exception {
+    void multiColumnExpressionShouldExpandEquals() throws Exception {
         var values = List.of(row("a", 1, "b", 2));
         var result = dialect.multiColumnExpression(Operator.EQUALS, values, v -> "?");
-        assertEquals("(a, b) = (?, ?)", result);
+        assertEquals("a = ? AND b = ?", result);
     }
 
     @Test
@@ -290,10 +290,10 @@ class PostgreSQLSqlDialectTest {
     }
 
     @Test
-    void multiColumnExpressionShouldUseTupleSyntaxForNotEquals() throws Exception {
+    void multiColumnExpressionShouldExpandNotEquals() throws Exception {
         var values = List.of(row("a", 1, "b", 2));
         var result = dialect.multiColumnExpression(Operator.NOT_EQUALS, values, v -> "?");
-        assertEquals("(a, b) <> (?, ?)", result);
+        assertEquals("NOT (a = ? AND b = ?)", result);
     }
 
     @Test


### PR DESCRIPTION
## The defect

A multi-column key comparison rendered as a row value tuple on every dialect willing to emit one. MariaDB reduces that tuple to its conjunction in a `SELECT` but **not** in an `UPDATE` or a `DELETE`, where it considers no index at all.

Measured on MariaDB 10.5.22, confirmed on 11.4.12, against a 118k-row table keyed on `(study_id, user_id)`:

| Statement | `(a, b) = (?, ?)` | `a = ? AND b = ?` |
|---|---|---|
| `SELECT` | `const`, primary key, 1 row | `const`, primary key, 1 row |
| `UPDATE` | `index`, **no candidate key**, all rows | `range`, 1 row |
| `DELETE` | `ALL`, all rows | `range`, 1 row |

Timed over single-row updates, the tuple form is **~7500x slower per statement**. The read path reducing it is what makes this easy to miss: the tuple looks harmless until it reaches a write. A batch of keyed updates then becomes quadratic in the table, and because a scanning statement locks what it examines, two batches against one table deadlock rather than merely running slowly.

## The rule

Whether a tuple helps is a property of the operator and the planner, not of the grammar. Dialects now answer `rendersTupleComparison(operator, rowCount)` and a single `multiColumnExpression` acts on it; the four dialects that each carried an identical copy of that method keep only the predicate.

- **A single row of equality never renders as a tuple.** On every dialect measured the expansion ties the tuple or beats it, and this is the shape behind every keyed update, delete and lookup, so it takes the form that is safe everywhere.
- **A multi-row list keeps the tuple.** MariaDB plans `(a, b) IN ((?, ?), ...)` as a materialized semi-join, ~150x faster than the equivalent chain of ORs; MySQL is ~4x faster on the same shape.
- **An ordering comparison divides the dialects**, so each answers for itself. PostgreSQL drives the index directly from `(a, b) > (?, ?)` where the lexicographic expansion costs ~40x more, and H2 likewise. MySQL and MariaDB do the reverse: both accept the tuple, neither indexes it, and both full-scan where the expansion gives a range scan. Those two now expand, correcting a pessimization on the keyset pagination path that predates this change.

Every dialect documents the plans measured for it. SQLite and MS SQL Server never rendered tuples and are unchanged.

## Oracle

Oracle's plans were not measured. It keeps its prior answer for the shapes where a tuple might help and says so in its javadoc rather than implying otherwise; single-row equality follows the universal rule.

## Tests

Full suite green across all 9 modules, 3889 tests. Dialect SQL assertions updated to the forms above, and test names that promised tuple syntax renamed where they now assert the expansion.

`MariaDBEntityRepositoryTest.testRemoveByCompoundPkExpandsWhere` is a new regression test: it fails against the previous behaviour with `WHERE (vet_id, specialty_id) = (?, ?)` and passes with the expansion.