### PR TITLE
fix(website): align tutorial snippet versions with the tested toolchain

### DIFF
--- a/website/src/pages/quickstart.js
+++ b/website/src/pages/quickstart.js
@@ -41,7 +41,7 @@ function buildBody(version) {
     P('}\n\n') +
     F('dependencies') + P(' {\n') +
     P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-h2"') + P(')          ') + C('// zero-setup in-memory database\n') +
-    P('    ') + F('runtimeOnly') + P('(') + S('"com.h2database:h2:2.2.224"') + P(')\n') +
+    P('    ') + F('runtimeOnly') + P('(') + S('"com.h2database:h2:2.3.232"') + P(')\n') +
     P('}');
 
   const entity =

--- a/website/src/pages/tutorials/build-a-rest-api.js
+++ b/website/src/pages/tutorials/build-a-rest-api.js
@@ -27,14 +27,14 @@ function buildBody(version) {
     C('// build.gradle.kts\n') +
     F('plugins') + P(' {\n') +
     P('    ') + F('kotlin') + P('(') + S('"jvm"') + P(') version ') + S(`"${kotlin}"`) + P('\n') +
-    P('    ') + F('id') + P('(') + S('"io.ktor.plugin"') + P(') version ') + S('"3.0.3"') + P('\n') +
+    P('    ') + F('id') + P('(') + S('"io.ktor.plugin"') + P(') version ') + S('"3.4.3"') + P('\n') +
     P('    ') + F('id') + P('(') + S('"com.google.devtools.ksp"') + P(') version ') + S(`"${ksp}"`) + P('\n') +
     P('    ') + F('id') + P('(') + S('"st.orm"') + P(') version ') + S(`"${version}"`) + P('\n') +
     P('}\n\n') +
     F('dependencies') + P(' {\n') +
     P('    ') + F('implementation') + P('(') + S('"st.orm:storm-ktor"') + P(')\n') +
     P('    ') + F('runtimeOnly') + P('(') + S('"st.orm:storm-h2"') + P(')\n') +
-    P('    ') + F('runtimeOnly') + P('(') + S('"com.h2database:h2:2.2.224"') + P(')\n\n') +
+    P('    ') + F('runtimeOnly') + P('(') + S('"com.h2database:h2:2.3.232"') + P(')\n\n') +
     P('    ') + F('implementation') + P('(') + S('"io.ktor:ktor-server-netty"') + P(')\n') +
     P('    ') + F('implementation') + P('(') + S('"io.ktor:ktor-server-content-negotiation"') + P(')\n') +
     P('    ') + F('implementation') + P('(') + S('"io.ktor:ktor-serialization-jackson"') + P(')\n') +


### PR DESCRIPTION
## Summary

The quickstart and the "Build a REST API from scratch" tutorial render their Gradle snippets from JS, and the Storm version in them already tracks releases automatically: both read `siteConfig.customFields.stormVersion`, which resolves via `website/plugins/read-storm-version.js` to `versions.json[0]` while the pom `<revision>` is a snapshot. So `id("st.orm") version "…"` will pick up 1.13.0 on its own when `release.yml` pushes the docs snapshot.

The other coordinates in those same snippets are plain literals and had drifted.

| File | Was | Now |
| --- | --- | --- |
| `tutorials/build-a-rest-api.js` | `io.ktor.plugin` 3.0.3 | 3.4.3 |
| `tutorials/build-a-rest-api.js` | `com.h2database:h2:2.2.224` | 2.3.232 |
| `quickstart.js` | `com.h2database:h2:2.2.224` | 2.3.232 |

## Why these versions

- **Ktor 3.4.3** is the root pom's `<ktor.version>`, i.e. what `storm-ktor` is compiled against, and what `storm-example-kotlin-ktor` uses. The plugin portal is at 3.5.1, but the Ktor Gradle plugin applies a matching Ktor BOM, and pinning 3.5.1 would hand readers a Ktor version Storm is not built or tested against.
- **H2 2.3.232** is the version Spring Boot 3.5.6 manages, so it is the driver the whole test suite runs on. Central is at 2.4.240, untested here.

`KOTLIN_VARIANTS` in `src/components/tutorial/tutorialTheme.js` needed no change: Kotlin 2.4.0 is selected and KSP 2.3.10 is the newest release on Central. No other Ktor or H2 literals exist in `docs/`, `README.md`, or the rest of `website/src`.

## Test plan

- `npx docusaurus build` succeeds.
- Built HTML for `/quickstart` and `/tutorials/build-a-rest-api` renders `3.4.3` and `h2:2.3.232`; the Storm version still renders `1.12.1`, as expected before the 1.13.0 snapshot lands.