### PR TITLE
fix: resolve the validation dialect from the database product

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/impl/DatabaseSchema.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/DatabaseSchema.java
@@ -23,10 +23,14 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import st.orm.core.template.SqlDialect.ConstraintDiscoveryStrategy;
 import st.orm.core.template.SqlDialect.SequenceDiscoveryStrategy;
 
@@ -39,6 +43,8 @@ import st.orm.core.template.SqlDialect.SequenceDiscoveryStrategy;
  * @since 1.9
  */
 public final class DatabaseSchema {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("st.orm.validation");
 
     /**
      * Represents a column discovered from the database metadata.
@@ -106,25 +112,55 @@ public final class DatabaseSchema {
             @Nonnull String pkColumnName
     ) {}
 
+    /**
+     * A kind of constraint a schema read discovers.
+     *
+     * <p>Each kind is read by one query (or one set of metadata calls) per strategy, so a failure applies to the
+     * kind as a whole. See {@link #isDiscovered(ConstraintKind)} for why the outcome is recorded.</p>
+     */
+    public enum ConstraintKind {
+        /** Primary keys and unique keys, which every strategy reads together. */
+        KEY,
+        /** Foreign keys. */
+        FOREIGN_KEY
+    }
+
     // Case-insensitive maps: table name -> columns/PKs/UKs/FKs.
     private final SortedMap<String, List<DbColumn>> columnsByTable;
     private final SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable;
     private final SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable;
     private final SortedMap<String, List<DbForeignKey>> foreignKeysByTable;
     private final SortedMap<String, Boolean> sequences;
+    private final Set<ConstraintKind> discoveredConstraints;
 
     private DatabaseSchema(
             @Nonnull SortedMap<String, List<DbColumn>> columnsByTable,
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
             @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
-            @Nonnull SortedMap<String, Boolean> sequences
+            @Nonnull SortedMap<String, Boolean> sequences,
+            @Nonnull Set<ConstraintKind> discoveredConstraints
     ) {
         this.columnsByTable = columnsByTable;
         this.primaryKeysByTable = primaryKeysByTable;
         this.uniqueKeysByTable = uniqueKeysByTable;
         this.foreignKeysByTable = foreignKeysByTable;
         this.sequences = sequences;
+        this.discoveredConstraints = discoveredConstraints;
+    }
+
+    /**
+     * Returns whether constraints of the given kind were actually read from the database.
+     *
+     * <p>A metadata query that fails leaves the corresponding map empty, which reads exactly like a schema that has
+     * no such constraints. Callers that would otherwise report a constraint as missing must check this first, so a
+     * database that cannot answer the query is reported as unknown rather than as wrong.</p>
+     *
+     * @param kind the constraint kind to check.
+     * @return {@code true} if the read succeeded, {@code false} if it failed and the constraints are unknown.
+     */
+    public boolean isDiscovered(@Nonnull ConstraintKind kind) {
+        return discoveredConstraints.contains(kind);
     }
 
     /**
@@ -203,11 +239,14 @@ public final class DatabaseSchema {
             }
         }
         // Discover primary keys, unique keys, and foreign keys using the dialect-provided strategy.
+        Set<ConstraintKind> discoveredConstraints = EnumSet.noneOf(ConstraintKind.class);
         readConstraints(connection, metadata, catalog, schemaPattern, columnsByTable,
-                primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, constraintDiscoveryStrategy);
+                primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, constraintDiscoveryStrategy,
+                discoveredConstraints);
         // Discover sequences using the dialect-provided strategy.
         readSequences(connection, catalog, schemaPattern, sequences, sequenceDiscoveryStrategy);
-        return new DatabaseSchema(columnsByTable, primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, sequences);
+        return new DatabaseSchema(columnsByTable, primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, sequences,
+                discoveredConstraints);
     }
 
     // ------------------------------------------------------------------------------------------------------------------
@@ -226,21 +265,22 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
             @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
-            @Nonnull ConstraintDiscoveryStrategy strategy
+            @Nonnull ConstraintDiscoveryStrategy strategy,
+            @Nonnull Set<ConstraintKind> discovered
     ) throws SQLException {
         switch (strategy) {
             case JDBC_METADATA -> readConstraintsFromJdbcMetadata(
                     metadata, catalog, schemaPattern, columnsByTable,
-                    primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable);
+                    primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, discovered);
             case INFORMATION_SCHEMA -> readConstraintsFromInformationSchema(
                     connection, catalog, schemaPattern, columnsByTable,
-                    primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable);
+                    primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, discovered);
             case INFORMATION_SCHEMA_REFERENCING -> readConstraintsFromInformationSchemaReferencing(
                     connection, catalog, schemaPattern, columnsByTable,
-                    primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable);
+                    primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, discovered);
             case ALL_CONSTRAINTS -> readConstraintsFromAllConstraints(
                     connection, schemaPattern, columnsByTable,
-                    primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable);
+                    primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, discovered);
         }
     }
 
@@ -257,8 +297,11 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbColumn>> columnsByTable,
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
-            @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable
+            @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
+            @Nonnull Set<ConstraintKind> discovered
     ) throws SQLException {
+        boolean keysRead = true;
+        boolean foreignKeysRead = true;
         for (String tableName : new ArrayList<>(columnsByTable.keySet())) {
             try (ResultSet primaryKeys = metadata.getPrimaryKeys(catalog, schemaPattern, tableName)) {
                 while (primaryKeys.next()) {
@@ -268,8 +311,10 @@ public final class DatabaseSchema {
                     primaryKeysByTable.computeIfAbsent(pkTableName, k -> new ArrayList<>())
                             .add(new DbPrimaryKey(pkTableName, columnName, keySeq));
                 }
-            } catch (SQLException ignored) {
-                // Some databases/views may not support getPrimaryKeys; skip gracefully.
+            } catch (SQLException e) {
+                // Some databases/views may not support getPrimaryKeys; the keys stay unknown.
+                LOGGER.debug("Failed to read primary keys for table '{}'.", tableName, e);
+                keysRead = false;
             }
         }
         for (String tableName : new ArrayList<>(columnsByTable.keySet())) {
@@ -287,8 +332,10 @@ public final class DatabaseSchema {
                     uniqueKeysByTable.computeIfAbsent(tableName, k -> new ArrayList<>())
                             .add(new DbUniqueKey(tableName, indexName, columnName, ordinalPosition));
                 }
-            } catch (SQLException ignored) {
-                // Some databases/views may not support getIndexInfo; skip gracefully.
+            } catch (SQLException e) {
+                // Some databases/views may not support getIndexInfo; the keys stay unknown.
+                LOGGER.debug("Failed to read unique indexes for table '{}'.", tableName, e);
+                keysRead = false;
             }
         }
         for (String tableName : new ArrayList<>(columnsByTable.keySet())) {
@@ -301,9 +348,17 @@ public final class DatabaseSchema {
                     foreignKeysByTable.computeIfAbsent(fkTableName, k -> new ArrayList<>())
                             .add(new DbForeignKey(fkTableName, fkColumnName, pkTableName, pkColumnName));
                 }
-            } catch (SQLException ignored) {
-                // Some databases/views may not support getImportedKeys; skip gracefully.
+            } catch (SQLException e) {
+                // Some databases/views may not support getImportedKeys; the keys stay unknown.
+                LOGGER.debug("Failed to read foreign keys for table '{}'.", tableName, e);
+                foreignKeysRead = false;
             }
+        }
+        if (keysRead) {
+            discovered.add(ConstraintKind.KEY);
+        }
+        if (foreignKeysRead) {
+            discovered.add(ConstraintKind.FOREIGN_KEY);
         }
     }
 
@@ -363,7 +418,8 @@ public final class DatabaseSchema {
             @Nullable String schemaPattern,
             @Nonnull SortedMap<String, List<DbColumn>> columnsByTable,
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
-            @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable
+            @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
+            @Nonnull Set<ConstraintKind> discovered
     ) {
         try {
             StringBuilder sql = new StringBuilder("""
@@ -398,8 +454,10 @@ public final class DatabaseSchema {
                     }
                 }
             }
-        } catch (SQLException ignored) {
-            // INFORMATION_SCHEMA views not available; constraint validation will be skipped.
+            discovered.add(ConstraintKind.KEY);
+        } catch (SQLException e) {
+            // INFORMATION_SCHEMA views not available; the keys stay unknown.
+            LOGGER.debug("Failed to read primary and unique keys from INFORMATION_SCHEMA.", e);
         }
     }
 
@@ -415,10 +473,11 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbColumn>> columnsByTable,
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
-            @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable
+            @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
+            @Nonnull Set<ConstraintKind> discovered
     ) {
         readPrimaryAndUniqueKeysFromInformationSchema(
-                connection, catalog, schemaPattern, columnsByTable, primaryKeysByTable, uniqueKeysByTable);
+                connection, catalog, schemaPattern, columnsByTable, primaryKeysByTable, uniqueKeysByTable, discovered);
         // Foreign keys: join REFERENTIAL_CONSTRAINTS with KEY_COLUMN_USAGE on both sides, matching columns by
         // POSITION_IN_UNIQUE_CONSTRAINT.
         try {
@@ -451,8 +510,10 @@ public final class DatabaseSchema {
                             .add(new DbForeignKey(fkTableName, fkColumnName, pkTableName, pkColumnName));
                 }
             }
-        } catch (SQLException ignored) {
-            // REFERENTIAL_CONSTRAINTS not available; foreign key validation will be skipped.
+            discovered.add(ConstraintKind.FOREIGN_KEY);
+        } catch (SQLException e) {
+            // REFERENTIAL_CONSTRAINTS not available; the foreign keys stay unknown.
+            LOGGER.debug("Failed to read foreign keys from INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS.", e);
         }
     }
 
@@ -467,13 +528,14 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbColumn>> columnsByTable,
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
-            @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable
+            @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
+            @Nonnull Set<ConstraintKind> discovered
     ) {
         // For databases that use catalogs as schemas, the catalog value represents the database name and maps to
         // TABLE_SCHEMA in INFORMATION_SCHEMA views (not TABLE_CATALOG).
         String effectiveSchema = schemaPattern != null ? schemaPattern : catalog;
         readPrimaryAndUniqueKeysFromInformationSchema(
-                connection, null, effectiveSchema, columnsByTable, primaryKeysByTable, uniqueKeysByTable);
+                connection, null, effectiveSchema, columnsByTable, primaryKeysByTable, uniqueKeysByTable, discovered);
         // Foreign keys: use REFERENCED_TABLE_NAME and REFERENCED_COLUMN_NAME columns in KEY_COLUMN_USAGE.
         try {
             StringBuilder sql = new StringBuilder("""
@@ -496,8 +558,10 @@ public final class DatabaseSchema {
                             .add(new DbForeignKey(fkTableName, fkColumnName, pkTableName, pkColumnName));
                 }
             }
-        } catch (SQLException ignored) {
-            // REFERENCED columns not available; foreign key validation will be skipped.
+            discovered.add(ConstraintKind.FOREIGN_KEY);
+        } catch (SQLException e) {
+            // REFERENCED columns not available; the foreign keys stay unknown.
+            LOGGER.debug("Failed to read foreign keys from INFORMATION_SCHEMA.KEY_COLUMN_USAGE.", e);
         }
     }
 
@@ -510,7 +574,8 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbColumn>> columnsByTable,
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
-            @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable
+            @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
+            @Nonnull Set<ConstraintKind> discovered
     ) {
         // Primary keys and unique constraints.
         try {
@@ -544,8 +609,10 @@ public final class DatabaseSchema {
                     }
                 }
             }
-        } catch (SQLException ignored) {
-            // ALL_CONSTRAINTS not available; primary key and unique key validation will be skipped.
+            discovered.add(ConstraintKind.KEY);
+        } catch (SQLException e) {
+            // ALL_CONSTRAINTS not available; the keys stay unknown.
+            LOGGER.debug("Failed to read primary and unique keys from ALL_CONSTRAINTS.", e);
         }
         // Foreign keys.
         try {
@@ -580,8 +647,10 @@ public final class DatabaseSchema {
                             .add(new DbForeignKey(fkTableName, fkColumnName, pkTableName, pkColumnName));
                 }
             }
-        } catch (SQLException ignored) {
-            // ALL_CONSTRAINTS FK query not available; foreign key validation will be skipped.
+            discovered.add(ConstraintKind.FOREIGN_KEY);
+        } catch (SQLException e) {
+            // ALL_CONSTRAINTS FK query not available; the foreign keys stay unknown.
+            LOGGER.debug("Failed to read foreign keys from ALL_CONSTRAINTS.", e);
         }
     }
 

--- a/storm-core/src/main/java/st/orm/core/template/impl/JpaTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/JpaTemplateImpl.java
@@ -26,9 +26,13 @@ import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import st.orm.BindVars;
 import st.orm.Data;
 import st.orm.Ref;
@@ -47,6 +51,7 @@ import st.orm.core.template.ORMTemplate;
 import st.orm.core.template.PreparedQuery;
 import st.orm.core.template.Query;
 import st.orm.core.template.Sql;
+import st.orm.core.template.SqlDialect;
 import st.orm.core.template.SqlTemplate;
 import st.orm.core.template.SqlTemplate.NamedParameter;
 import st.orm.core.template.SqlTemplate.PositionalParameter;
@@ -58,6 +63,15 @@ import st.orm.mapping.ForeignKeyResolver;
 import st.orm.mapping.TableNameResolver;
 
 public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JpaTemplateImpl.class);
+
+    /** The properties a persistence unit publishes its data source under, newest name first. */
+    private static final List<String> DATA_SOURCE_PROPERTIES = List.of(
+            "jakarta.persistence.nonJtaDataSource",
+            "jakarta.persistence.jtaDataSource",
+            "javax.persistence.nonJtaDataSource",
+            "javax.persistence.jtaDataSource");
 
     @FunctionalInterface
     private interface TemplateProcessor {
@@ -71,6 +85,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
     private final RefFactory refFactory;
     private final SqlTemplate sqlTemplate;
     private final StormConfig config;
+    private final SqlDialect dialect;
 
     public JpaTemplateImpl(@Nonnull EntityManager entityManager) {
         this(entityManager, StormConfig.defaults());
@@ -95,15 +110,61 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
         this.tableAliasResolver = TableAliasResolver.DEFAULT;
         this.providerFilter = null;
         this.config = config;
+        this.dialect = resolveDialect(entityManager, config);
         this.refFactory = new RefFactoryImpl(this, modelBuilder, providerFilter);
         this.sqlTemplate = createSqlTemplate();
+    }
+
+    /**
+     * Resolves the dialect for the database behind the given entity manager.
+     *
+     * <p>Asking the persistence unit for its data source is the portable way to reach the database: unwrapping an
+     * entity manager to a {@link java.sql.Connection} is not supported by every provider. A persistence unit
+     * configured with a connection URL rather than a data source, or one whose database cannot be reached while the
+     * template is being built, leaves the database unknown, and the dialect then comes from the classpath as
+     * before.</p>
+     */
+    private static SqlDialect resolveDialect(@Nonnull EntityManager entityManager, @Nonnull StormConfig config) {
+        DataSource dataSource = dataSourceOf(entityManager);
+        if (dataSource == null) {
+            return Providers.getSqlDialect(config);
+        }
+        try {
+            return Providers.getSqlDialect(dataSource, config);
+        } catch (RuntimeException e) {
+            LOGGER.debug("Failed to determine the database of the persistence unit.", e);
+            return Providers.getSqlDialect(config);
+        }
+    }
+
+    /**
+     * Returns the data source the persistence unit was configured with, or {@code null} if it was configured
+     * without one. Both the Jakarta Persistence property names and their Java Persistence predecessors are
+     * consulted, since providers carry the legacy names forward.
+     */
+    private static @Nullable DataSource dataSourceOf(@Nonnull EntityManager entityManager) {
+        Map<String, Object> properties;
+        try {
+            properties = entityManager.getEntityManagerFactory().getProperties();
+        } catch (RuntimeException e) {
+            LOGGER.debug("Failed to read the properties of the persistence unit.", e);
+            return null;
+        }
+        for (String property : DATA_SOURCE_PROPERTIES) {
+            if (properties.get(property) instanceof DataSource dataSource) {
+                return dataSource;
+            }
+        }
+        return null;
     }
 
     private JpaTemplateImpl(@Nonnull TemplateProcessor templateProcessor,
                             @Nonnull ModelBuilder modelBuilder,
                             @Nonnull TableAliasResolver tableAliasResolver,
                             @Nullable Predicate<Provider> providerFilter,
-                            @Nonnull StormConfig config) {
+                            @Nonnull StormConfig config,
+                            @Nonnull SqlDialect dialect) {
+        this.dialect = dialect;
         this.templateProcessor = templateProcessor;
         this.modelBuilder = modelBuilder;
         this.tableAliasResolver = tableAliasResolver;
@@ -119,10 +180,10 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
                 .withColumnNameResolver(modelBuilder.columnNameResolver())
                 .withForeignKeyResolver(modelBuilder.foreignKeyResolver())
                 .withTableAliasResolver(tableAliasResolver);
-        if (providerFilter != null) {
-            template = template.withDialect(Providers.getSqlDialect(providerFilter, config));
-        }
-        return template;
+        // The shared template resolves a dialect without a database in view, so the dialect resolved for this
+        // persistence unit is applied on top. An explicit provider filter still wins.
+        return template.withDialect(
+                providerFilter != null ? Providers.getSqlDialect(providerFilter, config) : dialect);
     }
 
     private void setParameters(@Nonnull jakarta.persistence.Query query, @Nonnull List<SqlTemplate.Parameter> parameters) {
@@ -225,7 +286,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
      */
     @Override
     public JpaTemplate withTableNameResolver(@Nullable TableNameResolver tableNameResolver) {
-        return new JpaTemplateImpl(templateProcessor, modelBuilder.tableNameResolver(tableNameResolver), tableAliasResolver, providerFilter, config);
+        return new JpaTemplateImpl(templateProcessor, modelBuilder.tableNameResolver(tableNameResolver), tableAliasResolver, providerFilter, config, dialect);
     }
 
     /**
@@ -236,7 +297,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
      */
     @Override
     public JpaTemplate withColumnNameResolver(@Nullable ColumnNameResolver columnNameResolver) {
-        return new JpaTemplateImpl(templateProcessor, modelBuilder.columnNameResolver(columnNameResolver), tableAliasResolver, providerFilter, config);
+        return new JpaTemplateImpl(templateProcessor, modelBuilder.columnNameResolver(columnNameResolver), tableAliasResolver, providerFilter, config, dialect);
     }
 
     /**
@@ -247,7 +308,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
      */
     @Override
     public JpaTemplate withForeignKeyResolver(@Nullable ForeignKeyResolver foreignKeyResolver) {
-        return new JpaTemplateImpl(templateProcessor, modelBuilder.foreignKeyResolver(foreignKeyResolver), tableAliasResolver, providerFilter, config);
+        return new JpaTemplateImpl(templateProcessor, modelBuilder.foreignKeyResolver(foreignKeyResolver), tableAliasResolver, providerFilter, config, dialect);
     }
 
     /**
@@ -258,7 +319,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
      */
     @Override
     public JpaTemplate withTableAliasResolver(@Nonnull TableAliasResolver tableAliasResolver) {
-        return new JpaTemplateImpl(templateProcessor, modelBuilder, tableAliasResolver, providerFilter, config);
+        return new JpaTemplateImpl(templateProcessor, modelBuilder, tableAliasResolver, providerFilter, config, dialect);
     }
 
     /**
@@ -269,7 +330,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
      */
     @Override
     public JpaTemplate withProviderFilter(@Nullable Predicate<Provider> providerFilter) {
-        return new JpaTemplateImpl(templateProcessor, modelBuilder, tableAliasResolver, providerFilter, config);
+        return new JpaTemplateImpl(templateProcessor, modelBuilder, tableAliasResolver, providerFilter, config, dialect);
     }
 
     private class JpaPreparedQuery implements PreparedQuery {

--- a/storm-core/src/main/java/st/orm/core/template/impl/ORMTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/ORMTemplateImpl.java
@@ -171,9 +171,12 @@ public final class ORMTemplateImpl extends QueryTemplateImpl implements ORMTempl
                     "Schema validation requires a DataSource-backed template. "
                     + "Templates created from a Connection or EntityManager do not support schema validation.");
         }
+        // Without an explicit provider filter, the dialect comes from the database this template is bound to. The
+        // schema is read with vendor-specific queries, so a dialect picked without consulting the database reads it
+        // with queries the database may not understand.
         var sqlDialect = providerFilter != null
                 ? Providers.getSqlDialect(providerFilter, config)
-                : Providers.getSqlDialect(config);
+                : Providers.getSqlDialect(dataSource, config);
         return SchemaValidator.of(dataSource, modelBuilder, sqlDialect);
     }
 

--- a/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/PreparedStatementTemplateImpl.java
@@ -141,6 +141,7 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
     private final IntegrationStrategies strategies;
     private final SqlTemplate sqlTemplate;
     private final StormConfig config;
+    private final SqlDialect dialect;
 
     public PreparedStatementTemplateImpl(@Nonnull DataSource dataSource) {
         this(dataSource, StormConfig.defaults());
@@ -201,12 +202,20 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
                                           @Nonnull DataSource dataSource,
                                           @Nonnull StormConfig config,
                                           @Nullable SqlDialectProvider matchedProvider) {
-        this(createDataSourceProcessor(dataSource, strategies,
-                        matchedProvider != null ? matchedProvider.getSqlDialect(config) : getSqlDialect(config)),
+        this(strategies, dataSource, config, matchedProvider,
+                matchedProvider != null ? matchedProvider.getSqlDialect(config) : getSqlDialect(config));
+    }
+
+    private PreparedStatementTemplateImpl(@Nonnull IntegrationStrategies strategies,
+                                          @Nonnull DataSource dataSource,
+                                          @Nonnull StormConfig config,
+                                          @Nullable SqlDialectProvider matchedProvider,
+                                          @Nonnull SqlDialect dialect) {
+        this(createDataSourceProcessor(dataSource, strategies, dialect),
                 dataSource,
                 ModelBuilder.newInstance(), TableAliasResolver.DEFAULT,
                 matchedProvider != null ? matchedProvider.getProviderFilter() : null,
-                strategies, config);
+                strategies, config, dialect);
     }
 
     public PreparedStatementTemplateImpl(@Nonnull Connection connection) {
@@ -266,12 +275,20 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
                                           @Nonnull Connection connection,
                                           @Nonnull StormConfig config,
                                           @Nullable SqlDialectProvider matchedProvider) {
-        this(createConnectionProcessor(connection, strategies,
-                        matchedProvider != null ? matchedProvider.getSqlDialect(config) : getSqlDialect(config)),
+        this(strategies, connection, config, matchedProvider,
+                matchedProvider != null ? matchedProvider.getSqlDialect(config) : getSqlDialect(config));
+    }
+
+    private PreparedStatementTemplateImpl(@Nonnull IntegrationStrategies strategies,
+                                          @Nonnull Connection connection,
+                                          @Nonnull StormConfig config,
+                                          @Nullable SqlDialectProvider matchedProvider,
+                                          @Nonnull SqlDialect dialect) {
+        this(createConnectionProcessor(connection, strategies, dialect),
                 null,
                 ModelBuilder.newInstance(), TableAliasResolver.DEFAULT,
                 matchedProvider != null ? matchedProvider.getProviderFilter() : null,
-                strategies, config);
+                strategies, config, dialect);
     }
 
     private PreparedStatementTemplateImpl(@Nonnull TemplateProcessor templateProcessor,
@@ -280,8 +297,10 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
                                           @Nonnull TableAliasResolver tableAliasResolver,
                                           @Nullable Predicate<Provider> providerFilter,
                                           @Nonnull IntegrationStrategies strategies,
-                                          @Nonnull StormConfig config) {
+                                          @Nonnull StormConfig config,
+                                          @Nonnull SqlDialect dialect) {
         validate(config);
+        this.dialect = dialect;
         this.templateProcessor = templateProcessor;
         this.dataSource = dataSource;
         this.modelBuilder = modelBuilder;
@@ -414,10 +433,9 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
                 .withColumnNameResolver(modelBuilder.columnNameResolver())
                 .withForeignKeyResolver(modelBuilder.foreignKeyResolver())
                 .withTableAliasResolver(tableAliasResolver);
-        if (providerFilter != null) {
-            template = template.withDialect(getSqlDialect(providerFilter, config));
-        }
-        return template;
+        // The ambient template resolves a dialect without knowing which database this template is bound to, so the
+        // dialect resolved for this template's database is applied on top. An explicit provider filter still wins.
+        return template.withDialect(providerFilter != null ? getSqlDialect(providerFilter, config) : dialect);
     }
 
     /**
@@ -428,7 +446,7 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
      */
     @Override
     public PreparedStatementTemplateImpl withTableNameResolver(@Nullable TableNameResolver tableNameResolver) {
-        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder.tableNameResolver(tableNameResolver), tableAliasResolver, providerFilter, strategies, config);
+        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder.tableNameResolver(tableNameResolver), tableAliasResolver, providerFilter, strategies, config, dialect);
     }
 
     /**
@@ -439,7 +457,7 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
      */
     @Override
     public PreparedStatementTemplateImpl withColumnNameResolver(@Nullable ColumnNameResolver columnNameResolver) {
-        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder.columnNameResolver(columnNameResolver), tableAliasResolver, providerFilter, strategies, config);
+        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder.columnNameResolver(columnNameResolver), tableAliasResolver, providerFilter, strategies, config, dialect);
     }
 
     /**
@@ -450,7 +468,7 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
      */
     @Override
     public PreparedStatementTemplateImpl withForeignKeyResolver(@Nullable ForeignKeyResolver foreignKeyResolver) {
-        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder.foreignKeyResolver(foreignKeyResolver), tableAliasResolver, providerFilter, strategies, config);
+        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder.foreignKeyResolver(foreignKeyResolver), tableAliasResolver, providerFilter, strategies, config, dialect);
     }
 
     /**
@@ -461,7 +479,7 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
      */
     @Override
     public PreparedStatementTemplate withTableAliasResolver(@Nonnull TableAliasResolver tableAliasResolver) {
-        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder, tableAliasResolver, providerFilter, strategies, config);
+        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder, tableAliasResolver, providerFilter, strategies, config, dialect);
     }
 
     /**
@@ -472,7 +490,7 @@ public final class PreparedStatementTemplateImpl implements PreparedStatementTem
      */
     @Override
     public PreparedStatementTemplateImpl withProviderFilter(@Nullable Predicate<Provider> providerFilter) {
-        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder, tableAliasResolver, providerFilter, strategies, config);
+        return new PreparedStatementTemplateImpl(templateProcessor, dataSource, modelBuilder, tableAliasResolver, providerFilter, strategies, config, dialect);
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/SchemaValidator.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SchemaValidator.java
@@ -15,7 +15,9 @@
  */
 package st.orm.core.template.impl;
 
