### PR TITLE
fix(core): resolve navigation-only nodes in template fragments

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryModelImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryModelImpl.java
@@ -40,6 +40,7 @@ import st.orm.Data;
 import st.orm.Discriminator.DiscriminatorType;
 import st.orm.Element;
 import st.orm.Metamodel;
+import st.orm.Navigable;
 import st.orm.Operator;
 import st.orm.Ref;
 import st.orm.SelectMode;
@@ -612,10 +613,21 @@ final class QueryModelImpl implements QueryModel {
             case TemplateString ignore -> throw new SqlTemplateException("TemplateString is not allowed as a string template value.");
             case Stream<?> ignore -> throw new SqlTemplateException("Stream is not supported as a string template value. Collect the Stream into a List before passing it.");
             case Subqueryable t -> new Subquery(t.getSubquery(), true);
-            case Metamodel<?, ?> m when m.isColumn() -> new st.orm.core.template.impl.Elements.Column(m, CASCADE);
-            case Metamodel<?, ?> ignore -> throw new SqlTemplateException("Metamodel does not reference a column. Use a column-level metamodel (e.g., User_.name) rather than a table-level metamodel.");
+            case Navigable<?, ?> m when m.isColumn() -> new Elements.Column(toColumnMetamodel(m), CASCADE);
+            case Navigable<?, ?> ignore -> throw new SqlTemplateException("Path does not reference a column. Use a column-level path (e.g., User_.name) rather than a table-level path.");
             case null, default -> value;
         };
+    }
+
+    /**
+     * Resolves a navigable used as a template value into a column metamodel. Full metamodels are used as-is; a
+     * navigation-only node (one that navigates beyond a {@link Ref}) is rebuilt into a resolvable metamodel for its
+     * path so it can be selected or filtered. The rebuilt metamodel is query-only and cannot extract a value.
+     */
+    private static <T extends Data> Metamodel<T, ?> toColumnMetamodel(@Nonnull Navigable<T, ?> navigable) {
+        return navigable instanceof Metamodel<T, ?> metamodel
+                ? metamodel
+                : Metamodel.of(navigable.root(), navigable.fieldPath());
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplatePreparation.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplatePreparation.java
@@ -1208,6 +1208,10 @@ class TemplatePreparation {
         for (var value : template.values()) {
             switch (value) {
                 case Metamodel<?, ?> metamodel -> addReferencedTablePath(rootTable, metamodel, paths);
+                // A navigation-only node (one that navigates beyond a Ref) is rebuilt into a resolvable metamodel,
+                // so the joins beyond the reference are derived for it.
+                case Navigable<?, ?> navigable when navigable.isColumn() ->
+                        addReferencedTablePath(rootTable, toColumnMetamodel(navigable), paths);
                 case Expression expression ->
                         collectReferencedTablePaths(rootTable, expression, paths, tables, hydratedTables, hydratedPaths);
                 case Element element -> collectReferencedTablePaths(rootTable, element, paths, tables, hydratedTables, hydratedPaths);

--- a/storm-core/src/test/java/st/orm/core/RefGraphTraversalIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/RefGraphTraversalIntegrationTest.java
@@ -152,6 +152,21 @@ public class RefGraphTraversalIntegrationTest {
     }
 
     @Test
+    public void testFilterThroughRefInWhereTemplate() {
+        var orm = ORMTemplate.of(dataSource);
+        // A navigation-only node interpolated into a where template fragment must resolve to a column with its
+        // joins, exactly like the predicate form, rather than degrade to a bind parameter.
+        List<Integer> viaPredicate = orm.entity(PetOwnerRef.class).select()
+                .where(PetOwnerRef_.owner.address.city.name, EQUALS, "Madison")
+                .getResultList().stream().map(PetOwnerRef::id).sorted().toList();
+        List<Integer> viaTemplate = orm.entity(PetOwnerRef.class).select()
+                .where(raw("\0 = \0", PetOwnerRef_.owner.address.city.name, "Madison"))
+                .getResultList().stream().map(PetOwnerRef::id).sorted().toList();
+        assertFalse(viaPredicate.isEmpty());
+        assertEquals(viaPredicate, viaTemplate);
+    }
+
+    @Test
     public void testBeyondRefNodeIsNavigableOnly() {
         // The reference node itself is a value metamodel (getValue returns the Ref, so getResultGroupedByRef works),
         // but nodes beyond the reference are navigation-only: not TypedMetamodel, so value operations like


### PR DESCRIPTION
Fixes #364.

A navigation-only node (a path that navigates beyond a `Ref` foreign key) interpolated into a query builder template fragment was not resolved to a column. It fell through to parameter compilation, so the raw metamodel object reached the JDBC driver (`Type NavigableSiteMetamodel$7 not supported type` on MariaDB, `NotSerializableException` on H2). The predicate form and full select templates already handled the same path.

### Changes

- `QueryModelImpl.resolveElements` now resolves `Navigable` column nodes the same way `TemplatePreparation.resolveElements` does: full metamodels pass through, navigation-only nodes are rebuilt into resolvable runtime metamodels via `Metamodel.of(root, fieldPath)`. Table-level paths get the same error message as the main template path.
- The nested `TemplateString` value walker in `TemplatePreparation.collectReferencedTablePaths` records the referenced path for `Navigable` column nodes, so the joins beyond the reference are derived for template fragments. Without this, the resolved column failed with `Alias for table not found`.
- `RefGraphTraversalIntegrationTest.testFilterThroughRefInWhereTemplate` compares the template fragment form against the predicate form; it reproduced both failure layers before the fix.

### Verification

`./mvnw -pl storm-foundation,storm-core test`: 2501 tests, 0 failures.
