### PR TITLE
fix: resolve metamodel field types from the canonical constructor

### DIFF
--- a/storm-metamodel-processor/src/main/java/st/orm/metamodel/MetamodelProcessor.java
+++ b/storm-metamodel-processor/src/main/java/st/orm/metamodel/MetamodelProcessor.java
@@ -460,10 +460,16 @@ public final class MetamodelProcessor extends AbstractProcessor {
     @Nullable
     private TypeMirror getTypeElement(@Nonnull Element recordElement, @Nonnull String fieldName,
                                       boolean applyMetamodelType) {
-        var constructors = recordElement.getEnclosedElements()
-                .stream()
-                .filter(enclosed -> enclosed.getKind() == CONSTRUCTOR)
-                .toList();
+        // The canonical constructor defines the component types. A convenience constructor may reuse a component name
+        // for a parameter of another type — a record holding a Ref<City> taking the City it refers to, say — so
+        // scanning every constructor would resolve the field to whichever one is enclosed first.
+        var canonicalConstructor = findCanonicalConstructor(recordElement);
+        var constructors = canonicalConstructor != null
+                ? List.<Element>of(canonicalConstructor)
+                : recordElement.getEnclosedElements()
+                        .stream()
+                        .filter(enclosed -> enclosed.getKind() == CONSTRUCTOR)
+                        .toList();
         for (var constructor : constructors) {
             var parameters = ((ExecutableElement) constructor).getParameters();
             for (var parameter : parameters) {


### PR DESCRIPTION
`getTypeElement()` scanned every constructor of a record and returned the first parameter whose name matched the field it was resolving.

A record can have a convenience constructor that reuses a component name for a parameter of a different type: one holding a `Ref<City>` that also takes the `City` it refers to, for example. In that case the field's resolved type came down to which constructor `getEnclosedElements()` returned first, which is not something the processor should depend on.

This resolves from the canonical constructor, which is what defines the component types, and falls back to scanning all constructors only when there is no canonical one to find (non-records, or a record whose canonical constructor cannot be identified).

`isDataType()` already preferred the canonical constructor with the same fallback, so the two paths now agree.

### Verification

`storm-core` builds and its full suite passes against the changed processor: 2495 tests, 0 failures. Reactor build of `storm-metamodel-processor -am` succeeds.

Worth flagging: `storm-metamodel-processor` has no test sources of its own, so the coverage here is entirely downstream through the modules that run the processor. A record with a name-colliding convenience constructor is not in any existing fixture, so nothing currently pins this behavior directly.