+import static st.orm.core.spi.Providers.getDatabaseProductName;
 import static st.orm.core.spi.Providers.getSqlDialect;
+import static st.orm.core.spi.Providers.getSqlDialectProvider;
 import static st.orm.core.template.impl.RecordReflection.isPolymorphicData;
 
 import jakarta.annotation.Nonnull;
@@ -47,12 +49,15 @@ import st.orm.GenerationStrategy;
 import st.orm.PK;
 import st.orm.ProjectionQuery;
 import st.orm.Ref;
+import st.orm.StormConfig;
 import st.orm.UK;
+import st.orm.core.spi.SqlDialectProvider;
 import st.orm.core.spi.TypeDiscovery;
 import st.orm.core.template.Column;
 import st.orm.core.template.Model;
 import st.orm.core.template.SqlDialect;
 import st.orm.core.template.SqlTemplateException;
+import st.orm.core.template.impl.DatabaseSchema.ConstraintKind;
 import st.orm.core.template.impl.DatabaseSchema.DbColumn;
 import st.orm.core.template.impl.DatabaseSchema.DbForeignKey;
 import st.orm.core.template.impl.DatabaseSchema.DbUniqueKey;
@@ -104,7 +109,7 @@ public final class SchemaValidator {
      */
     public static SchemaValidator of(@Nonnull DataSource dataSource) {
         return new SchemaValidator(dataSource, ModelBuilder.newInstance(), TypeCompatibility.defaultCompatibility(),
-                getSqlDialect());
+                resolveSqlDialect(dataSource));
     }
 
     /**
@@ -116,7 +121,22 @@ public final class SchemaValidator {
      */
     public static SchemaValidator of(@Nonnull DataSource dataSource, @Nonnull ModelBuilder modelBuilder) {
         return new SchemaValidator(dataSource, modelBuilder, TypeCompatibility.defaultCompatibility(),
-                getSqlDialect());
+                resolveSqlDialect(dataSource));
+    }
+
+    /**
+     * Resolves the dialect for the given data source from its database product, the same way the template factories
+     * do.
+     *
+     * <p>Selecting by product matters when several dialect modules are on the classpath: the strategies a dialect
+     * uses to read constraints and sequences are vendor-specific, so a dialect that does not match the database
+     * reads the schema with queries the database does not understand. Only when no provider claims the product does
+     * this fall back to the first registered dialect.</p>
+     */
+    private static SqlDialect resolveSqlDialect(@Nonnull DataSource dataSource) {
+        StormConfig config = StormConfig.defaults();
+        SqlDialectProvider provider = getSqlDialectProvider(getDatabaseProductName(dataSource));
+        return provider != null ? provider.getSqlDialect(config) : getSqlDialect(config);
     }
 
     /**
@@ -456,8 +476,9 @@ public final class SchemaValidator {
                                 .formatted(columnName, qualifiedTableName)));
             }
         }
-        // 5. Primary key match.
-        if (requirePrimaryKey) {
+        // 5. Primary key match. Skipped when the keys could not be read: an empty result would otherwise read as
+        // "the table has no primary key".
+        if (requirePrimaryKey && schema.isDiscovered(ConstraintKind.KEY)) {
             Set<String> entityPkColumns = model.declaredColumns().stream()
                     .filter(Column::primaryKey)
                     .map(column -> column.name().toUpperCase())
@@ -531,6 +552,10 @@ public final class SchemaValidator {
             @Nonnull Set<String> ignoredComponents,
             @Nonnull List<SchemaValidationError> errors
     ) {
+        if (!schema.isDiscovered(ConstraintKind.KEY)) {
+            // The unique keys could not be read, so nothing can be said about them.
+            return;
+        }
         // Build a map of unique index name -> set of column names from the database.
         List<DbUniqueKey> dbUniqueKeys = schema.getUniqueKeys(tableName);
         SortedMap<String, SortedSet<String>> indexColumnsByName = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -580,6 +605,10 @@ public final class SchemaValidator {
             @Nonnull Set<String> ignoredComponents,
             @Nonnull List<SchemaValidationError> errors
     ) {
+        if (!schema.isDiscovered(ConstraintKind.FOREIGN_KEY)) {
+            // The foreign keys could not be read, so nothing can be said about them.
+            return;
+        }
         List<DbForeignKey> dbForeignKeys = schema.getForeignKeys(tableName);
         for (RecordField field : model.recordType().fields()) {
             if (field.isAnnotationPresent(DbIgnore.class)) {

--- a/storm-core/src/test/java/st/orm/core/template/impl/DatabaseSchemaTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/DatabaseSchemaTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import st.orm.core.template.SqlDialect.ConstraintDiscoveryStrategy;
 import st.orm.core.template.SqlDialect.SequenceDiscoveryStrategy;
+import st.orm.core.template.impl.DatabaseSchema.ConstraintKind;
 import st.orm.core.template.impl.DatabaseSchema.DbColumn;
 import st.orm.core.template.impl.DatabaseSchema.DbForeignKey;
 import st.orm.core.template.impl.DatabaseSchema.DbPrimaryKey;
@@ -45,6 +46,38 @@ class DatabaseSchemaTest {
     }
 
     // Basic read() tests
+
+    // Constraint discovery outcome
+
+    @Test
+    void testConstraintsAreDiscoveredWithAFittingStrategy() throws SQLException {
+        execute("CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+        execute("CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent (id))");
+        try (Connection connection = getConnection()) {
+            DatabaseSchema schema = DatabaseSchema.read(connection);
+            assertTrue(schema.isDiscovered(ConstraintKind.KEY));
+            assertTrue(schema.isDiscovered(ConstraintKind.FOREIGN_KEY));
+            assertEquals(1, schema.getForeignKeys("child").size());
+        }
+    }
+
+    @Test
+    void testForeignKeysStayUnknownWhenTheStrategyDoesNotFitTheDatabase() throws SQLException {
+        execute("CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+        execute("CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent (id))");
+        try (Connection connection = getConnection()) {
+            // INFORMATION_SCHEMA_REFERENCING reads KEY_COLUMN_USAGE.REFERENCED_TABLE_NAME, a column H2 does not
+            // have, so the foreign key query fails and the foreign keys stay unknown.
+            DatabaseSchema schema = DatabaseSchema.read(connection, connection.getCatalog(), connection.getSchema(),
+                    SequenceDiscoveryStrategy.INFORMATION_SCHEMA,
+                    ConstraintDiscoveryStrategy.INFORMATION_SCHEMA_REFERENCING);
+            assertFalse(schema.isDiscovered(ConstraintKind.FOREIGN_KEY));
+            assertTrue(schema.getForeignKeys("child").isEmpty());
+            // The keys come from a query H2 does understand, so they are known and were read.
+            assertTrue(schema.isDiscovered(ConstraintKind.KEY));
+            assertEquals(1, schema.getPrimaryKeys("child").size());
+        }
+    }
 
     @Test
     void testReadEmptySchema() throws SQLException {

--- a/storm-core/src/test/java/st/orm/core/template/impl/SchemaValidatorConstraintDiscoveryTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/SchemaValidatorConstraintDiscoveryTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.template.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.Nonnull;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import st.orm.DbTable;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+import st.orm.StormConfig;
+import st.orm.core.spi.DefaultSqlDialect;
+import st.orm.core.template.SqlDialect;
+import st.orm.core.template.SqlDialect.ConstraintDiscoveryStrategy;
+import st.orm.core.template.impl.SchemaValidationError.ErrorKind;
+
+/**
+ * Tests that constraint validation reports what the database actually said, and stays silent about what it could
+ * not be asked.
+ *
+ * <p>A constraint discovery query that the database does not understand leaves the constraints unknown, which is
+ * not the same as the database having none. Reporting the latter turns a dialect that does not fit the database
+ * into a schema that looks broken.</p>
+ */
+class SchemaValidatorConstraintDiscoveryTest {
+
+    private static final AtomicInteger DB_COUNTER = new AtomicInteger();
+
+    private DataSource dataSource;
+
+    @DbTable("parent")
+    record Parent(@PK Integer id) implements Entity<Integer> {}
+
+    @DbTable("child")
+    record Child(@PK Integer id, @FK Parent parent) implements Entity<Integer> {}
+
+    /**
+     * The default dialect, reading constraints the way a database that does not match it would be read. This is what
+     * a MySQL dialect does to an H2 database: {@code KEY_COLUMN_USAGE.REFERENCED_TABLE_NAME} does not exist there,
+     * so the foreign key query fails.
+     */
+    private static final class MismatchedDialect extends DefaultSqlDialect {
+
+        MismatchedDialect(@Nonnull StormConfig config) {
+            super(config);
+        }
+
+        @Override
+        public ConstraintDiscoveryStrategy constraintDiscoveryStrategy() {
+            return ConstraintDiscoveryStrategy.INFORMATION_SCHEMA_REFERENCING;
+        }
+    }
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        dataSource = new SimpleDriverDataSource(new org.h2.Driver(),
+                "jdbc:h2:mem:validator_discovery_" + DB_COUNTER.incrementAndGet() + ";DB_CLOSE_DELAY=-1");
+        try (var connection = dataSource.getConnection();
+             var statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+            statement.execute(
+                    "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL REFERENCES parent (id))");
+        }
+    }
+
+    private List<SchemaValidationError> validateWith(@Nonnull SqlDialect dialect) {
+        return SchemaValidator.of(dataSource, ModelBuilder.newInstance(), dialect)
+                .validate(List.of(Parent.class, Child.class));
+    }
+
+    @Test
+    void foreignKeyIsFoundWithAFittingDialect() {
+        List<SchemaValidationError> errors = validateWith(new DefaultSqlDialect(StormConfig.defaults()));
+
+        assertTrue(errors.isEmpty(), "Expected no errors for a matching schema, got: " + errors);
+    }
+
+    @Test
+    void foreignKeyIsNotReportedMissingWhenItsDiscoveryFailed() {
+        List<SchemaValidationError> errors = validateWith(new MismatchedDialect(StormConfig.defaults()));
+
+        // The foreign key is there; the query that would have found it failed. Claiming it is missing would send
+        // the reader looking for a constraint that exists.
+        assertTrue(errors.stream().noneMatch(error -> error.kind() == ErrorKind.FOREIGN_KEY_MISSING),
+                "Foreign keys must not be reported as missing when they could not be read, got: " + errors);
+    }
+
+    @Test
+    void primaryKeysAreStillValidatedWhenOnlyForeignKeyDiscoveryFails() {
+        // The mismatched dialect reads primary and unique keys with a query H2 does understand, so those stay known
+        // and keep being validated. Only the kind that failed is skipped.
+        List<SchemaValidationError> errors = validateWith(new MismatchedDialect(StormConfig.defaults()));
+
+        assertTrue(errors.stream().noneMatch(error -> error.kind() == ErrorKind.PRIMARY_KEY_MISSING),
+                "Primary keys are readable here and match, got: " + errors);
+        assertEquals(List.of(), errors);
+    }
+}

