### PR TITLE
fix: address review of the dialect resolution changes

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/impl/DatabaseSchema.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/DatabaseSchema.java
@@ -23,12 +23,16 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.EnumSet;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import st.orm.core.template.SqlDialect.ConstraintDiscoveryStrategy;
@@ -115,12 +119,15 @@ public final class DatabaseSchema {
     /**
      * A kind of constraint a schema read discovers.
      *
-     * <p>Each kind is read by one query (or one set of metadata calls) per strategy, so a failure applies to the
-     * kind as a whole. See {@link #isDiscovered(ConstraintKind)} for why the outcome is recorded.</p>
+     * <p>The kinds are separate because a strategy can read one and fail on another: the JDBC metadata strategy
+     * asks for each with its own call. See {@link #isDiscovered(String, ConstraintKind)} for why the outcome is
+     * recorded.</p>
      */
     public enum ConstraintKind {
-        /** Primary keys and unique keys, which every strategy reads together. */
-        KEY,
+        /** Primary keys. */
+        PRIMARY_KEY,
+        /** Unique keys. */
+        UNIQUE_KEY,
         /** Foreign keys. */
         FOREIGN_KEY
     }
@@ -131,7 +138,7 @@ public final class DatabaseSchema {
     private final SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable;
     private final SortedMap<String, List<DbForeignKey>> foreignKeysByTable;
     private final SortedMap<String, Boolean> sequences;
-    private final Set<ConstraintKind> discoveredConstraints;
+    private final Map<ConstraintKind, SortedSet<String>> discoveredByKind;
 
     private DatabaseSchema(
             @Nonnull SortedMap<String, List<DbColumn>> columnsByTable,
@@ -139,28 +146,45 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
             @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
             @Nonnull SortedMap<String, Boolean> sequences,
-            @Nonnull Set<ConstraintKind> discoveredConstraints
+            @Nonnull Map<ConstraintKind, SortedSet<String>> discoveredByKind
     ) {
         this.columnsByTable = columnsByTable;
         this.primaryKeysByTable = primaryKeysByTable;
         this.uniqueKeysByTable = uniqueKeysByTable;
         this.foreignKeysByTable = foreignKeysByTable;
         this.sequences = sequences;
-        this.discoveredConstraints = discoveredConstraints;
+        this.discoveredByKind = discoveredByKind;
     }
 
     /**
-     * Returns whether constraints of the given kind were actually read from the database.
+     * Returns whether constraints of the given kind were actually read for the given table.
      *
-     * <p>A metadata query that fails leaves the corresponding map empty, which reads exactly like a schema that has
+     * <p>A metadata query that fails leaves the corresponding map empty, which reads exactly like a table that has
      * no such constraints. Callers that would otherwise report a constraint as missing must check this first, so a
      * database that cannot answer the query is reported as unknown rather than as wrong.</p>
      *
+     * <p>The answer is per table and per kind, because a read can fail for one table while succeeding for the rest,
+     * and for one kind while succeeding for another. A failure that costs the schema its foreign keys leaves its
+     * primary keys, and every other table, still worth validating.</p>
+     *
+     * @param tableName the table to check, case-insensitively.
      * @param kind the constraint kind to check.
      * @return {@code true} if the read succeeded, {@code false} if it failed and the constraints are unknown.
      */
-    public boolean isDiscovered(@Nonnull ConstraintKind kind) {
-        return discoveredConstraints.contains(kind);
+    public boolean isDiscovered(@Nonnull String tableName, @Nonnull ConstraintKind kind) {
+        return discoveredByKind.getOrDefault(kind, EMPTY_TABLES).contains(tableName);
+    }
+
+    private static final SortedSet<String> EMPTY_TABLES = Collections.emptySortedSet();
+
+    /** Records that the given kind was read successfully for the given tables. */
+    private static void discovered(
+            @Nonnull Map<ConstraintKind, SortedSet<String>> discoveredByKind,
+            @Nonnull ConstraintKind kind,
+            @Nonnull Collection<String> tableNames
+    ) {
+        discoveredByKind.computeIfAbsent(kind, k -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER))
+                .addAll(tableNames);
     }
 
     /**
@@ -239,14 +263,14 @@ public final class DatabaseSchema {
             }
         }
         // Discover primary keys, unique keys, and foreign keys using the dialect-provided strategy.
-        Set<ConstraintKind> discoveredConstraints = EnumSet.noneOf(ConstraintKind.class);
+        Map<ConstraintKind, SortedSet<String>> discoveredByKind = new EnumMap<>(ConstraintKind.class);
         readConstraints(connection, metadata, catalog, schemaPattern, columnsByTable,
                 primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, constraintDiscoveryStrategy,
-                discoveredConstraints);
+                discoveredByKind);
         // Discover sequences using the dialect-provided strategy.
         readSequences(connection, catalog, schemaPattern, sequences, sequenceDiscoveryStrategy);
         return new DatabaseSchema(columnsByTable, primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, sequences,
-                discoveredConstraints);
+                discoveredByKind);
     }
 
     // ------------------------------------------------------------------------------------------------------------------
@@ -266,7 +290,7 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
             @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
             @Nonnull ConstraintDiscoveryStrategy strategy,
-            @Nonnull Set<ConstraintKind> discovered
+            @Nonnull Map<ConstraintKind, SortedSet<String>> discovered
     ) throws SQLException {
         switch (strategy) {
             case JDBC_METADATA -> readConstraintsFromJdbcMetadata(
@@ -298,10 +322,8 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
             @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
-            @Nonnull Set<ConstraintKind> discovered
+            @Nonnull Map<ConstraintKind, SortedSet<String>> discovered
     ) throws SQLException {
-        boolean keysRead = true;
-        boolean foreignKeysRead = true;
         for (String tableName : new ArrayList<>(columnsByTable.keySet())) {
             try (ResultSet primaryKeys = metadata.getPrimaryKeys(catalog, schemaPattern, tableName)) {
                 while (primaryKeys.next()) {
@@ -311,10 +333,10 @@ public final class DatabaseSchema {
                     primaryKeysByTable.computeIfAbsent(pkTableName, k -> new ArrayList<>())
                             .add(new DbPrimaryKey(pkTableName, columnName, keySeq));
                 }
+                discovered(discovered, ConstraintKind.PRIMARY_KEY, List.of(tableName));
             } catch (SQLException e) {
-                // Some databases/views may not support getPrimaryKeys; the keys stay unknown.
+                // Some databases/views may not support getPrimaryKeys; this table's primary key stays unknown.
                 LOGGER.debug("Failed to read primary keys for table '{}'.", tableName, e);
-                keysRead = false;
             }
         }
         for (String tableName : new ArrayList<>(columnsByTable.keySet())) {
@@ -332,10 +354,10 @@ public final class DatabaseSchema {
                     uniqueKeysByTable.computeIfAbsent(tableName, k -> new ArrayList<>())
                             .add(new DbUniqueKey(tableName, indexName, columnName, ordinalPosition));
                 }
+                discovered(discovered, ConstraintKind.UNIQUE_KEY, List.of(tableName));
             } catch (SQLException e) {
-                // Some databases/views may not support getIndexInfo; the keys stay unknown.
+                // Some databases/views may not support getIndexInfo; this table's unique keys stay unknown.
                 LOGGER.debug("Failed to read unique indexes for table '{}'.", tableName, e);
-                keysRead = false;
             }
         }
         for (String tableName : new ArrayList<>(columnsByTable.keySet())) {
@@ -348,17 +370,11 @@ public final class DatabaseSchema {
                     foreignKeysByTable.computeIfAbsent(fkTableName, k -> new ArrayList<>())
                             .add(new DbForeignKey(fkTableName, fkColumnName, pkTableName, pkColumnName));
                 }
+                discovered(discovered, ConstraintKind.FOREIGN_KEY, List.of(tableName));
             } catch (SQLException e) {
-                // Some databases/views may not support getImportedKeys; the keys stay unknown.
+                // Some databases/views may not support getImportedKeys; this table's foreign keys stay unknown.
                 LOGGER.debug("Failed to read foreign keys for table '{}'.", tableName, e);
-                foreignKeysRead = false;
             }
-        }
-        if (keysRead) {
-            discovered.add(ConstraintKind.KEY);
-        }
-        if (foreignKeysRead) {
-            discovered.add(ConstraintKind.FOREIGN_KEY);
         }
     }
 
@@ -419,7 +435,7 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbColumn>> columnsByTable,
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
-            @Nonnull Set<ConstraintKind> discovered
+            @Nonnull Map<ConstraintKind, SortedSet<String>> discovered
     ) {
         try {
             StringBuilder sql = new StringBuilder("""
@@ -454,9 +470,10 @@ public final class DatabaseSchema {
                     }
                 }
             }
-            discovered.add(ConstraintKind.KEY);
+            discovered(discovered, ConstraintKind.PRIMARY_KEY, columnsByTable.keySet());
+            discovered(discovered, ConstraintKind.UNIQUE_KEY, columnsByTable.keySet());
         } catch (SQLException e) {
-            // INFORMATION_SCHEMA views not available; the keys stay unknown.
+            // INFORMATION_SCHEMA views not available; the primary and unique keys stay unknown.
             LOGGER.debug("Failed to read primary and unique keys from INFORMATION_SCHEMA.", e);
         }
     }
@@ -474,7 +491,7 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
             @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
-            @Nonnull Set<ConstraintKind> discovered
+            @Nonnull Map<ConstraintKind, SortedSet<String>> discovered
     ) {
         readPrimaryAndUniqueKeysFromInformationSchema(
                 connection, catalog, schemaPattern, columnsByTable, primaryKeysByTable, uniqueKeysByTable, discovered);
@@ -510,7 +527,7 @@ public final class DatabaseSchema {
                             .add(new DbForeignKey(fkTableName, fkColumnName, pkTableName, pkColumnName));
                 }
             }
-            discovered.add(ConstraintKind.FOREIGN_KEY);
+            discovered(discovered, ConstraintKind.FOREIGN_KEY, columnsByTable.keySet());
         } catch (SQLException e) {
             // REFERENTIAL_CONSTRAINTS not available; the foreign keys stay unknown.
             LOGGER.debug("Failed to read foreign keys from INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS.", e);
@@ -529,7 +546,7 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
             @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
-            @Nonnull Set<ConstraintKind> discovered
+            @Nonnull Map<ConstraintKind, SortedSet<String>> discovered
     ) {
         // For databases that use catalogs as schemas, the catalog value represents the database name and maps to
         // TABLE_SCHEMA in INFORMATION_SCHEMA views (not TABLE_CATALOG).
@@ -558,7 +575,7 @@ public final class DatabaseSchema {
                             .add(new DbForeignKey(fkTableName, fkColumnName, pkTableName, pkColumnName));
                 }
             }
-            discovered.add(ConstraintKind.FOREIGN_KEY);
+            discovered(discovered, ConstraintKind.FOREIGN_KEY, columnsByTable.keySet());
         } catch (SQLException e) {
             // REFERENCED columns not available; the foreign keys stay unknown.
             LOGGER.debug("Failed to read foreign keys from INFORMATION_SCHEMA.KEY_COLUMN_USAGE.", e);
@@ -575,7 +592,7 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbPrimaryKey>> primaryKeysByTable,
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
             @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
-            @Nonnull Set<ConstraintKind> discovered
+            @Nonnull Map<ConstraintKind, SortedSet<String>> discovered
     ) {
         // Primary keys and unique constraints.
         try {
@@ -609,9 +626,10 @@ public final class DatabaseSchema {
                     }
                 }
             }
-            discovered.add(ConstraintKind.KEY);
+            discovered(discovered, ConstraintKind.PRIMARY_KEY, columnsByTable.keySet());
+            discovered(discovered, ConstraintKind.UNIQUE_KEY, columnsByTable.keySet());
         } catch (SQLException e) {
-            // ALL_CONSTRAINTS not available; the keys stay unknown.
+            // ALL_CONSTRAINTS not available; the primary and unique keys stay unknown.
             LOGGER.debug("Failed to read primary and unique keys from ALL_CONSTRAINTS.", e);
         }
         // Foreign keys.
@@ -647,7 +665,7 @@ public final class DatabaseSchema {
                             .add(new DbForeignKey(fkTableName, fkColumnName, pkTableName, pkColumnName));
                 }
             }
-            discovered.add(ConstraintKind.FOREIGN_KEY);
+            discovered(discovered, ConstraintKind.FOREIGN_KEY, columnsByTable.keySet());
         } catch (SQLException e) {
             // ALL_CONSTRAINTS FK query not available; the foreign keys stay unknown.
             LOGGER.debug("Failed to read foreign keys from ALL_CONSTRAINTS.", e);

--- a/storm-core/src/main/java/st/orm/core/template/impl/SchemaValidator.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SchemaValidator.java
@@ -15,9 +15,6 @@
  */
 package st.orm.core.template.impl;
 
-import static st.orm.core.spi.Providers.getDatabaseProductName;
-import static st.orm.core.spi.Providers.getSqlDialect;
-import static st.orm.core.spi.Providers.getSqlDialectProvider;
 import static st.orm.core.template.impl.RecordReflection.isPolymorphicData;
 
 import jakarta.annotation.Nonnull;
@@ -51,7 +48,7 @@ import st.orm.ProjectionQuery;
 import st.orm.Ref;
 import st.orm.StormConfig;
 import st.orm.UK;
-import st.orm.core.spi.SqlDialectProvider;
+import st.orm.core.spi.Providers;
 import st.orm.core.spi.TypeDiscovery;
 import st.orm.core.template.Column;
 import st.orm.core.template.Model;
@@ -87,13 +84,14 @@ public final class SchemaValidator {
     private final DataSource dataSource;
     private final ModelBuilder modelBuilder;
     private final TypeCompatibility typeCompatibility;
-    private final SqlDialect sqlDialect;
+    /** The dialect to validate with, or {@code null} to resolve it from the connection when validating. */
+    private final @Nullable SqlDialect sqlDialect;
 
     private SchemaValidator(
             @Nonnull DataSource dataSource,
             @Nonnull ModelBuilder modelBuilder,
             @Nonnull TypeCompatibility typeCompatibility,
-            @Nonnull SqlDialect sqlDialect
+            @Nullable SqlDialect sqlDialect
     ) {
         this.dataSource = dataSource;
         this.modelBuilder = modelBuilder;
@@ -109,7 +107,7 @@ public final class SchemaValidator {
      */
     public static SchemaValidator of(@Nonnull DataSource dataSource) {
         return new SchemaValidator(dataSource, ModelBuilder.newInstance(), TypeCompatibility.defaultCompatibility(),
-                resolveSqlDialect(dataSource));
+                null);
     }
 
     /**
@@ -120,23 +118,7 @@ public final class SchemaValidator {
      * @return a new schema validator.
      */
     public static SchemaValidator of(@Nonnull DataSource dataSource, @Nonnull ModelBuilder modelBuilder) {
-        return new SchemaValidator(dataSource, modelBuilder, TypeCompatibility.defaultCompatibility(),
-                resolveSqlDialect(dataSource));
-    }
-
-    /**
-     * Resolves the dialect for the given data source from its database product, the same way the template factories
-     * do.
-     *
-     * <p>Selecting by product matters when several dialect modules are on the classpath: the strategies a dialect
-     * uses to read constraints and sequences are vendor-specific, so a dialect that does not match the database
-     * reads the schema with queries the database does not understand. Only when no provider claims the product does
-     * this fall back to the first registered dialect.</p>
-     */
-    private static SqlDialect resolveSqlDialect(@Nonnull DataSource dataSource) {
-        StormConfig config = StormConfig.defaults();
-        SqlDialectProvider provider = getSqlDialectProvider(getDatabaseProductName(dataSource));
-        return provider != null ? provider.getSqlDialect(config) : getSqlDialect(config);
+        return new SchemaValidator(dataSource, modelBuilder, TypeCompatibility.defaultCompatibility(), null);
     }
 
     /**
@@ -172,10 +154,16 @@ public final class SchemaValidator {
         try (Connection connection = dataSource.getConnection()) {
             String defaultCatalog = connection.getCatalog();
             String defaultSchema = connection.getSchema();
+            // The strategies a dialect reads constraints and sequences with are vendor-specific, so a dialect that
+            // does not match the database reads the schema with queries the database does not understand. Unless a
+            // dialect was supplied, it comes from the database on the other end of this connection.
+            SqlDialect dialect = sqlDialect != null
+                    ? sqlDialect
+                    : Providers.getSqlDialect(connection, StormConfig.defaults());
             // Cache DatabaseSchema instances per schema name (case-insensitive) to avoid redundant metadata reads.
             SortedMap<String, DatabaseSchema> schemaCache = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             for (Class<? extends Data> type : types) {
-                validateType(type, connection, defaultCatalog, defaultSchema, schemaCache, errors);
+                validateType(type, connection, dialect, defaultCatalog, defaultSchema, schemaCache, errors);
             }
         } catch (SQLException e) {
             throw new st.orm.PersistenceException("Failed to read database schema for validation.", e);
@@ -356,6 +344,7 @@ public final class SchemaValidator {
      */
     private DatabaseSchema resolveSchema(
             @Nonnull Connection connection,
+            @Nonnull SqlDialect dialect,
             @Nullable String defaultCatalog,
             @Nullable String defaultSchema,
             @Nonnull String entitySchema,
@@ -371,7 +360,7 @@ public final class SchemaValidator {
         }
         String catalog;
         String schemaPattern;
-        if (!entitySchema.isEmpty() && sqlDialect.useCatalogAsSchema()) {
+        if (!entitySchema.isEmpty() && dialect.useCatalogAsSchema()) {
             // Database uses catalogs as schemas (e.g., MySQL, MariaDB). The entity's schema represents a
             // database name, which maps to the JDBC catalog.
             catalog = entitySchema;
@@ -381,7 +370,7 @@ public final class SchemaValidator {
             schemaPattern = entitySchema.isEmpty() ? defaultSchema : entitySchema;
         }
         DatabaseSchema databaseSchema = DatabaseSchema.read(connection, catalog, schemaPattern,
-                sqlDialect.sequenceDiscoveryStrategy(), sqlDialect.constraintDiscoveryStrategy());
+                dialect.sequenceDiscoveryStrategy(), dialect.constraintDiscoveryStrategy());
         schemaCache.put(schemaKey, databaseSchema);
         return databaseSchema;
     }
@@ -392,6 +381,7 @@ public final class SchemaValidator {
     private void validateType(
             @Nonnull Class<? extends Data> type,
             @Nonnull Connection connection,
+            @Nonnull SqlDialect dialect,
             @Nullable String defaultCatalog,
             @Nullable String defaultSchema,
             @Nonnull SortedMap<String, DatabaseSchema> schemaCache,
@@ -419,7 +409,7 @@ public final class SchemaValidator {
         String entitySchema = model.schema();
         DatabaseSchema schema;
         try {
-            schema = resolveSchema(connection, defaultCatalog, defaultSchema, entitySchema, schemaCache);
+            schema = resolveSchema(connection, dialect, defaultCatalog, defaultSchema, entitySchema, schemaCache);
         } catch (SQLException e) {
             throw new st.orm.PersistenceException(
                     "Failed to read database schema '%s' for validation.".formatted(entitySchema), e);
@@ -476,9 +466,9 @@ public final class SchemaValidator {
                                 .formatted(columnName, qualifiedTableName)));
             }
         }
-        // 5. Primary key match. Skipped when the keys could not be read: an empty result would otherwise read as
-        // "the table has no primary key".
-        if (requirePrimaryKey && schema.isDiscovered(ConstraintKind.KEY)) {
+        // 5. Primary key match. Skipped when this table's primary key could not be read: an empty result would
+        // otherwise read as "the table has no primary key".
+        if (requirePrimaryKey && schema.isDiscovered(tableName, ConstraintKind.PRIMARY_KEY)) {
             Set<String> entityPkColumns = model.declaredColumns().stream()
                     .filter(Column::primaryKey)
                     .map(column -> column.name().toUpperCase())
@@ -552,8 +542,8 @@ public final class SchemaValidator {
             @Nonnull Set<String> ignoredComponents,
             @Nonnull List<SchemaValidationError> errors
     ) {
-        if (!schema.isDiscovered(ConstraintKind.KEY)) {
-            // The unique keys could not be read, so nothing can be said about them.
+        if (!schema.isDiscovered(tableName, ConstraintKind.UNIQUE_KEY)) {
+            // This table's unique keys could not be read, so nothing can be said about them.
             return;
         }
         // Build a map of unique index name -> set of column names from the database.
@@ -605,8 +595,8 @@ public final class SchemaValidator {
             @Nonnull Set<String> ignoredComponents,
             @Nonnull List<SchemaValidationError> errors
     ) {
-        if (!schema.isDiscovered(ConstraintKind.FOREIGN_KEY)) {
-            // The foreign keys could not be read, so nothing can be said about them.
+        if (!schema.isDiscovered(tableName, ConstraintKind.FOREIGN_KEY)) {
+            // This table's foreign keys could not be read, so nothing can be said about them.
             return;
         }
         List<DbForeignKey> dbForeignKeys = schema.getForeignKeys(tableName);

--- a/storm-core/src/test/java/st/orm/core/template/impl/DatabaseSchemaTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/DatabaseSchemaTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Proxy;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
@@ -55,8 +57,9 @@ class DatabaseSchemaTest {
         execute("CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent (id))");
         try (Connection connection = getConnection()) {
             DatabaseSchema schema = DatabaseSchema.read(connection);
-            assertTrue(schema.isDiscovered(ConstraintKind.KEY));
-            assertTrue(schema.isDiscovered(ConstraintKind.FOREIGN_KEY));
+            assertTrue(schema.isDiscovered("child", ConstraintKind.PRIMARY_KEY));
+            assertTrue(schema.isDiscovered("child", ConstraintKind.UNIQUE_KEY));
+            assertTrue(schema.isDiscovered("child", ConstraintKind.FOREIGN_KEY));
             assertEquals(1, schema.getForeignKeys("child").size());
         }
     }
@@ -71,11 +74,73 @@ class DatabaseSchemaTest {
             DatabaseSchema schema = DatabaseSchema.read(connection, connection.getCatalog(), connection.getSchema(),
                     SequenceDiscoveryStrategy.INFORMATION_SCHEMA,
                     ConstraintDiscoveryStrategy.INFORMATION_SCHEMA_REFERENCING);
-            assertFalse(schema.isDiscovered(ConstraintKind.FOREIGN_KEY));
+            assertFalse(schema.isDiscovered("child", ConstraintKind.FOREIGN_KEY));
             assertTrue(schema.getForeignKeys("child").isEmpty());
             // The keys come from a query H2 does understand, so they are known and were read.
-            assertTrue(schema.isDiscovered(ConstraintKind.KEY));
+            assertTrue(schema.isDiscovered("child", ConstraintKind.PRIMARY_KEY));
             assertEquals(1, schema.getPrimaryKeys("child").size());
+            // A table nothing was read for is unknown rather than assumed empty.
+            assertFalse(schema.isDiscovered("no_such_table", ConstraintKind.PRIMARY_KEY));
+        }
+    }
+
+    /**
+     * Wraps the connection so one {@link DatabaseMetaData} call fails, optionally only for one table, the way a
+     * driver refuses a call it does not support for a particular relation.
+     */
+    private Connection metadataFailing(String failingMethod, String failingTable) throws SQLException {
+        Connection delegate = getConnection();
+        DatabaseMetaData realMetaData = delegate.getMetaData();
+        DatabaseMetaData metaData = (DatabaseMetaData) Proxy.newProxyInstance(
+                DatabaseMetaData.class.getClassLoader(), new Class<?>[]{DatabaseMetaData.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals(failingMethod)
+                            && (failingTable == null || failingTable.equalsIgnoreCase(String.valueOf(args[2])))) {
+                        throw new SQLException("metadata call not supported");
+                    }
+                    return invoke(method, realMetaData, args);
+                });
+        return (Connection) Proxy.newProxyInstance(
+                Connection.class.getClassLoader(), new Class<?>[]{Connection.class},
+                (proxy, method, args) -> method.getName().equals("getMetaData")
+                        ? metaData
+                        : invoke(method, delegate, args));
+    }
+
+    private static Object invoke(java.lang.reflect.Method method, Object target, Object[] args) throws Throwable {
+        try {
+            return method.invoke(target, args);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    private DatabaseSchema readWithJdbcMetadata(Connection connection) throws SQLException {
+        return DatabaseSchema.read(connection, connection.getCatalog(), connection.getSchema(),
+                SequenceDiscoveryStrategy.INFORMATION_SCHEMA, ConstraintDiscoveryStrategy.JDBC_METADATA);
+    }
+
+    @Test
+    void testAFailedReadForOneTableLeavesTheOthersDiscovered() throws SQLException {
+        execute("CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+        execute("CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent (id))");
+        try (Connection connection = metadataFailing("getImportedKeys", "CHILD")) {
+            DatabaseSchema schema = readWithJdbcMetadata(connection);
+            // Only the table whose read failed is unknown; the rest of the schema stays worth validating.
+            assertFalse(schema.isDiscovered("child", ConstraintKind.FOREIGN_KEY));
+            assertTrue(schema.isDiscovered("parent", ConstraintKind.FOREIGN_KEY));
+        }
+    }
+
+    @Test
+    void testAFailedUniqueKeyReadLeavesPrimaryKeysDiscovered() throws SQLException {
+        execute("CREATE TABLE parent (id INTEGER PRIMARY KEY)");
+        try (Connection connection = metadataFailing("getIndexInfo", null)) {
+            DatabaseSchema schema = readWithJdbcMetadata(connection);
+            // Primary keys and unique keys are separate calls, so losing one keeps the other.
+            assertFalse(schema.isDiscovered("parent", ConstraintKind.UNIQUE_KEY));
+            assertTrue(schema.isDiscovered("parent", ConstraintKind.PRIMARY_KEY));
+            assertEquals(1, schema.getPrimaryKeys("parent").size());
         }
     }
 


### PR DESCRIPTION
Follow-up to #360, which merged before its review comments were addressed. Three of the five were raised inline, two were suppressed; all five held up.

## Resolving the dialect no longer opens a connection

`SchemaValidator.of(DataSource)` resolved the dialect while constructing the validator, which reached the database for its product name. Building a validator could therefore fail on connection pool initialisation, authentication or the network before `validate()` was ever called.

`validate()` already holds an open connection, and `Providers.getSqlDialect(Connection, StormConfig)` already exists, so the dialect is resolved there instead. The extra connection is gone rather than moved. A dialect passed explicitly to the three-argument factory still wins, and `ORMTemplateImpl` keeps resolving from its own data source with its own config.

This also removes the helper that duplicated `Providers.getSqlDialect(DataSource, StormConfig)`, including its fallback branch, which the default provider made unreachable.

## Discovery is recorded per table

Constraint discovery was recorded for the schema as a whole. Under the JDBC metadata strategy, which asks per table, one table a driver could not answer for disabled primary and unique key validation for *every* table. A view that does not support `getPrimaryKeys` would have hidden real mismatches across the schema.

Discovery is now recorded per table, so a failure costs only the table it happened on. The bulk strategies read every table in one query, so their success or failure still covers the whole schema, which the same per-table record expresses.

## Primary keys and unique keys are separate kinds

They were one `KEY` kind, but the JDBC metadata strategy reads them with separate calls: `getPrimaryKeys` and `getIndexInfo`. A driver that could not report unique indexes therefore also cost the primary keys. They are now `PRIMARY_KEY` and `UNIQUE_KEY`, and each failure comment names the kind it belongs to rather than saying "keys" in a foreign key block.

## Tests

Two tests in `DatabaseSchemaTest` cover the new precision, using a `DatabaseMetaData` proxy that fails one call for one table:

- a failed read for one table leaves the other tables discovered
- a failed unique key read leaves the primary keys discovered

Unlike the tests in #360, these two cannot be run against the previous code to show them failing: the enum constants and the `isDiscovered` signature both changed, so there is no earlier version to point them at. They hold by construction.

The regression tests from #360 still bite: pointing the deferred resolution back at the product-blind lookup fails two of them.

Full reactor on this base: BUILD SUCCESS, 7240 tests.