### PR TITLE
fix: settle transaction callbacks on the transaction that commits

### DIFF
--- a/docs/entity-lifecycle.md
+++ b/docs/entity-lifecycle.md
@@ -222,7 +222,7 @@ A callback that throws in order to block a removal only blocks the paths that ca
 
 ### Database Operations Inside Callbacks
 
-Callbacks execute in the same thread and transaction as the repository operation that triggered them. This means a callback can safely perform additional database work, such as inserting related entities, querying for validation data, or updating audit logs, and that work will participate in the same transaction. If the transaction rolls back, all changes made by callbacks roll back as well.
+Callbacks execute in the same thread and transaction as the repository operation that triggered them. This means a callback can safely perform additional database work, such as inserting related entities, querying for validation data, or updating audit logs, and that work will participate in the same transaction. If the transaction rolls back, all changes made by callbacks roll back as well. Work that must happen only once the transaction commits, and side effects outside the database that a rollback cannot take back, belong on a commit callback registered through a joining [`transaction { }`](transactions.md#registering-from-nested-code) block instead; see [Logging](#logging).
 
 In Spring Boot, callbacks are regular beans and can have repositories or other services injected through standard dependency injection. Outside Spring, a callback can capture a reference to the `ORMTemplate` or a repository at construction time.
 
@@ -378,7 +378,7 @@ public class ArticleValidationCallback implements EntityCallback<Article> {
 
 ### Logging
 
-The "after" callbacks are well-suited for logging, since they fire only after the database operation succeeds. This avoids logging mutations that were rolled back. What gets logged depends on the method that performed the write (see [After Callback Entity State](#after-callback-entity-state)): `insert` logs what your application sent, while `insertAndFetch` logs the stored row.
+The "after" callbacks are well-suited for logging, since they fire only after the database operation succeeds, so a statement that failed never produces an entry. What gets logged depends on the method that performed the write (see [After Callback Entity State](#after-callback-entity-state)): `insert` logs what your application sent, while `insertAndFetch` logs the stored row.
 
 ```java
 public class ArticleLoggingCallback implements EntityCallback<Article> {
@@ -400,3 +400,42 @@ public class ArticleLoggingCallback implements EntityCallback<Article> {
     }
 }
 ```
+
+They fire *within* the transaction, though, not after it commits. The statement succeeded, but the transaction it belongs to has not finished, so an entry written straight from the callback outlives a mutation that a later rollback undoes.
+
+That is fine for a log that records attempts. Where the record must reflect committed state, and for any side effect that cannot be taken back, such as publishing an event or invalidating a cache, the callback participates in the transaction the way any code does: it opens a joining [`transaction { }`](transactions.md#registering-from-nested-code) block and registers the work as a commit callback, which runs only if the transaction commits:
+
+<Tabs groupId="language">
+<TabItem value="kotlin" label="Kotlin" default>
+
+```kotlin
+class ArticlePublishingCallback : EntityCallback<Article> {
+    override fun afterInsert(entity: Article) {
+        transactionBlocking {
+            onCommit { events.publish(ArticlePublished(entity.id)) }
+        }
+    }
+}
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+public class ArticlePublishingCallback implements EntityCallback<Article> {
+    @Override
+    public void afterInsert(Article entity) {
+        Transactions.transaction(tx -> {
+            tx.onCommit(() -> events.publish(new ArticlePublished(entity.id())));
+            return null;
+        });
+    }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The pattern works the same under a Spring-managed transaction (`@Transactional`): the block detects the active Spring transaction, so the publish waits for Spring's commit. See [Mixed-Usage Caveats](transactions.md#mixed-usage-caveats) for the fine print.
+
+The callback fires once per entity, including for each row of a batch write, so registering there registers one callback per row. For anything beyond a handful, collect the entities and register a single callback for the batch instead.

--- a/docs/refs.md
+++ b/docs/refs.md
@@ -417,11 +417,6 @@ A path names the referenced table one column at a time. A query can also name th
 ```kotlin
 // Selects the referenced entity: the city table is joined on demand, and so is its own country foreign key.
 val cities = orm.entity<User>().select(City::class).resultList
-
-// Joins another table onto the referenced one. The join needs the city table, so the reference brings it in.
-val sharingACity = orm.entity<User>().select()
-    .innerJoin<User>().on<City>()
-    .resultList
 ```
 
 </TabItem>
@@ -430,21 +425,18 @@ val sharingACity = orm.entity<User>().select()
 ```java
 // Selects the referenced entity: the city table is joined on demand, and so is its own country foreign key.
 List<City> cities = orm.entity(User.class).select(City.class).getResultList();
-
-// Joins another table onto the referenced one. The join needs the city table, so the reference brings it in.
-List<User> sharingACity = orm.entity(User.class).select()
-    .innerJoin(User.class).on(City.class)
-    .getResultList();
 ```
 
 </TabItem>
 </Tabs>
 
-A query that names the table both ways gets one occurrence: a path navigating to it resolves against the same join. A table the query joins explicitly keeps that occurrence, so an explicit join stays in charge of the table it brings in.
+An explicit `innerJoin(...).on(City.class)` names the table the same way, and the reference brings it in for the join to resolve against. A query that names the table both ways gets one occurrence: a path navigating to it resolves against the same join, and a table the query joins explicitly keeps that occurrence, so an explicit join stays in charge of the table it brings in.
+
+Bringing the table in is not the same as resolving the reference. A join makes the referenced table available to the rest of the statement, and `select(City::class)` makes it the result, but neither one touches the `User.city` of a selected user: it stays an unloaded foreign key. Resolving it into the user is what [`fetch(User_.city)`](#resolving-a-ref-as-part-of-the-query) does, and it works on the select list rather than on the tables the query can name. The two also differ in what they do to the rows: an inner join drops users whose city does not match, while `fetch(...)` uses an outer join for a nullable reference so every row survives.
 
 ### What You Can and Cannot Do Beyond a Ref
 
-Nodes reached *beyond* a reference are **navigation-only**. They can be used anywhere a query needs a column reference: `where`, `orderBy`, `groupBy`, `having`, and custom selected columns. They cannot extract a value from an in-memory record, because a `Ref` is never hydrated into the parent, so value operations (such as `getValue` or `resultGroupedBy`) are not available on them and fail to compile. The reference node itself (`User_.city`) is value-extractable and yields the `Ref`, so grouping by the reference with `resultGroupedByRef` works. See [Navigating Through Refs](metamodel.md#navigating-through-refs) for the type-level details.
+Nodes reached *beyond* a reference are **navigation-only**. They can be used anywhere a query needs a column reference: `where`, `orderBy`, `groupBy`, `having`, and custom selected columns. They cannot extract a value from an in-memory record, because a `Ref` is never hydrated into the parent, so value operations (such as `getValue` or `resultGroupedBy`) are not available on them and fail to compile. The reference node itself (`User_.city`) is value-extractable and yields the `Ref`, so grouping by the reference with [`resultGroupedByRef`](queries.md#grouped-results) works. See [Navigating Through Refs](metamodel.md#navigating-through-refs) for the type-level details.
 
 ### Designing Entities to Avoid Excessive Joins
 
@@ -547,16 +539,16 @@ By contrast, refs created with `Ref.of(entity)` wrap an already-loaded entity in
 | `Ref.of(entity)` | Yes (full entity) | Returns the wrapped entity | `false` |
 | Loaded by Storm (from query) | Yes (after fetch) | Returns entity or fetches from DB/cache | `true` |
 
-Use `Ref.of(entity)` when you already have the entity in memory and want to wrap it as a ref (for example, to pass into a method that expects `Ref<T>`). Use `Ref.of(type, primaryKey)` when you only have the ID and want a lightweight identifier for equality checks, map keys, or later resolution within a transaction context.
+Use `Ref.of(entity)` when you already have the entity in memory and want to wrap it as a ref (for example, to pass into a method that expects `Ref<T>`). Use `Ref.of(type, primaryKey)` when you only have the ID and want a lightweight identifier for equality checks, map keys, or a lookup you hand to a repository with `findByRef` or `findAllByRef`.
 
 ---
 
 ## Aggregation with Refs
 
+Refs are particularly useful in aggregation queries where you group by a foreign key. Instead of loading the full related entity for each group, you can select only the primary key as a Ref. This keeps the query lightweight while still giving you a typed identifier to use in subsequent lookups if needed.
+
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
-
-Refs are particularly useful in aggregation queries where you group by a foreign key. Instead of loading the full related entity for each group, you can select only the primary key as a Ref. This keeps the query lightweight while still giving you a typed identifier to use in subsequent lookups if needed.
 
 ```kotlin
 data class GroupedByCity(
@@ -597,6 +589,8 @@ Map<Ref<City>, Long> counts = orm.query(RAW."""
 
 </TabItem>
 </Tabs>
+
+The database does the aggregating, so one row per city comes back and the reference carries the key you group by. Fetch the cities themselves with `findAllByRef(counts.keys)` when a later step needs them.
 
 ---
 
@@ -653,7 +647,8 @@ Understanding how `fetch()` resolves its target helps you predict performance an
 - `getOrThrow()` and `getOrNull()` never query. They return what is already loaded, so they are the accessors to reach for when the query was meant to resolve the reference.
 - `fetch()` checks the [entity cache](entity-cache.md) before querying the database. If the entity was already loaded in the current transaction, no additional query is issued.
 - Multiple Refs pointing to the same entity share the cached instance within a transaction, preserving object identity.
-- Calling `fetch()` on a detached Ref created with `Ref.of(type, id)` will fail unless an active transaction context is available.
+- Calling `fetch()` on a detached Ref created with `Ref.of(type, id)` always fails. Fetching needs the `ORMTemplate` that produced the reference, and a detached one carries only a type and a key. An active transaction does not change that; pass the reference to `findByRef` or `findAllByRef` instead.
+- An attached Ref, conversely, needs no transaction of its own. It fetches over the connection its template provides, and that read runs in whatever transaction happens to be active at the time, or in none. There is no session to keep open and no state to lose, so a reference fetched outside a transaction reads exactly as it would inside one.
 
 ## Tips
 

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 
 Transaction management is fundamental to database programming. Storm takes a practical approach: rather than inventing new abstractions, it provides first-class support for standard transaction semantics while integrating seamlessly with your existing infrastructure.
 
-Storm works directly with JDBC transactions and supports both programmatic and declarative transaction management. For Kotlin, Storm provides a coroutine-friendly API inspired by Exposed. For Java, Storm integrates with Spring's transaction management or works directly with JDBC connections.
+Storm works directly with JDBC transactions and supports both programmatic and declarative transaction management. For Kotlin, Storm provides a coroutine-friendly API inspired by Exposed. For Java, Storm provides the same programmatic API through `Transactions.transaction(...)`, and integrates with Spring's transaction management or works directly with JDBC connections.
 
 ---
 
@@ -763,6 +763,10 @@ try {
 
 This design ensures that the root cause of a failure is never masked by callback errors.
 
+Callbacks a block defers to a Spring-managed transaction run as Spring synchronizations and follow Spring's
+rules instead: a failure there is logged by Spring rather than thrown. See
+[Mixed-Usage Caveats](#mixed-usage-caveats).
+
 #### Propagation Interaction
 
 Callbacks are tied to the **physical** transaction, not the logical scope. This distinction matters when nesting transactions with different propagation modes.
@@ -949,6 +953,35 @@ transaction {
 }
 ```
 
+#### Registering from Nested Code
+
+The callbacks above are registered on the block's own handle, which works wherever the block is in view. Code
+that runs *beneath* the block never sees that handle: an [entity callback](entity-lifecycle.md#logging), a
+service method several frames down is called by Storm or by your own code, not handed the transaction.
+
+Such code participates the same way any transactional code does: it opens a `transaction { }` block of its own.
+With joining propagation, the default, the block is the same transaction, and its callbacks defer to the
+outermost physical commit exactly as the [propagation rules](#propagation-interaction) describe:
+
+```kotlin
+class ArticleCallback : EntityCallback<Article> {
+    override fun afterInsert(entity: Article) {
+        transactionBlocking {
+            // Joins the transaction the insert runs in; the publish waits for its commit.
+            onCommit { events.publish(ArticlePublished(entity)) }
+        }
+    }
+}
+```
+
+The nested block adds no transaction of its own and, when it performs no database work, no work at all: it is a
+registration point. This holds inside Spring-managed transactions as well; see
+[Mixed-Usage Caveats](#mixed-usage-caveats) for the fine print.
+
+Register once per unit of work rather than once per record. An entity callback fires per entity, including for
+each row of a batch, so registering there means one callback per row held until commit. Collect into a list and
+register a single callback when the volume is more than a handful.
+
 ### Global Transaction Options
 
 Set defaults for all transactions:
@@ -984,7 +1017,7 @@ withTransactionOptionsBlocking(isolation = SERIALIZABLE) {
 
 ### How Transactions Bind to Templates
 
-Since 1.13, a `transaction` or `transactionBlocking` block binds to the first `ORMTemplate` that executes inside it. Opening the block only records the requested options (propagation, isolation, timeout, read-only); the actual transaction is opened by that first template's transaction provider. This means the block automatically uses whatever transaction system the template is configured with, whether that is Storm's own JDBC transactions or a platform bridge such as Spring's transaction management. A block that never touches a template completes as a no-op.
+Since 1.13, a `transaction` or `transactionBlocking` block binds to the first `ORMTemplate` that executes inside it. Opening the block only records the requested options (propagation, isolation, timeout, read-only); the actual transaction is opened by that first template's transaction provider. This means the block automatically uses whatever transaction system the template is configured with, whether that is Storm's own JDBC transactions or a platform bridge such as Spring's transaction management. A block that never touches a template completes as a no-op; callbacks it registered and a rollback-only mark still settle against the transaction that surrounds it, whether that is an outer Storm block or a detected externally managed transaction (see [Mixed-Usage Caveats](#mixed-usage-caveats)).
 
 Templates that should share a transaction must use the same transaction provider instance. This is automatic for repositories of one application (the Spring Boot starter and the Ktor plugin configure one provider per application context or plugin installation). Mixing templates with *different* transaction providers inside one block fails fast with a descriptive error, since a single commit cannot span two transaction systems.
 
@@ -1037,83 +1070,111 @@ class UserService(private val orm: ORMTemplate) {
 }
 ```
 
-#### Propagation Interaction
+#### Mixed-Usage Caveats
+
+Storm blocks and Spring-managed transactions compose without special care. A Storm block finds the transaction
+it belongs to in one of three ways: through Storm's own scope chain, when the surrounding transaction is
+another Storm block; through the first query that executes inside it (see
+[How Transactions Bind to Templates](#how-transactions-bind-to-templates)); or, when neither exists and the
+propagation is joining, by detecting the Spring transaction active on the thread. In every case the result is
+the same, whether or not the block performs database work: `onCommit` and `onRollback` wait for the transaction
+that actually commits, and `setRollbackOnly()` dooms it.
+
+That is what makes the [nested-code pattern](#registering-from-nested-code) work identically under
+`@Transactional`. An entity callback that runs inside a Spring-managed write registers its commit hook the same
+way it would inside a Storm-managed one:
+
+```kotlin
+class ArticlePublishingCallback : EntityCallback<Article> {
+    override fun afterInsert(entity: Article) {
+        transactionBlocking {
+            // The block detects the Spring transaction the insert runs in; the publish waits for its commit.
+            onCommit { events.publish(ArticlePublished(entity)) }
+        }
+    }
+}
+```
+
+Two limits remain:
+
+- Callbacks that wait for Spring's completion run as Spring transaction synchronizations, so a callback that
+  throws is logged by Spring rather than surfacing as a `TransactionCallbackException`.
+- The rules above describe joining propagation, the default. A `REQUIRES_NEW` block opens its own independent
+  transaction and fires its own callbacks, exactly as within Storm-managed transactions.
+
+#### Propagation with @Transactional
 
 Storm's propagation modes work with Spring transactions:
 
 ```kotlin
 @Transactional
-suspend fun processWithAudit(user: User) {
-    transaction {
+fun processWithAudit(user: User) {
+    transactionBlocking {
         orm insert user
     }
 
     // REQUIRES_NEW creates an independent transaction, even within Spring's transaction
-    transaction(propagation = REQUIRES_NEW) {
+    transactionBlocking(propagation = REQUIRES_NEW) {
         auditRepository.log("User created: ${user.id}")
         // Commits independently - audit survives even if outer transaction rolls back
     }
 }
 ```
 
-#### Suspend Functions with @Transactional
+#### Suspend Functions and @Transactional
 
-For suspend functions, use Spring's `@Transactional` with the coroutine-aware transaction manager:
+Spring's `@Transactional` does not support suspending functions with a JDBC `PlatformTransactionManager`:
+Spring requires a `ReactiveTransactionManager` for suspending methods, which JDBC does not provide. Storm's
+suspending `transaction { }` variant is likewise rejected with Spring-managed transactions, since Spring binds
+its transaction state to the calling thread.
+
+Keep the transactional boundary blocking and call it from coroutine code on an IO dispatcher:
 
 ```kotlin
-@Configuration
-@EnableTransactionManagement
-class TransactionConfig {
-    @Bean
-    fun transactionManager(dataSource: DataSource): ReactiveTransactionManager {
-        return DataSourceTransactionManager(dataSource)
-    }
-}
-
 @Service
 class OrderService(private val orm: ORMTemplate) {
 
     @Transactional
-    suspend fun placeOrder(order: Order): Order {
-        val savedOrder = orm insert order
-
-        // Can switch dispatchers while staying in the same transaction
-        withContext(Dispatchers.Default) {
-            calculateLoyaltyPoints(savedOrder)
-        }
-
-        return savedOrder
-    }
+    fun placeOrder(order: Order): Order = orm insert order
 }
+
+// From coroutine code:
+val saved = withContext(Dispatchers.IO) { orderService.placeOrder(order) }
 ```
+
+Dispatcher freedom inside a transaction — switching with `withContext` while staying in the same transaction —
+is a property of Storm-managed [suspend transactions](#suspend-transactions); a Spring-managed transaction stays
+on the thread that started it.
 
 #### Using Storm Without @Transactional
 
-You can also use Storm's programmatic transactions without Spring's `@Transactional`. Storm manages the transaction lifecycle directly:
+You can also use Storm's programmatic transactions without Spring's `@Transactional`. With the Spring-composed
+template the blocks run through Spring's transaction manager all the same; only the boundary is programmatic:
 
 ```kotlin
 @Service
 class UserService(private val orm: ORMTemplate) {
 
-    // No @Transactional needed - Storm handles it
-    suspend fun createUser(user: User): User {
-        return transaction {
-            orm insert user
-        }
+    // No @Transactional needed - the block drives the transaction
+    fun createUser(user: User): User = transactionBlocking {
+        orm insert user
     }
 
     // Explicit propagation and isolation
-    suspend fun transferFunds(from: Account, to: Account, amount: BigDecimal) {
-        transaction(
-            propagation = REQUIRED,
-            isolation = SERIALIZABLE
-        ) {
+    fun transferFunds(from: Account, to: Account, amount: BigDecimal) {
+        transactionBlocking(propagation = REQUIRED, isolation = SERIALIZABLE) {
             accountRepository.debit(from, amount)
             accountRepository.credit(to, amount)
         }
     }
 }
 ```
+
+### Ktor Route Transactions
+
+In Ktor, the [`transactional { }` route DSL](ktor-integration.md#route-scoped-transactions) wraps a group of routes so that
+every call to a route inside it runs in its own transaction, opened before the handler and committed when it returns.
+It takes the same options as `transaction { }` and leaves the handlers free of transaction code.
 
 </TabItem>
 <TabItem value="java" label="Java">
@@ -1192,6 +1253,30 @@ transaction(tx -> {
 ```
 
 Callbacks registered in a scope that joins an outer transaction are deferred to the outermost physical transaction's completion; `REQUIRES_NEW` scopes fire their own callbacks independently. The three kinds share one registration order: callbacks run in the order they were registered after the transaction has fully completed, skipping the ones that do not apply to the outcome. `onCompletion` receives whether the transaction committed, which is the variant for work that has to happen either way. If a callback throws, the remaining callbacks still execute and the failures surface as a `TransactionCallbackException` whose cause is the first one, with the rest suppressed; `isCommitted()` tells a failed side effect apart from a failed transaction, which need opposite responses, since retrying the former repeats work that already succeeded.
+
+### Registering from Nested Code
+
+Code that does not see the block's `tx` handle — an [entity callback](entity-lifecycle.md#logging), a helper
+several frames down — participates by opening a joining block of its own. With the default `REQUIRED`
+propagation its callbacks register on the transaction it joins and defer to the outermost physical commit:
+
+```java
+public class ArticleCallback implements EntityCallback<Article> {
+    @Override
+    public void afterInsert(Article entity) {
+        Transactions.transaction(tx -> {
+            // Joins the transaction the insert runs in; the publish waits for its commit.
+            tx.onCommit(() -> events.publish(new ArticlePublished(entity)));
+            return null;
+        });
+    }
+}
+```
+
+The nested block adds no transaction of its own and, when it performs no database work, no work at all: it is a
+registration point. This holds inside Spring-managed transactions as well; see
+[Mixed-Usage Caveats](#mixed-usage-caveats-1) for the fine print. Register once per unit of work rather than once
+per record: an entity callback fires per entity, including for each row of a batch.
 
 ### Global and Scoped Defaults
 
@@ -1308,9 +1393,9 @@ public class AuditService {
 }
 ```
 
-#### Programmatic Transactions
+#### Spring's TransactionTemplate
 
-While `@Transactional` works well for most cases, sometimes you need finer control over transaction boundaries. For example, processing a batch where each item should be in its own transaction, or conditionally rolling back based on runtime conditions. Spring's `TransactionTemplate` provides this control while still integrating with Spring's transaction infrastructure.
+While `@Transactional` works well for most cases, sometimes you need finer control over transaction boundaries. For example, processing a batch where each item should be in its own transaction, or conditionally rolling back based on runtime conditions. Spring's `TransactionTemplate` provides this control while still integrating with Spring's transaction infrastructure. Storm's own [`transaction(...)`](#programmatic-transactions) blocks are the alternative, with the same boundaries and Storm's callback API.
 
 ```java
 @Service
@@ -1361,6 +1446,39 @@ List<User> users = template.execute(status -> {
 });
 ```
 
+#### Mixed-Usage Caveats
+
+Storm blocks and Spring-managed transactions compose without special care. A Storm block finds the transaction
+it belongs to in one of three ways: through Storm's own scope chain, when the surrounding transaction is
+another Storm block; through the first query that executes inside it; or, when neither exists and the
+propagation is joining, by detecting the Spring transaction active on the thread. In every case the result is
+the same, whether or not the block performs database work: `onCommit` and `onRollback` wait for the transaction
+that actually commits, and `setRollbackOnly()` dooms it.
+
+That is what makes the [nested-code pattern](#registering-from-nested-code-1) work identically under
+`@Transactional`. An entity callback that runs inside a Spring-managed write registers its commit hook the same
+way it would inside a Storm-managed one:
+
+```java
+public class ArticlePublishingCallback implements EntityCallback<Article> {
+    @Override
+    public void afterInsert(Article entity) {
+        Transactions.transaction(tx -> {
+            // The block detects the Spring transaction the insert runs in; the publish waits for its commit.
+            tx.onCommit(() -> events.publish(new ArticlePublished(entity)));
+            return null;
+        });
+    }
+}
+```
+
+Two limits remain:
+
+- Callbacks that wait for Spring's completion run as Spring transaction synchronizations, so a callback that
+  throws is logged by Spring rather than surfacing as a `TransactionCallbackException`.
+- The rules above describe joining propagation, the default. A `REQUIRES_NEW` block opens its own independent
+  transaction and fires its own callbacks, exactly as within Storm-managed transactions.
+
 ### JDBC Transactions
 
 For applications not using Spring, or for maximum control, you can manage transactions directly through JDBC. Storm works with any JDBC connection. Create an `ORMTemplate` from the connection and use it within your transaction scope.
@@ -1410,19 +1528,25 @@ public class HybridService {
 
 ---
 
-## Important Notes
+## A Transaction Runs One Thing at a Time
 
-Understanding these nuances helps avoid common pitfalls when working with transactions.
+A transaction owns a single database connection, and a connection can serve only one caller at a time. That, rather than any particular thread, is what bounds a transaction.
 
-### Concurrency
+**Moving between threads is fine.** A Storm-managed suspend `transaction { }` travels with the coroutine context, so `withContext(Dispatchers.IO)` or `Dispatchers.Default` inside the block offloads work and comes back in the same transaction. `withContext` suspends the caller until it returns, so the transaction is still doing one thing at a time. The same holds for the blocking API on virtual threads: a block parks on I/O rather than pinning its carrier thread, and the transaction goes with it.
 
-Launching concurrent work inside a transaction using `async`, `launch`, or other parallel coroutine builders is **not supported**. Database transactions are bound to the calling thread/coroutine. Use sequential operations or split work into separate transactions if parallelism is required.
+**Doing two things at once is not.** Work started with `async`, `launch`, an `ExecutorService`, or a parallel stream *inherits* the transaction and then uses its connection concurrently, which the connection cannot serve. Await each unit before starting the next, or give the parallel work its own transactions.
 
-### RollbackOnly Semantics
+```kotlin
+transaction {
+    // Fine: sequential, even though it changes dispatcher and thread.
+    val report = withContext(Dispatchers.Default) { render(orm.findAll<Order>()) }
+    orm insert Archive(report)
 
-- In `NESTED` propagation: rolls back to the savepoint, preserving outer transaction's work
-- In `REQUIRED` or `REQUIRES_NEW`: affects the entire transaction scope
+    // Not supported: both halves would use this transaction's connection at once.
+    // val a = async { orm insert first }
+    // val b = async { orm insert second }
+    // awaitAll(a, b)
+}
+```
 
-### Context Switching (Kotlin)
-
-Within any transactional scope, you can switch dispatchers (e.g., `withContext(Dispatchers.Default)`) and still access the **same active transaction**. This allows offloading CPU-bound work without breaking transactional context.
+A Spring-managed transaction is bound to its thread rather than a coroutine context, so it does not travel across dispatchers at all; see [Suspend Functions and @Transactional](#suspend-functions-and-transactional).

--- a/storm-core/src/main/java/module-info.java
+++ b/storm-core/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module storm.core {
     uses st.orm.core.spi.SqlDialectProvider;
     uses st.orm.core.spi.ConnectionProvider;
     uses st.orm.core.spi.TransactionTemplateProvider;
+    uses st.orm.core.spi.ExternalTransactionProvider;
     uses st.orm.core.spi.CursorCodecProvider;
     uses st.orm.mapping.Instantiator;
     exports st.orm.core.template;

--- a/storm-core/src/main/java/st/orm/core/spi/ExternalTransactionProvider.java
+++ b/storm-core/src/main/java/st/orm/core/spi/ExternalTransactionProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.spi;
+
+import java.util.Optional;
+import st.orm.Transaction;
+
+/**
+ * Detects a transaction that an external transaction manager owns on the current thread, so that a
+ * transactional block that never binds to a template still settles against it: completion callbacks the block
+ * registered fire on the transaction's real outcome, and a rollback-only demand is pushed onto it.
+ *
+ * <p>Storm's own transactional blocks need no detection: they find each other through the transaction scope
+ * chain, and a block that executes a query binds to the surrounding transaction through the template's
+ * transaction provider. This SPI covers the one remaining case, where neither exists: a block that only
+ * registers callbacks inside a transaction the application opened through its framework, such as Spring's
+ * {@code @Transactional}.</p>
+ *
+ * <p>Implementations must be stateless, answering from the external manager's own thread-bound state alone.
+ * They carry no configuration, and they are never consulted for query execution or transaction control, so
+ * {@code ServiceLoader} discovery cannot change how templates behave; per-context configuration, such as the
+ * transaction managers a template runs through, stays on the composed, instance-scoped providers. Providers
+ * are asked in {@link Orderable} order and the first transaction found wins; an implementation returns an
+ * empty optional whenever its transaction manager has no transaction active on the current thread.</p>
+ *
+ * @since 1.13
+ */
+public interface ExternalTransactionProvider extends Provider {
+
+    /**
+     * Returns a handle to the externally managed transaction active on the current thread, if any.
+     *
+     * <p>The returned handle registers callbacks with the external transaction manager, which fires them when
+     * the physical transaction completes, and marks the transaction rollback-only through that manager.</p>
+     *
+     * @return the active transaction, or an empty optional when this provider's transaction manager has no
+     * transaction active on the current thread.
+     */
+    Optional<Transaction> currentTransaction();
+}

--- a/storm-core/src/main/java/st/orm/core/spi/Providers.java
+++ b/storm-core/src/main/java/st/orm/core/spi/Providers.java
@@ -70,6 +70,7 @@ public final class Providers {
     private static final Supplier<List<SqlDialectProvider>> SQL_DIALECT_PROVIDERS = createProviders(SqlDialectProvider.class);
     private static final Supplier<List<ConnectionProvider>> CONNECTION_PROVIDERS = createProviders(ConnectionProvider.class);
     private static final Supplier<List<TransactionTemplateProvider>> TRANSACTION_TEMPLATE_PROVIDERS = createProviders(TransactionTemplateProvider.class);
+    private static final Supplier<List<ExternalTransactionProvider>> EXTERNAL_TRANSACTION_PROVIDERS = createProviders(ExternalTransactionProvider.class);
 
     private static final ConcurrentMap<Object, List<?>> PROVIDER_CACHE = new ConcurrentHashMap<>();
 
@@ -357,6 +358,20 @@ public final class Providers {
     public static TransactionTemplateProvider getTransactionTemplateProvider() {
         return selectUnique(TRANSACTION_TEMPLATE_PROVIDERS, "transaction template provider",
                 "ORMTemplate.builder(dataSource).transactionTemplateProvider(...)");
+    }
+
+    /**
+     * Resolves the external transaction providers via {@code ServiceLoader} discovery, in resolution order.
+     *
+     * <p>Unlike the other lookups this one returns every enabled provider rather than a single winner: each
+     * detects only the transaction manager it bridges, so several can coexist and at most one has a
+     * transaction active on a given thread. Enablement is re-evaluated on every resolution.</p>
+     *
+     * @return the external transaction providers, in the order they are consulted.
+     * @since 1.13
+     */
+    public static List<ExternalTransactionProvider> getExternalTransactionProviders() {
+        return Orderable.sort(enabled(EXTERNAL_TRANSACTION_PROVIDERS)).toList();
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/spi/TransactionRunner.java
+++ b/storm-core/src/main/java/st/orm/core/spi/TransactionRunner.java
@@ -112,10 +112,20 @@ public final class TransactionRunner {
         CURRENT_CALLBACKS.set(callbacks);
         R value;
         boolean rollbackOnly;
+        // Read while the scope still holds its transaction state, which completing releases.
+        boolean joinedExternal;
+        boolean mayDefer;
+        boolean mayMark;
         try {
             value = block.execute(scopeTransaction(scope, callbacks));
             rollbackOnly = scope.isRollbackOnly();
+            joinedExternal = scope.joinedExistingTransaction();
+            mayDefer = mayDeferToExternal(scope);
+            mayMark = mayMarkExternalRollbackOnly(scope);
         } catch (Throwable e) {
+            joinedExternal = scope.joinedExistingTransaction();
+            mayDefer = mayDeferToExternal(scope);
+            mayMark = mayMarkExternalRollbackOnly(scope);
             // Restore and uninstall the scope before firing so callbacks see a clean state.
             restoreCallbacks(previousCallbacks);
             Throwable wrapped;
@@ -127,7 +137,7 @@ public final class TransactionRunner {
                 scope.close();
             }
             try {
-                callbacks.fireRollback();
+                complete(scope, callbacks, joinedExternal, mayDefer, mayMark, false);
             } catch (Throwable callbackException) {
                 wrapped.addSuppressed(callbackException);
             }
@@ -144,17 +154,13 @@ public final class TransactionRunner {
             }
         } catch (Throwable completionException) {
             try {
-                callbacks.fireRollback();
+                complete(scope, callbacks, joinedExternal, mayDefer, mayMark, false);
             } catch (Throwable callbackException) {
                 completionException.addSuppressed(callbackException);
             }
             throw sneakyThrow(completionException);
         }
-        if (rollbackOnly) {
-            callbacks.fireRollback();
-        } else {
-            callbacks.fireCommit();
-        }
+        complete(scope, callbacks, joinedExternal, mayDefer, rollbackOnly && mayMark, !rollbackOnly);
         return value;
     }
 
@@ -207,6 +213,114 @@ public final class TransactionRunner {
             return new TransactionTimedOutException(description != null ? base + " [" + description + "]" : base, e);
         }
         return e;
+    }
+
+    /**
+     * Settles the block's callbacks for the given outcome.
+     *
+     * <p>A block inside a physical transaction an external manager owns has not reached an outcome yet: that
+     * manager still decides one and commits. A block that joined the transaction hands its callbacks to its
+     * transaction handle, which registers them with the manager to fire on the real outcome, keeping their
+     * registration order. A block that never bound to a template settles the same way through the detected
+     * external transaction, which also receives the block's rollback-only demand, mirroring how a joined scope
+     * marks its parent. Everything else fires here, since the block's own transaction has completed.</p>
+     */
+    private static void complete(@Nonnull TransactionScope scope,
+                                 @Nonnull BlockingCallbacks callbacks,
+                                 boolean joinedExternal,
+                                 boolean mayDeferToExternal,
+                                 boolean markExternalRollbackOnly,
+                                 boolean committed) {
+        if (joinedExternal) {
+            if (!callbacks.isEmpty()) {
+                scope.deferCompletion(callbacks::fire);
+            }
+            return;
+        }
+        if (mayDeferToExternal && (markExternalRollbackOnly || !callbacks.isEmpty())) {
+            var external = externalTransaction();
+            if (external != null) {
+                if (markExternalRollbackOnly) {
+                    external.setRollbackOnly();
+                }
+                if (!callbacks.isEmpty()) {
+                    external.onCompletion(callbacks::fire);
+                }
+                return;
+            }
+        }
+        if (callbacks.isEmpty()) {
+            return;
+        }
+        if (committed) {
+            callbacks.fireCommit();
+        } else {
+            callbacks.fireRollback();
+        }
+    }
+
+    /**
+     * Returns whether the block may sit inside an externally managed transaction it never bound to: its scope
+     * never materialized while its propagation joins whatever transaction surrounds it. Settlement then asks
+     * the {@link ExternalTransactionProvider external transaction providers} whether one is active.
+     *
+     * <p>Must be called before the scope completes, since completing releases the transaction state this
+     * reads.</p>
+     *
+     * @param scope the scope of the completed block.
+     * @return {@code true} if the block's callbacks may belong to an external transaction.
+     * @since 1.13
+     */
+    public static boolean mayDeferToExternal(@Nonnull TransactionScope scope) {
+        return !scope.isMaterialized() && isJoining(scope.options().propagation());
+    }
+
+    /**
+     * Returns whether a rollback demand of an unbound block must be pushed onto the surrounding external
+     * transaction.
+     *
+     * <p>Mirrors {@link TransactionScope}'s parent-mark propagation: {@code REQUIRED}, {@code SUPPORTS} and
+     * {@code MANDATORY} join the surrounding transaction outright, so their rollback dooms it, while
+     * {@code NESTED} bounds its rollback at a savepoint. A materialized scope delivers the mark through its
+     * own handle, and needs no push here.</p>
+     *
+     * <p>Must be called before the scope completes, since completing releases the transaction state this
+     * reads.</p>
+     *
+     * @param scope the scope of the completed block.
+     * @return {@code true} if a rollback of the block must mark the surrounding external transaction.
+     * @since 1.13
+     */
+    public static boolean mayMarkExternalRollbackOnly(@Nonnull TransactionScope scope) {
+        if (scope.isMaterialized()) {
+            return false;
+        }
+        var propagation = scope.options().propagation();
+        return propagation == null
+                || propagation == TransactionPropagation.REQUIRED
+                || propagation == TransactionPropagation.SUPPORTS
+                || propagation == TransactionPropagation.MANDATORY;
+    }
+
+    /**
+     * Returns the handle of the externally managed transaction active on the current thread, asking each
+     * external transaction provider in resolution order and taking the first that answers, or {@code null}
+     * when there is none.
+     *
+     * <p>Exposed for language flows that own their callback orchestration, such as the Kotlin suspend flow,
+     * which settle their callbacks against the same external transaction this class does.</p>
+     *
+     * @return the externally managed transaction, or {@code null} when none is active.
+     * @since 1.13
+     */
+    public static @Nullable Transaction externalTransaction() {
+        for (var provider : Providers.getExternalTransactionProviders()) {
+            var transaction = provider.currentTransaction().orElse(null);
+            if (transaction != null) {
+                return transaction;
+            }
+        }
+        return null;
     }
 
     private static boolean isJoining(@Nullable TransactionPropagation propagation) {
@@ -293,6 +407,10 @@ public final class TransactionRunner {
         @Override
         public void addOnCompletion(@Nonnull Consumer<Boolean> callback) {
             callbacks.add(new Entry(true, true, callback));
+        }
+
+        boolean isEmpty() {
+            return callbacks.isEmpty();
         }
 
         void fireCommit() {

--- a/storm-core/src/main/java/st/orm/core/spi/TransactionScope.java
+++ b/storm-core/src/main/java/st/orm/core/spi/TransactionScope.java
@@ -17,6 +17,7 @@ package st.orm.core.spi;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import java.util.function.Consumer;
 import st.orm.PersistenceException;
 import st.orm.TransactionIsolation;
 import st.orm.TransactionPropagation;
@@ -227,6 +228,40 @@ public final class TransactionScope {
      */
     public @Nullable TransactionTemplateProvider owner() {
         return owner;
+    }
+
+    /**
+     * Returns whether this scope joined a physical transaction that an external transaction manager had already
+     * opened, which makes that manager, rather than this scope, the owner of its completion.
+     *
+     * <p>Must be read before the scope completes, since a provider releases the underlying transaction state as
+     * part of completing.</p>
+     *
+     * @return {@code true} if this scope materialized into an externally owned physical transaction.
+     * @since 1.13
+     */
+    public boolean joinedExistingTransaction() {
+        var currentHandle = handle;
+        return currentHandle != null && currentHandle.joinedExistingTransaction();
+    }
+
+    /**
+     * Hands a completion callback to the physical transaction this scope joined, so the external manager that
+     * owns it fires the callback on the real outcome.
+     *
+     * <p>Only valid for scopes that {@link #joinedExistingTransaction() joined an existing transaction}; the
+     * owning provider registers the callback with its transaction manager.</p>
+     *
+     * @param callback receives {@code true} when the external transaction commits and {@code false} when it
+     * rolls back.
+     * @since 1.13
+     */
+    public void deferCompletion(@Nonnull Consumer<Boolean> callback) {
+        var currentHandle = handle;
+        if (currentHandle == null) {
+            throw new IllegalStateException("Scope has not been materialized.");
+        }
+        currentHandle.deferCompletion(callback);
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/spi/TransactionTemplate.java
+++ b/storm-core/src/main/java/st/orm/core/spi/TransactionTemplate.java
@@ -20,6 +20,7 @@ import static java.util.Optional.ofNullable;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.Optional;
+import java.util.function.Consumer;
 import st.orm.PersistenceException;
 import st.orm.TransactionIsolation;
 import st.orm.TransactionPropagation;
@@ -136,6 +137,38 @@ public interface TransactionTemplate {
          * @return the transaction status; never {@code null}.
          */
         TransactionStatus status();
+
+        /**
+         * Returns whether this handle joined a physical transaction that an external transaction manager had
+         * already opened, rather than opening one of its own.
+         *
+         * <p>The distinction decides who completes the transaction, and therefore where completion callbacks
+         * belong: a handle that opened the transaction fires them when its block ends, while a handle that
+         * joined one defers them to the manager that will commit it, via {@link #deferCompletion(Consumer)}.
+         * Providers that always open their own transaction, such as the JDBC one, keep the default.</p>
+         *
+         * @return {@code true} if the physical transaction was already open and this handle joined it.
+         * @since 1.13
+         */
+        default boolean joinedExistingTransaction() {
+            return false;
+        }
+
+        /**
+         * Registers a completion callback with the physical transaction this handle joined.
+         *
+         * <p>Called only for handles that {@link #joinedExistingTransaction() joined an existing transaction}:
+         * the external manager owns the commit, so the callback must fire on that manager's outcome rather
+         * than at the end of the block. The provider registers it with its transaction manager, under Spring
+         * as a transaction synchronization. Providers that never join keep the default.</p>
+         *
+         * @param callback receives {@code true} when the transaction commits and {@code false} when it rolls
+         * back.
+         * @since 1.13
+         */
+        default void deferCompletion(@Nonnull Consumer<Boolean> callback) {
+            throw new UnsupportedOperationException("This transaction handle does not defer completion.");
+        }
 
         /**
          * Completes the opened transaction.

--- a/storm-java21/src/test/java/st/orm/template/TransactionCallbackTest.java
+++ b/storm-java21/src/test/java/st/orm/template/TransactionCallbackTest.java
@@ -208,4 +208,21 @@ public class TransactionCallbackTest {
                 }));
         assertEquals(List.of("inner-rollback"), events);
     }
+
+    @Test
+    public void aNestedBlockRegistersCallbacksOnTheTransactionItJoins() {
+        List<String> events = new ArrayList<>();
+        transaction(outer -> {
+            countVisits();
+            // Code that does not see the outer handle, such as an entity callback, participates by opening a
+            // joining block of its own; its callbacks defer to the outermost physical commit.
+            transaction(inner -> {
+                inner.onCommit(() -> events.add("commit"));
+                return null;
+            });
+            assertEquals(List.of(), events);
+            return null;
+        });
+        assertEquals(List.of("commit"), events);
+    }
 }

--- a/storm-kotlin/src/main/kotlin/st/orm/template/Transactions.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/Transactions.kt
@@ -175,30 +175,36 @@ suspend fun <T> transaction(
             TransactionOutcome(value, scope.isRollbackOnly)
         }
     } catch (e: Throwable) {
+        // Read while the scope still holds its transaction state, which completing releases.
+        val mayDefer = TransactionRunner.mayDeferToExternal(scope)
+        val mayMark = TransactionRunner.mayMarkExternalRollbackOnly(scope)
         val wrapped = try {
             TransactionRunner.completeAfterFailure(scope, e)
         } catch (completionException: Throwable) {
             completionException
         }
         try {
-            callbacks.fireRollback()
+            callbacks.settle(mayDefer, mayMark, committed = false)
         } catch (callbackException: Throwable) {
             wrapped.addSuppressed(callbackException)
         }
         throw wrapped
     }
+    // Read while the scope still holds its transaction state, which completing releases.
+    val mayDefer = TransactionRunner.mayDeferToExternal(scope)
+    val mayMark = TransactionRunner.mayMarkExternalRollbackOnly(scope)
     try {
         scope.complete(false)
         TransactionRunner.afterSuccessfulCompletion(scope)
     } catch (completionException: Throwable) {
         try {
-            callbacks.fireRollback()
+            callbacks.settle(mayDefer, mayMark, committed = false)
         } catch (callbackException: Throwable) {
             completionException.addSuppressed(callbackException)
         }
         throw completionException
     }
-    if (outcome.rollbackOnly) callbacks.fireRollback() else callbacks.fireCommit()
+    callbacks.settle(mayDefer, outcome.rollbackOnly && mayMark, committed = !outcome.rollbackOnly)
     return outcome.value
 }
 

--- a/storm-kotlin/src/main/kotlin/st/orm/template/impl/TransactionCallbacks.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/impl/TransactionCallbacks.kt
@@ -15,7 +15,9 @@
  */
 package st.orm.template.impl
 
+import kotlinx.coroutines.runBlocking
 import st.orm.TransactionCallbackException
+import st.orm.core.spi.TransactionRunner
 import java.util.function.Consumer
 
 /**
@@ -70,6 +72,30 @@ internal class TransactionCallbacks : st.orm.core.spi.TransactionCallbacks {
 
     override fun addOnCompletion(callback: Consumer<Boolean>) {
         callbacks += Entry(onCommit = true, onRollback = true) { committed -> callback.accept(committed) }
+    }
+
+    /**
+     * Settles the callbacks for the given outcome, honoring external ownership of the physical transaction:
+     * the suspend-flow counterpart of the blocking flow's settlement in [TransactionRunner].
+     *
+     * When [mayDeferToExternal] and an external transaction is detected, the callbacks are handed over to fire
+     * on that transaction's outcome, and [markExternalRollbackOnly] pushes the block's rollback demand onto it.
+     * The external manager completes on its own thread without a coroutine context, so the transferred
+     * callbacks are bridged via `runBlocking`, matching the blocking flow's documented callback semantics.
+     * Otherwise the callbacks fire here for the given outcome.
+     */
+    suspend fun settle(mayDeferToExternal: Boolean, markExternalRollbackOnly: Boolean, committed: Boolean) {
+        if (mayDeferToExternal && (markExternalRollbackOnly || callbacks.isNotEmpty())) {
+            val external = TransactionRunner.externalTransaction()
+            if (external != null) {
+                if (markExternalRollbackOnly) external.setRollbackOnly()
+                if (callbacks.isNotEmpty()) {
+                    external.onCompletion { externalOutcome -> runBlocking { fire(externalOutcome) } }
+                }
+                return
+            }
+        }
+        if (committed) fireCommit() else fireRollback()
     }
 
     suspend fun fireCommit() {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/TransactionCallbackTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/TransactionCallbackTest.kt
@@ -442,4 +442,23 @@ open class TransactionCallbackTest(
         }
         events shouldBe listOf("first", "second")
     }
+
+    @Test
+    fun `a nested blocking block registers callbacks on the suspend transaction it joins`(): Unit = runBlocking {
+        val events = mutableListOf<String>()
+        transaction {
+            orm.exists<Visit>()
+            // Code that does not see this block's receiver, such as an entity callback, participates by opening
+            // a joining block of its own; its callbacks defer to the outermost physical commit.
+            registerAuditHook(events)
+            events shouldBe emptyList()
+        }
+        events shouldBe listOf("commit")
+    }
+
+    private fun registerAuditHook(events: MutableList<String>) {
+        transactionBlocking {
+            onCommit { events += "commit" }
+        }
+    }
 }

--- a/storm-spring/src/main/java/module-info.java
+++ b/storm-spring/src/main/java/module-info.java
@@ -25,4 +25,5 @@ module storm.spring {
     exports st.orm.spring;
     exports st.orm.spring.boot;
     exports st.orm.spring.impl;
+    provides st.orm.core.spi.ExternalTransactionProvider with st.orm.spring.SpringExternalTransactionProvider;
 }

--- a/storm-spring/src/main/java/st/orm/spring/SpringExternalTransactionProvider.java
+++ b/storm-spring/src/main/java/st/orm/spring/SpringExternalTransactionProvider.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.springframework.transaction.support.TransactionSynchronization.STATUS_COMMITTED;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.springframework.transaction.NoTransactionException;
+import org.springframework.transaction.interceptor.TransactionAspectSupport;
+import org.springframework.transaction.support.ResourceHolderSupport;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import st.orm.PersistenceException;
+import st.orm.Transaction;
+import st.orm.core.spi.ExternalTransactionProvider;
+
+/**
+ * Detects a Spring-managed transaction on the current thread, so a Storm transactional block that never binds
+ * to a template still settles against it: completion callbacks the block registered fire on the Spring
+ * transaction's real outcome, and a rollback-only demand marks the Spring transaction.
+ *
+ * <p>The provider is stateless and reads Spring's thread-bound transaction state directly, which is what makes
+ * {@code ServiceLoader} discovery safe: it carries no configuration, works identically for every application
+ * context in the JVM, and is never consulted for query execution or transaction control. Per-context
+ * configuration, such as the transaction managers a template runs through, stays on the composed
+ * {@link SpringTransactionTemplateProvider}.</p>
+ *
+ * <p>Callbacks are registered as a {@link TransactionSynchronization} on the physical transaction, which is
+ * what makes {@code onCommit} mean the same thing here as inside a Storm-managed transaction: it runs after
+ * Spring commits, and not at all when Spring rolls back.</p>
+ *
+ * @since 1.13
+ */
+public class SpringExternalTransactionProvider implements ExternalTransactionProvider {
+
+    @Override
+    public Optional<Transaction> currentTransaction() {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+            return empty();
+        }
+        return of(new SpringTransaction());
+    }
+
+    /**
+     * Handle to the Spring transaction active on the current thread.
+     *
+     * <p>Synchronizations are registered per callback rather than once per handle, so a handle that is resolved
+     * and never used adds nothing to the transaction.</p>
+     */
+    private static final class SpringTransaction implements Transaction {
+
+        @Override
+        public boolean isRollbackOnly() {
+            var status = aspectStatus();
+            if (status != null) {
+                return status.isRollbackOnly();
+            }
+            return boundResources().anyMatch(ResourceHolderSupport::isRollbackOnly);
+        }
+
+        @Override
+        public void setRollbackOnly() {
+            var status = aspectStatus();
+            if (status != null) {
+                status.setRollbackOnly();
+                return;
+            }
+            // A transaction driven by Spring's TransactionTemplate binds no aspect status, so the mark goes on
+            // the resource holders the transaction manager reads when it decides the outcome, which is the same
+            // place its own doSetRollbackOnly writes.
+            var marked = boundResources().peek(ResourceHolderSupport::setRollbackOnly).count();
+            if (marked == 0) {
+                throw new PersistenceException("""
+                        A Spring transaction is active, but it holds no resource to mark rollback-only and no \
+                        transaction status is bound to this thread. This happens when transaction \
+                        synchronization was activated without Spring driving a resource transaction. Run the \
+                        work under @Transactional or Spring's TransactionTemplate, or open the transaction with \
+                        Storm's transaction API.""");
+            }
+        }
+
+        @Override
+        public void onCommit(@Nonnull Runnable callback) {
+            requireNonNull(callback, "callback");
+            register(committed -> {
+                if (committed) {
+                    callback.run();
+                }
+            });
+        }
+
+        @Override
+        public void onRollback(@Nonnull Runnable callback) {
+            requireNonNull(callback, "callback");
+            register(committed -> {
+                if (!committed) {
+                    callback.run();
+                }
+            });
+        }
+
+        @Override
+        public void onCompletion(@Nonnull Consumer<Boolean> callback) {
+            requireNonNull(callback, "callback");
+            register(callback);
+        }
+
+        /**
+         * Registers a completion callback with the physical Spring transaction. Spring fires synchronizations
+         * in registration order and reports the outcome through {@code afterCompletion}, which matches the
+         * ordering and outcome contract of the callbacks a Storm block collects.
+         */
+        private void register(@Nonnull Consumer<Boolean> callback) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCompletion(int status) {
+                    callback.accept(status == STATUS_COMMITTED);
+                }
+            });
+        }
+
+        /**
+         * Returns the transaction status Spring's interceptor bound to this thread, or {@code null} when the
+         * transaction was not driven through the interceptor, as with Spring's {@code TransactionTemplate}.
+         */
+        private static @Nullable org.springframework.transaction.TransactionStatus aspectStatus() {
+            try {
+                return TransactionAspectSupport.currentTransactionStatus();
+            } catch (NoTransactionException e) {
+                return null;
+            }
+        }
+
+        /**
+         * Returns the resource holders bound to the active transaction, which carry its rollback-only state
+         * when no aspect status is available.
+         */
+        private static Stream<ResourceHolderSupport> boundResources() {
+            return TransactionSynchronizationManager.getResourceMap().values().stream()
+                    .filter(ResourceHolderSupport.class::isInstance)
+                    .map(ResourceHolderSupport.class::cast);
+        }
+    }
+}

--- a/storm-spring/src/main/java/st/orm/spring/SpringTransactionTemplateProvider.java
+++ b/storm-spring/src/main/java/st/orm/spring/SpringTransactionTemplateProvider.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
@@ -180,6 +181,23 @@ public class SpringTransactionTemplateProvider implements TransactionTemplatePro
                                 return context.isRollbackOnly();
                             }
                         };
+                    }
+
+                    @Override
+                    public boolean joinedExistingTransaction() {
+                        return context.joinedExistingTransaction();
+                    }
+
+                    @Override
+                    public void deferCompletion(@Nonnull Consumer<Boolean> callback) {
+                        // The Spring-managed transaction this handle joined owns the commit; the callback fires
+                        // on its outcome, as a synchronization on the physical transaction.
+                        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                            @Override
+                            public void afterCompletion(int status) {
+                                callback.accept(status == TransactionSynchronization.STATUS_COMMITTED);
+                            }
+                        });
                     }
 
                     @Override

--- a/storm-spring/src/main/java/st/orm/spring/impl/SpringTransactionContext.java
+++ b/storm-spring/src/main/java/st/orm/spring/impl/SpringTransactionContext.java
@@ -159,6 +159,22 @@ public final class SpringTransactionContext implements TransactionContext {
         return stack.isEmpty() ? null : stack.getLast();
     }
 
+    /**
+     * Returns whether the current frame joined a Spring transaction that was already open, which happens when
+     * the surrounding code is {@code @Transactional} or drives Spring's own {@code TransactionTemplate}. Spring
+     * then owns the completion, so the frame's commit is a participation rather than a physical commit.
+     *
+     * <p>A frame whose transaction has not started yet joined nothing, and neither did a frame that opened its
+     * own transaction, such as one propagating {@code REQUIRES_NEW}.</p>
+     *
+     * @return {@code true} if the current frame participates in an externally opened Spring transaction.
+     * @since 1.13
+     */
+    public boolean joinedExistingTransaction() {
+        var state = lastOrNull();
+        return state != null && state.transactionStatus != null && !state.transactionStatus.isNewTransaction();
+    }
+
     @Override
     public Optional<String> describe() {
         var state = lastOrNull();

--- a/storm-spring/src/main/resources/META-INF/services/st.orm.core.spi.ExternalTransactionProvider
+++ b/storm-spring/src/main/resources/META-INF/services/st.orm.core.spi.ExternalTransactionProvider
@@ -1,0 +1,1 @@
+st.orm.spring.SpringExternalTransactionProvider

--- a/storm-spring/src/test/java/st/orm/spring/SpringTransactionBridgeTest.java
+++ b/storm-spring/src/test/java/st/orm/spring/SpringTransactionBridgeTest.java
@@ -149,6 +149,159 @@ class SpringTransactionBridgeTest {
     }
 
     @Test
+    void joinedBlockDefersCallbacksToTheSpringCommit() {
+        var events = new java.util.ArrayList<String>();
+        var springTransaction = new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        springTransaction.executeWithoutResult(status -> {
+            transaction(tx -> {
+                tx.onCommit(() -> events.add("commit"));
+                tx.onRollback(() -> events.add("rollback"));
+                insertVisit("joined");
+                return null;
+            });
+            // The joined block has returned, but the physical Spring transaction is still open.
+            assertEquals(List.of(), events, "callbacks must not fire while the physical transaction is open");
+            status.setRollbackOnly();
+        });
+        assertEquals(List.of("rollback"), events);
+    }
+
+    @Test
+    void joinedBlockCallbacksFireOnTheSpringCommit() {
+        var events = new java.util.ArrayList<String>();
+        var springTransaction = new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        springTransaction.executeWithoutResult(status -> {
+            transaction(tx -> {
+                tx.onCommit(() -> events.add("commit"));
+                tx.onRollback(() -> events.add("rollback"));
+                insertVisit("joined, kept");
+                return null;
+            });
+            assertEquals(List.of(), events, "callbacks must wait for the Spring commit");
+        });
+        assertEquals(List.of("commit"), events);
+    }
+
+    @Test
+    void entityCallbackParticipatesInAStormManagedTransaction() {
+        var events = new java.util.ArrayList<String>();
+        // An entity callback wanting commit-time work participates by opening a joining block of its own. The
+        // block joins the Storm-managed transaction the insert runs in, so the callback fires on its outcome.
+        ORMTemplate withCallback = orm.withEntityCallback(new st.orm.EntityCallback<Visit>() {
+            @Override
+            public void afterInsert(@jakarta.annotation.Nonnull Visit entity) {
+                transaction(tx -> {
+                    tx.onCommit(() -> events.add("inserted " + entity.description()));
+                    return null;
+                });
+            }
+        });
+        transaction(tx -> {
+            withCallback.entity(Visit.class).insert(new Visit(null, LocalDate.now(), "kept", pet, Instant.now()));
+            assertEquals(List.of(), events, "the log must wait for the commit");
+            return null;
+        });
+        assertEquals(List.of("inserted kept"), events);
+
+        events.clear();
+        assertThrows(IllegalStateException.class, () ->
+                transaction(tx -> {
+                    withCallback.entity(Visit.class).insert(new Visit(null, LocalDate.now(), "undone", pet, Instant.now()));
+                    throw new IllegalStateException("Fail the transaction.");
+                }));
+        assertEquals(List.of(), events, "a rolled-back insert must not be logged as if it had been applied");
+    }
+
+    @Test
+    void entityCallbackDefersItsLogToTheSpringCommit() {
+        var events = new java.util.ArrayList<String>();
+        // The same pattern as under Storm-managed transactions: the callback opens a joining block of its own.
+        // The block runs no query, so the detected Spring transaction is what its onCommit waits for.
+        ORMTemplate withCallback = orm.withEntityCallback(new st.orm.EntityCallback<Visit>() {
+            @Override
+            public void afterInsert(@jakarta.annotation.Nonnull Visit entity) {
+                transaction(tx -> {
+                    tx.onCommit(() -> events.add("inserted " + entity.description()));
+                    return null;
+                });
+            }
+        });
+        var springTransaction = new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        springTransaction.executeWithoutResult(status -> {
+            withCallback.entity(Visit.class).insert(new Visit(null, LocalDate.now(), "kept", pet, Instant.now()));
+            assertEquals(List.of(), events, "the log must wait for the commit");
+        });
+        assertEquals(List.of("inserted kept"), events);
+
+        events.clear();
+        springTransaction.executeWithoutResult(status -> {
+            withCallback.entity(Visit.class).insert(new Visit(null, LocalDate.now(), "undone", pet, Instant.now()));
+            status.setRollbackOnly();
+        });
+        assertEquals(List.of(), events, "a rolled-back insert must not be logged as if it had been applied");
+    }
+
+    @Test
+    void registrationOnlyBlockDefersCallbacksToTheSpringCommit() {
+        // The block performs no database work, so it never binds to a template; the detected Spring transaction
+        // is what settles its callbacks.
+        var events = new java.util.ArrayList<String>();
+        var springTransaction = new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        springTransaction.executeWithoutResult(status -> {
+            transaction(tx -> {
+                tx.onCommit(() -> events.add("commit"));
+                tx.onRollback(() -> events.add("rollback"));
+                return null;
+            });
+            assertEquals(List.of(), events, "callbacks must wait for the Spring commit");
+        });
+        assertEquals(List.of("commit"), events);
+    }
+
+    @Test
+    void registrationOnlyBlockCallbacksFollowTheSpringRollback() {
+        var events = new java.util.ArrayList<String>();
+        var springTransaction = new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        springTransaction.executeWithoutResult(status -> {
+            transaction(tx -> {
+                tx.onCommit(() -> events.add("commit"));
+                tx.onRollback(() -> events.add("rollback"));
+                return null;
+            });
+            status.setRollbackOnly();
+        });
+        assertEquals(List.of("rollback"), events);
+    }
+
+    @Test
+    void registrationOnlyBlockPropagatesRollbackOnlyToSpring() {
+        long before = visits.count();
+        var springTransaction = new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        // Spring reports a transaction that was marked rollback-only from within, rather than rolling back
+        // silently, which is how it treats every rollback-only mark it did not make itself.
+        assertThrows(org.springframework.transaction.UnexpectedRollbackException.class, () ->
+                springTransaction.executeWithoutResult(status -> {
+                    insertVisit("doomed by the inner mark");
+                    transaction(tx -> {
+                        tx.setRollbackOnly();
+                        return null;
+                    });
+                }));
+        assertEquals(before, visits.count());
+    }
+
+    @Test
+    void registrationOnlyBlockWithoutAnyTransactionFiresAtBlockEnd() {
+        // No transaction anywhere: block end is the completion, so the callbacks fire there.
+        var events = new java.util.ArrayList<String>();
+        transaction(tx -> {
+            tx.onCommit(() -> events.add("commit"));
+            return null;
+        });
+        assertEquals(List.of("commit"), events);
+    }
+
+    @Test
     void providerWithoutManagersRejectsStormInitiatedTransactions() {
         ORMTemplate unbridged = ORMTemplate.builder(dataSource)
                 .connectionProvider(new SpringConnectionProvider())


### PR DESCRIPTION
## The bug

A `transaction { }` block inside a Spring-managed transaction fired its `onCommit` callbacks as soon as the block ended. The callback ran while the transaction was still open, and reported a commit even when Spring went on to roll back — the opposite of what `onCommit` promises.

```java
springTransaction.executeWithoutResult(status -> {
    transaction(tx -> {
        tx.onCommit(() -> events.add("commit"));
        insertVisit("joined");
        return null;
    });
    // "commit" had already fired here, inside the still-open transaction.
    status.setRollbackOnly();
});
// ...and the write was discarded anyway.
```

## The fix

Callbacks settle on the outcome of the transaction that actually commits, through two paths:

- **Bound through a query.** The block joined the physical transaction, so it hands its callbacks to the manager that owns it, via the new `TransactionHandle.joinedExistingTransaction()` / `deferCompletion(...)` on the existing instance-scoped SPI.
- **Never bound to a template.** A block that only registers callbacks has no query to bind it, so it settles through the new `ExternalTransactionProvider` SPI, which detects the externally managed transaction active on the thread. `storm-spring` implements it over `TransactionSynchronizationManager`.

In both paths callbacks register as Spring synchronizations in registration order, and `setRollbackOnly()` in an unbound block marks the surrounding transaction, mirroring how a joined scope marks its parent (`NESTED` stays bounded at its savepoint). `REQUIRES_NEW` blocks own their transaction and keep firing their own callbacks; a block with no transaction anywhere still fires at block end, unchanged.

The result is one contract everywhere: code that does not see a block's handle — an entity callback in particular — registers commit-time work by opening a joining block, and that behaves identically under Storm-managed and Spring-managed transactions.

## On the new SPI

`ExternalTransactionProvider` is discovered via `ServiceLoader`, which 1.13 otherwise moved away from for the Spring modules. The distinction is deliberate and documented on the interface: it is stateless *capability detection*, carrying no configuration, identical for every application context in the JVM, and never consulted for query execution or transaction control — so its discovery cannot change how any template behaves. Per-context *configuration*, such as the transaction managers a template runs through, stays on the composed, instance-scoped providers.

## Documentation

The transaction docs gain a section on registering from nested code, and the mixed-usage limitation is replaced by the fine print that remains after the fix. Two corrections found while auditing:

- The thread-binding note claimed a transaction cannot cross threads. A suspend transaction travels with the coroutine context, so `withContext(Dispatchers.IO)` stays in it; the real limit is concurrent use of one connection, which is also why `async`/`launch` fan-out is unsupported — they inherit the transaction and contend for its connection.
- The suspend-with-`@Transactional` example built a `ReactiveTransactionManager` from `DataSourceTransactionManager`, which does not compile, and claimed dispatcher switching stays in the Spring transaction.

Also: duplicate section names removed, the missing pointer to Ktor's `transactional { }` routes added, and in the Ref docs a self-join example dropped that returned duplicate rows (13 root rows in, 16 out) under a variable name promising deduplicated ones.

## Tests

- `SpringTransactionBridgeTest`: 15 tests, covering the joined-block regression, registration-only deferral, rollback propagation to Spring, no-transaction-anywhere, and an entity callback that logs on commit and stays silent on rollback.
- `storm-java21` 31, `storm-kotlin` 147, `storm-kotlin-spring` 111 transaction tests, both starters and test-autoconfigure green. The Java and Kotlin modules run without the detector on the classpath, confirming no behavior change where `storm-spring` is absent.