--- a/storm-mysql/pom.xml
+++ b/storm-mysql/pom.xml
@@ -114,5 +114,12 @@
             <version>8.0.33</version>
             <scope>test</scope>
         </dependency>
+        <!-- A database this module's dialect does not claim, so the tests can assert that it is not applied to
+             one. See MySQLDialectResolutionTest. -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLDialectResolutionTest.java
+++ b/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLDialectResolutionTest.java
@@ -17,7 +17,6 @@ package st.orm.spi.mysql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.annotation.Nonnull;
@@ -35,6 +34,8 @@ import st.orm.StormConfig;
 import st.orm.core.spi.DefaultSqlDialect;
 import st.orm.core.spi.Providers;
 import st.orm.core.template.ORMTemplate;
+import st.orm.core.template.SqlTemplate;
+import st.orm.core.template.impl.PreparedStatementTemplateImpl;
 import st.orm.core.template.impl.SchemaValidationError;
 import st.orm.core.template.impl.SchemaValidationError.ErrorKind;
 import st.orm.core.template.impl.SchemaValidator;
@@ -96,7 +97,7 @@ class MySQLDialectResolutionTest {
     @Test
     void theProductBlindLookupWouldPickThisModulesDialect() {
         // Guards the premise of the tests below: without consulting the database, resolution lands on MySQL.
-        assertInstanceOf(MySQLSqlDialect.class, Providers.getSqlDialect(StormConfig.defaults()),
+        assertEquals(MySQLSqlDialect.class, Providers.getSqlDialect(StormConfig.defaults()).getClass(),
                 "These tests only mean something while this module's dialect is the one a product-blind lookup "
                         + "returns. Adding another dialect to this module's test scope disarms them.");
     }
@@ -105,8 +106,27 @@ class MySQLDialectResolutionTest {
     void resolvingForAnUnclaimedDatabaseFallsBackToTheDefaultDialect() throws SQLException {
         var dataSource = h2(CHILD_WITH_FOREIGN_KEY);
 
-        assertInstanceOf(DefaultSqlDialect.class,
-                Providers.getSqlDialect(dataSource, StormConfig.defaults()));
+        assertEquals(DefaultSqlDialect.class,
+                Providers.getSqlDialect(dataSource, StormConfig.defaults()).getClass());
+    }
+
+    /**
+     * The dialect a template generates SQL with is the one resolved for its database, not the one the shared
+     * {@link SqlTemplate#PS} carries.
+     *
+     * <p>The shared template resolves a dialect once, with no database in view. Building on it unchanged writes
+     * MySQL syntax for a database that is not MySQL, while the statements are executed with the dialect the
+     * template did resolve for itself, so the two halves of one query disagree about the database.</p>
+     */
+    @Test
+    void sqlIsGeneratedWithTheDialectOfTheDatabaseTheTemplateIsBoundTo() throws SQLException {
+        // The dialects share a hierarchy, so only the exact class distinguishes them.
+        assertEquals(MySQLSqlDialect.class, SqlTemplate.PS.dialect().getClass(),
+                "The shared template resolves this module's dialect, which is the state this test needs");
+
+        var template = new PreparedStatementTemplateImpl(h2(CHILD_WITH_FOREIGN_KEY));
+
+        assertEquals(DefaultSqlDialect.class, template.sqlTemplate().dialect().getClass());
     }
 
     @Test

--- a/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLDialectResolutionTest.java
+++ b/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLDialectResolutionTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spi.mysql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.Nonnull;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import st.orm.DbTable;
+import st.orm.Entity;
+import st.orm.FK;
+import st.orm.PK;
+import st.orm.StormConfig;
+import st.orm.core.spi.DefaultSqlDialect;
+import st.orm.core.spi.Providers;
+import st.orm.core.template.ORMTemplate;
+import st.orm.core.template.impl.SchemaValidationError;
+import st.orm.core.template.impl.SchemaValidationError.ErrorKind;
+import st.orm.core.template.impl.SchemaValidator;
+
+/**
+ * Tests that a dialect is chosen for the database in front of it, not for the modules that happen to be on the
+ * classpath.
+ *
+ * <p>This module puts the MySQL dialect provider on the test classpath, and these tests connect to H2, which no
+ * provider here claims. Resolution must therefore land on the default dialect. Picking the first registered
+ * provider instead lands on MySQL, whose constraint discovery reads a {@code KEY_COLUMN_USAGE} column H2 does not
+ * have; that query fails, the foreign keys are never read, and validation loses the ability to say anything about
+ * them.</p>
+ *
+ * <p>Every module has at most one dialect, so this mismatch is the only configuration in which the reactor can
+ * catch a resolution that ignores the database. {@link #theProductBlindLookupWouldPickThisModulesDialect()} asserts
+ * that the mismatch is still there, so that adding the H2 dialect to this module's test scope fails loudly rather
+ * than quietly disarming these tests.</p>
+ */
+class MySQLDialectResolutionTest {
+
+    private static final AtomicInteger DB_COUNTER = new AtomicInteger();
+
+    @DbTable("parent")
+    record Parent(@PK Integer id) implements Entity<Integer> {}
+
+    @DbTable("child")
+    record Child(@PK Integer id, @FK Parent parent) implements Entity<Integer> {}
+
+    private static final String PARENT_TABLE = "CREATE TABLE parent (id INTEGER PRIMARY KEY)";
+
+    private static final String CHILD_WITH_FOREIGN_KEY =
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL REFERENCES parent (id))";
+
+    private static final String CHILD_WITHOUT_FOREIGN_KEY =
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL)";
+
+    private static final String OTHER_TABLE = "CREATE TABLE other (id INTEGER PRIMARY KEY)";
+
+    /** The column carries a foreign key, but to a table the entity does not name. */
+    private static final String CHILD_WITH_WRONG_FOREIGN_KEY =
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL REFERENCES other (id))";
+
+    /**
+     * An H2 database, which the MySQL dialect provider does not claim.
+     */
+    private static DataSource h2(@Nonnull String childTable) throws SQLException {
+        var dataSource = new SimpleDriverDataSource(new org.h2.Driver(),
+                "jdbc:h2:mem:mysql_dialect_resolution_" + DB_COUNTER.incrementAndGet() + ";DB_CLOSE_DELAY=-1");
+        try (var connection = dataSource.getConnection();
+             var statement = connection.createStatement()) {
+            statement.execute(PARENT_TABLE);
+            statement.execute(OTHER_TABLE);
+            statement.execute(childTable);
+        }
+        return dataSource;
+    }
+
+    @Test
+    void theProductBlindLookupWouldPickThisModulesDialect() {
+        // Guards the premise of the tests below: without consulting the database, resolution lands on MySQL.
+        assertInstanceOf(MySQLSqlDialect.class, Providers.getSqlDialect(StormConfig.defaults()),
+                "These tests only mean something while this module's dialect is the one a product-blind lookup "
+                        + "returns. Adding another dialect to this module's test scope disarms them.");
+    }
+
+    @Test
+    void resolvingForAnUnclaimedDatabaseFallsBackToTheDefaultDialect() throws SQLException {
+        var dataSource = h2(CHILD_WITH_FOREIGN_KEY);
+
+        assertInstanceOf(DefaultSqlDialect.class,
+                Providers.getSqlDialect(dataSource, StormConfig.defaults()));
+    }
+
+    @Test
+    void validatorReadsForeignKeysOfAnUnclaimedDatabase() throws SQLException {
+        var dataSource = h2(CHILD_WITH_FOREIGN_KEY);
+
+        List<SchemaValidationError> errors = SchemaValidator.of(dataSource)
+                .validate(List.of(Parent.class, Child.class));
+
+        assertEquals(List.of(), errors);
+    }
+
+    /**
+     * The discriminating case. A missing foreign key can only be reported by a dialect whose constraint discovery
+     * works against this database; one that cannot read them has nothing to report.
+     */
+    @Test
+    void validatorStillReportsAMissingForeignKeyOnAnUnclaimedDatabase() throws SQLException {
+        var dataSource = h2(CHILD_WITHOUT_FOREIGN_KEY);
+
+        List<SchemaValidationError> errors = SchemaValidator.of(dataSource)
+                .validate(List.of(Parent.class, Child.class));
+
+        assertTrue(errors.stream().anyMatch(error -> error.kind() == ErrorKind.FOREIGN_KEY_MISSING),
+                "Expected the absent foreign key to be reported, got: " + errors);
+    }
+
+    @Test
+    void templateValidationReadsForeignKeysOfAnUnclaimedDatabase() throws SQLException {
+        var orm = ORMTemplate.of(h2(CHILD_WITH_FOREIGN_KEY));
+
+        assertEquals(List.of(), orm.validateSchema(List.of(Parent.class, Child.class)));
+    }
+
+    /**
+     * The same discriminating case through {@link ORMTemplate#validateSchema}, which resolves its own dialect
+     * rather than going through the {@link SchemaValidator} factories.
+     *
+     * <p>A misdirected foreign key rather than an absent one, because a foreign key that is merely missing is a
+     * warning, and warnings are logged but kept out of the returned list unless validation is strict. A foreign key
+     * pointing somewhere else is a hard error, and spotting it requires having read the constraint.</p>
+     */
+    @Test
+    void templateValidationStillReportsAMisdirectedForeignKeyOnAnUnclaimedDatabase() throws SQLException {
+        var orm = ORMTemplate.of(h2(CHILD_WITH_WRONG_FOREIGN_KEY));
+
+        List<String> errors = orm.validateSchema(List.of(Parent.class, Child.class));
+
+        assertFalse(errors.isEmpty(), "Expected the foreign key to 'other' to be reported as a mismatch");
+    }
+
+    /**
+     * The {@link SchemaValidator} factory sees the same misdirected foreign key.
+     */
+    @Test
+    void validatorReportsAMisdirectedForeignKeyOnAnUnclaimedDatabase() throws SQLException {
+        var dataSource = h2(CHILD_WITH_WRONG_FOREIGN_KEY);
+
+        List<SchemaValidationError> errors = SchemaValidator.of(dataSource)
+                .validate(List.of(Parent.class, Child.class));
+
+        assertTrue(errors.stream().anyMatch(error -> error.kind() == ErrorKind.FOREIGN_KEY_MISMATCH),
+                "Expected the foreign key to 'other' to be reported as a mismatch, got: " + errors);
+    }
+}

--- a/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLJpaDialectResolutionTest.java
+++ b/storm-mysql/src/test/java/st/orm/spi/mysql/MySQLJpaDialectResolutionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spi.mysql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.StormConfig;
+import st.orm.core.spi.DefaultSqlDialect;
+import st.orm.core.template.SqlTemplate;
+import st.orm.core.template.impl.JpaTemplateImpl;
+
+/**
+ * A JPA template generates SQL for the database its persistence unit is configured with.
+ *
+ * <p>This module's dialect claims only MySQL, and the persistence unit here runs on an embedded database it does
+ * not claim. Without asking the persistence unit which database it holds, the template falls back to the shared
+ * {@link SqlTemplate#JPA}, whose dialect is resolved once from the classpath, and writes MySQL syntax for a
+ * database that is not MySQL.</p>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IntegrationConfig.class)
+// The module's SQL fixtures are written for MySQL, and this persistence unit deliberately runs on another
+// database, so they are not applied here.
+@DataJpaTest(showSql = false, properties = "spring.sql.init.mode=never")
+public class MySQLJpaDialectResolutionTest {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void sqlIsGeneratedWithTheDialectOfThePersistenceUnitsDatabase() {
+        // The dialects share a hierarchy, so only the exact class distinguishes them.
+        assertEquals(MySQLSqlDialect.class, SqlTemplate.JPA.dialect().getClass(),
+                "The shared template resolves this module's dialect, which is the state this test needs");
+
+        var template = new JpaTemplateImpl(entityManager, StormConfig.defaults());
+
+        assertEquals(DefaultSqlDialect.class, template.sqlTemplate().dialect().getClass());
+    }
+}


### PR DESCRIPTION
Fixes #359

## The defect

`SchemaValidator.of(DataSource)` resolved its dialect with the no-argument `Providers.getSqlDialect()`, which returns the first registered `SqlDialectProvider` without consulting the database it is about to read. It had the `DataSource` in hand, and `Providers.getSqlDialect(dataSource, config)` already selects by product name, which is what `PreparedStatementTemplateImpl` does. Queries therefore stayed on the right dialect while validation did not.

With several dialect modules registered, the winner of that `findFirst()` depends on service loading order. An H2 database could be read with the MySQL dialect, whose `INFORMATION_SCHEMA_REFERENCING` strategy queries `KEY_COLUMN_USAGE.REFERENCED_TABLE_NAME`, a column H2 does not have.

The failure then became invisible. `DatabaseSchema` swallowed the `SQLException`, and an empty foreign key map reads exactly like a schema with no foreign keys, so validation reported every `@FK` as missing. The existing comments state the intent ("foreign key validation will be skipped"); the implementation reported instead of skipping.

## The change

**Dialect resolution.** `SchemaValidator.of(DataSource)` and `of(DataSource, ModelBuilder)` resolve the dialect from the database product, falling back to the first registered dialect only when no provider claims the product.

**Unknown is not missing.** A schema read records which constraint kinds it managed to read (`DatabaseSchema.isDiscovered`). Validation skips the primary key, unique key and foreign key checks for a kind that stayed unknown, so a database that cannot answer a discovery query is reported as unknown rather than as wrong. Kinds are tracked separately: a failed foreign key query no longer suppresses primary key validation. The cause of a failed read is logged at debug instead of being discarded.

## Verification

- `SchemaValidatorConstraintDiscoveryTest` covers the reporting half: with a dialect whose constraint discovery does not fit the database, the foreign key that exists is not reported missing, while the primary keys that were readable are still validated. Both new assertions fail without the change.
- `DatabaseSchemaTest` covers the read half: a fitting strategy discovers the foreign key, a mismatched one leaves `FOREIGN_KEY` undiscovered while `KEY` stays discovered.
- storm-core (2500 tests) and storm-h2 (158 tests) pass.
- End to end: an application carrying `storm-h2`, `storm-mysql` and `storm-postgresql` together, which failed its suite consistently before, now passes five consecutive runs.