### PR TITLE
fix(compiler-plugin): apply the template rules to string concatenation

### DIFF
--- a/storm-compiler-plugin/src/main/kotlin-transformer-2.0/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
+++ b/storm-compiler-plugin/src/main/kotlin-transformer-2.0/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
@@ -5,6 +5,7 @@ package st.orm.kotlin.plugin
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irConcat
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
@@ -34,6 +35,11 @@ import org.jetbrains.kotlin.name.Name
  *
  * Expressions already wrapped in `t()` or `insert()` are left unchanged, so explicit usage remains valid.
  *
+ * The `+` operator on strings follows the same rules, so `"SELECT $col, " + "COUNT(*)"` yields the same template as
+ * `"SELECT $col, COUNT(*)"`: literal operands are SQL text and every other operand is interpolated. An expression
+ * inside an interpolation yields a value rather than SQL, so its own interpolations and concatenations are left to
+ * Kotlin: `"... LIKE ${"%" + name + "%"}"` interpolates a single string.
+ *
  * Example transformation:
  *
  * Source:
@@ -53,7 +59,15 @@ class StormTemplateIrTransformer(
     companion object {
         private val TEMPLATE_CONTEXT_FQN = FqName("st.orm.template.TemplateContext")
         private val TEMPLATE_CONTEXT_CLASS_ID = ClassId(FqName("st.orm.template"), Name.identifier("TemplateContext"))
+        private val STRING_FQN = FqName("kotlin.String")
     }
+
+    /**
+     * Tracks whether the expression being visited contributes SQL text. Text position covers the statements of a
+     * TemplateBuilder lambda; the arguments of a string template (`${...}`) are value position, because they yield
+     * bind values rather than SQL.
+     */
+    private var textPosition: Boolean = false
 
     /**
      * Tracks the `TemplateContext` receiver parameter when we're inside a TemplateBuilder lambda, so we can generate
@@ -91,7 +105,9 @@ class StormTemplateIrTransformer(
         }
         // We're inside a TemplateBuilder lambda. Set the receiver so nested visits can use it.
         val previousReceiver = templateContextReceiver
+        val previousTextPosition = textPosition
         templateContextReceiver = extensionReceiver
+        textPosition = true
         // Resolve function symbols if not already cached.
         if (tFunctionSymbol == null) {
             tFunctionSymbol = resolveTFunction()
@@ -106,21 +122,65 @@ class StormTemplateIrTransformer(
             injectAutoInterpolationCall(function, extensionReceiver, autoInterpolation)
         }
         templateContextReceiver = previousReceiver
+        textPosition = previousTextPosition
         return result
     }
 
     override fun visitStringConcatenation(expression: IrStringConcatenation): IrExpression {
-        val receiver = templateContextReceiver ?: return super.visitStringConcatenation(expression)
-        val tFunction = tFunctionSymbol ?: return super.visitStringConcatenation(expression)
-        // We're inside a TemplateBuilder lambda and found a string template. Wrap each non-constant argument in t().
-        // First, recursively transform each argument so that nested TemplateBuilder lambdas (e.g., inside subquery
+        if (templateContextReceiver == null || tFunctionSymbol == null) {
+            return super.visitStringConcatenation(expression)
+        }
+        if (!textPosition) {
+            // Value position: the string is computed as an ordinary Kotlin expression and interpolated as a single
+            // bind value, so its own interpolations are left alone. Nested TemplateBuilder lambdas are still visited.
+            return super.visitStringConcatenation(expression)
+        }
+        return processConcatenation(expression, isOperatorConcatenation(expression))
+    }
+
+    override fun visitCall(expression: IrCall): IrExpression {
+        val tFunction = tFunctionSymbol
+        if (templateContextReceiver == null || tFunction == null || !textPosition || !isStringPlus(expression)) {
+            return super.visitCall(expression)
+        }
+        // `a + b` in text position means the same as "$a$b", so rewrite it into a concatenation and apply the
+        // template rules to its operands. Nested `+` calls become concatenations in turn and are flattened below.
+        val operands = listOfNotNull(expression.dispatchReceiver, expression.getValueArgument(0))
+        if (operands.size != 2) {
+            return super.visitCall(expression)
+        }
+        val builder = DeclarationIrBuilder(pluginContext, tFunction.symbol, expression.startOffset, expression.endOffset)
+        val concatenation = builder.irConcat()
+        concatenation.arguments.addAll(operands)
+        return processConcatenation(concatenation, operatorConcatenation = true)
+    }
+
+    /**
+     * Applies the template rules to the arguments of [expression]: literal text stays a fragment and every other
+     * argument is wrapped in a `t()` call.
+     *
+     * When [operatorConcatenation] is true, the node represents a `+` chain rather than a single string literal. Its
+     * arguments are operands that contribute SQL text, so they are visited in text position and nested concatenations
+     * are spliced in rather than interpolated as a value. The arguments of a string literal are `${...}` expressions,
+     * which are visited in value position.
+     */
+    private fun processConcatenation(
+        expression: IrStringConcatenation,
+        operatorConcatenation: Boolean,
+    ): IrExpression {
+        val receiver = templateContextReceiver ?: return expression
+        val tFunction = tFunctionSymbol ?: return expression
+        // Recursively transform each argument first, so that nested TemplateBuilder lambdas (e.g., inside subquery
         // calls) are processed before we wrap the argument in t().
         val newArguments = expression.arguments.flatMap { argument ->
-            val transformed = argument.transform(this, null)
+            val transformed = transformInPosition(argument, operatorConcatenation)
             when {
                 transformed is IrConst<*> && isFragment(transformed) -> listOf(transformed)
                 transformed is IrConst<*> && hasMergedConstant(transformed) ->
                     splitMergedConstant(transformed, receiver, tFunction)
+                // A literal operand of a `+` chain is SQL text, like the literal part of a string template.
+                transformed is IrConst<*> && operatorConcatenation -> listOf(transformed)
+                transformed is IrStringConcatenation && operatorConcatenation -> transformed.arguments.toList()
                 isAlreadyWrappedInT(transformed) -> listOf(transformed)
                 else -> listOf(wrapInT(transformed, receiver, tFunction))
             }
@@ -128,6 +188,36 @@ class StormTemplateIrTransformer(
         expression.arguments.clear()
         expression.arguments.addAll(newArguments)
         return expression
+    }
+
+    /** Transforms [expression] with [textPosition] set for the duration of the visit. */
+    private fun transformInPosition(expression: IrExpression, textPosition: Boolean): IrExpression {
+        val previousTextPosition = this.textPosition
+        this.textPosition = textPosition
+        val result = expression.transform(this, null)
+        this.textPosition = previousTextPosition
+        return result
+    }
+
+    /**
+     * Checks whether an [IrStringConcatenation] represents a `+` chain rather than a single string literal.
+     *
+     * The compiler folds `"a${b}" + "c"` into one concatenation node whose arguments are the operands, which is
+     * indistinguishable in shape from the arguments of a string literal. The source range tells them apart: the
+     * arguments of a string literal all start after its opening quote, while the first operand of a `+` chain starts
+     * where the chain itself starts.
+     */
+    private fun isOperatorConcatenation(expression: IrStringConcatenation): Boolean {
+        val first = expression.arguments.firstOrNull() ?: return false
+        if (expression.startOffset < 0 || first.startOffset < 0) return false
+        return first.startOffset <= expression.startOffset
+    }
+
+    /** Checks whether a call is `String.plus`, the desugared form of the `+` operator on strings. */
+    private fun isStringPlus(expression: IrCall): Boolean {
+        if (expression.symbol.owner.name.asString() != "plus") return false
+        val receiverType = expression.dispatchReceiver?.type ?: return false
+        return receiverType.classFqName == STRING_FQN
     }
 
     /**

--- a/storm-compiler-plugin/src/main/kotlin-transformer-2.0/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
+++ b/storm-compiler-plugin/src/main/kotlin-transformer-2.0/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
@@ -178,8 +178,9 @@ class StormTemplateIrTransformer(
                 transformed is IrConst<*> && isFragment(transformed) -> listOf(transformed)
                 transformed is IrConst<*> && hasMergedConstant(transformed) ->
                     splitMergedConstant(transformed, receiver, tFunction)
-                // A literal operand of a `+` chain is SQL text, like the literal part of a string template.
-                transformed is IrConst<*> && operatorConcatenation -> listOf(transformed)
+                // A string literal operand of a `+` chain is SQL text, like the literal part of a string template.
+                // Any other constant is interpolated, so that `+ 42` and `${42}` produce the same bind value.
+                transformed is IrConst<*> && operatorConcatenation && transformed.value is String -> listOf(transformed)
                 transformed is IrStringConcatenation && operatorConcatenation -> transformed.arguments.toList()
                 isAlreadyWrappedInT(transformed) -> listOf(transformed)
                 else -> listOf(wrapInT(transformed, receiver, tFunction))

--- a/storm-compiler-plugin/src/main/kotlin-transformer-2.1/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
+++ b/storm-compiler-plugin/src/main/kotlin-transformer-2.1/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
@@ -5,6 +5,7 @@ package st.orm.kotlin.plugin
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irConcat
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
@@ -34,6 +35,11 @@ import org.jetbrains.kotlin.name.Name
  *
  * Expressions already wrapped in `t()` or `insert()` are left unchanged, so explicit usage remains valid.
  *
+ * The `+` operator on strings follows the same rules, so `"SELECT $col, " + "COUNT(*)"` yields the same template as
+ * `"SELECT $col, COUNT(*)"`: literal operands are SQL text and every other operand is interpolated. An expression
+ * inside an interpolation yields a value rather than SQL, so its own interpolations and concatenations are left to
+ * Kotlin: `"... LIKE ${"%" + name + "%"}"` interpolates a single string.
+ *
  * Example transformation:
  *
  * Source:
@@ -53,7 +59,15 @@ class StormTemplateIrTransformer(
     companion object {
         private val TEMPLATE_CONTEXT_FQN = FqName("st.orm.template.TemplateContext")
         private val TEMPLATE_CONTEXT_CLASS_ID = ClassId(FqName("st.orm.template"), Name.identifier("TemplateContext"))
+        private val STRING_FQN = FqName("kotlin.String")
     }
+
+    /**
+     * Tracks whether the expression being visited contributes SQL text. Text position covers the statements of a
+     * TemplateBuilder lambda; the arguments of a string template (`${...}`) are value position, because they yield
+     * bind values rather than SQL.
+     */
+    private var textPosition: Boolean = false
 
     /**
      * Tracks the `TemplateContext` receiver parameter when we're inside a TemplateBuilder lambda, so we can generate
@@ -91,7 +105,9 @@ class StormTemplateIrTransformer(
         }
         // We're inside a TemplateBuilder lambda. Set the receiver so nested visits can use it.
         val previousReceiver = templateContextReceiver
+        val previousTextPosition = textPosition
         templateContextReceiver = extensionReceiver
+        textPosition = true
         // Resolve function symbols if not already cached.
         if (tFunctionSymbol == null) {
             tFunctionSymbol = resolveTFunction()
@@ -106,21 +122,65 @@ class StormTemplateIrTransformer(
             injectAutoInterpolationCall(function, extensionReceiver, autoInterpolation)
         }
         templateContextReceiver = previousReceiver
+        textPosition = previousTextPosition
         return result
     }
 
     override fun visitStringConcatenation(expression: IrStringConcatenation): IrExpression {
-        val receiver = templateContextReceiver ?: return super.visitStringConcatenation(expression)
-        val tFunction = tFunctionSymbol ?: return super.visitStringConcatenation(expression)
-        // We're inside a TemplateBuilder lambda and found a string template. Wrap each non-constant argument in t().
-        // First, recursively transform each argument so that nested TemplateBuilder lambdas (e.g., inside subquery
+        if (templateContextReceiver == null || tFunctionSymbol == null) {
+            return super.visitStringConcatenation(expression)
+        }
+        if (!textPosition) {
+            // Value position: the string is computed as an ordinary Kotlin expression and interpolated as a single
+            // bind value, so its own interpolations are left alone. Nested TemplateBuilder lambdas are still visited.
+            return super.visitStringConcatenation(expression)
+        }
+        return processConcatenation(expression, isOperatorConcatenation(expression))
+    }
+
+    override fun visitCall(expression: IrCall): IrExpression {
+        val tFunction = tFunctionSymbol
+        if (templateContextReceiver == null || tFunction == null || !textPosition || !isStringPlus(expression)) {
+            return super.visitCall(expression)
+        }
+        // `a + b` in text position means the same as "$a$b", so rewrite it into a concatenation and apply the
+        // template rules to its operands. Nested `+` calls become concatenations in turn and are flattened below.
+        val operands = listOfNotNull(expression.dispatchReceiver, expression.getValueArgument(0))
+        if (operands.size != 2) {
+            return super.visitCall(expression)
+        }
+        val builder = DeclarationIrBuilder(pluginContext, tFunction.symbol, expression.startOffset, expression.endOffset)
+        val concatenation = builder.irConcat()
+        concatenation.arguments.addAll(operands)
+        return processConcatenation(concatenation, operatorConcatenation = true)
+    }
+
+    /**
+     * Applies the template rules to the arguments of [expression]: literal text stays a fragment and every other
+     * argument is wrapped in a `t()` call.
+     *
+     * When [operatorConcatenation] is true, the node represents a `+` chain rather than a single string literal. Its
+     * arguments are operands that contribute SQL text, so they are visited in text position and nested concatenations
+     * are spliced in rather than interpolated as a value. The arguments of a string literal are `${...}` expressions,
+     * which are visited in value position.
+     */
+    private fun processConcatenation(
+        expression: IrStringConcatenation,
+        operatorConcatenation: Boolean,
+    ): IrExpression {
+        val receiver = templateContextReceiver ?: return expression
+        val tFunction = tFunctionSymbol ?: return expression
+        // Recursively transform each argument first, so that nested TemplateBuilder lambdas (e.g., inside subquery
         // calls) are processed before we wrap the argument in t().
         val newArguments = expression.arguments.flatMap { argument ->
-            val transformed = argument.transform(this, null)
+            val transformed = transformInPosition(argument, operatorConcatenation)
             when {
                 transformed is IrConst && isFragment(transformed) -> listOf(transformed)
                 transformed is IrConst && hasMergedConstant(transformed) ->
                     splitMergedConstant(transformed, receiver, tFunction)
+                // A literal operand of a `+` chain is SQL text, like the literal part of a string template.
+                transformed is IrConst && operatorConcatenation -> listOf(transformed)
+                transformed is IrStringConcatenation && operatorConcatenation -> transformed.arguments.toList()
                 isAlreadyWrappedInT(transformed) -> listOf(transformed)
                 else -> listOf(wrapInT(transformed, receiver, tFunction))
             }
@@ -128,6 +188,36 @@ class StormTemplateIrTransformer(
         expression.arguments.clear()
         expression.arguments.addAll(newArguments)
         return expression
+    }
+
+    /** Transforms [expression] with [textPosition] set for the duration of the visit. */
+    private fun transformInPosition(expression: IrExpression, textPosition: Boolean): IrExpression {
+        val previousTextPosition = this.textPosition
+        this.textPosition = textPosition
+        val result = expression.transform(this, null)
+        this.textPosition = previousTextPosition
+        return result
+    }
+
+    /**
+     * Checks whether an [IrStringConcatenation] represents a `+` chain rather than a single string literal.
+     *
+     * The compiler folds `"a${b}" + "c"` into one concatenation node whose arguments are the operands, which is
+     * indistinguishable in shape from the arguments of a string literal. The source range tells them apart: the
+     * arguments of a string literal all start after its opening quote, while the first operand of a `+` chain starts
+     * where the chain itself starts.
+     */
+    private fun isOperatorConcatenation(expression: IrStringConcatenation): Boolean {
+        val first = expression.arguments.firstOrNull() ?: return false
+        if (expression.startOffset < 0 || first.startOffset < 0) return false
+        return first.startOffset <= expression.startOffset
+    }
+
+    /** Checks whether a call is `String.plus`, the desugared form of the `+` operator on strings. */
+    private fun isStringPlus(expression: IrCall): Boolean {
+        if (expression.symbol.owner.name.asString() != "plus") return false
+        val receiverType = expression.dispatchReceiver?.type ?: return false
+        return receiverType.classFqName == STRING_FQN
     }
 
     /**

--- a/storm-compiler-plugin/src/main/kotlin-transformer-2.1/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
+++ b/storm-compiler-plugin/src/main/kotlin-transformer-2.1/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
@@ -178,8 +178,9 @@ class StormTemplateIrTransformer(
                 transformed is IrConst && isFragment(transformed) -> listOf(transformed)
                 transformed is IrConst && hasMergedConstant(transformed) ->
                     splitMergedConstant(transformed, receiver, tFunction)
-                // A literal operand of a `+` chain is SQL text, like the literal part of a string template.
-                transformed is IrConst && operatorConcatenation -> listOf(transformed)
+                // A string literal operand of a `+` chain is SQL text, like the literal part of a string template.
+                // Any other constant is interpolated, so that `+ 42` and `${42}` produce the same bind value.
+                transformed is IrConst && operatorConcatenation && transformed.value is String -> listOf(transformed)
                 transformed is IrStringConcatenation && operatorConcatenation -> transformed.arguments.toList()
                 isAlreadyWrappedInT(transformed) -> listOf(transformed)
                 else -> listOf(wrapInT(transformed, receiver, tFunction))

--- a/storm-compiler-plugin/src/main/kotlin-transformer-2.2/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
+++ b/storm-compiler-plugin/src/main/kotlin-transformer-2.2/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
@@ -183,8 +183,9 @@ class StormTemplateIrTransformer(
                 transformed is IrConst && isFragment(transformed) -> listOf(transformed)
                 transformed is IrConst && hasMergedConstant(transformed) ->
                     splitMergedConstant(transformed, receiver, tFunction)
-                // A literal operand of a `+` chain is SQL text, like the literal part of a string template.
-                transformed is IrConst && operatorConcatenation -> listOf(transformed)
+                // A string literal operand of a `+` chain is SQL text, like the literal part of a string template.
+                // Any other constant is interpolated, so that `+ 42` and `${42}` produce the same bind value.
+                transformed is IrConst && operatorConcatenation && transformed.value is String -> listOf(transformed)
                 transformed is IrStringConcatenation && operatorConcatenation -> transformed.arguments.toList()
                 isAlreadyWrappedInT(transformed) -> listOf(transformed)
                 else -> listOf(wrapInT(transformed, receiver, tFunction))

--- a/storm-compiler-plugin/src/main/kotlin-transformer-2.2/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
+++ b/storm-compiler-plugin/src/main/kotlin-transformer-2.2/st/orm/kotlin/plugin/StormTemplateIrTransformer.kt
@@ -5,6 +5,7 @@ package st.orm.kotlin.plugin
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irConcat
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
@@ -37,6 +38,11 @@ import org.jetbrains.kotlin.name.Name
  *
  * Expressions already wrapped in `t()` or `insert()` are left unchanged, so explicit usage remains valid.
  *
+ * The `+` operator on strings follows the same rules, so `"SELECT $col, " + "COUNT(*)"` yields the same template as
+ * `"SELECT $col, COUNT(*)"`: literal operands are SQL text and every other operand is interpolated. An expression
+ * inside an interpolation yields a value rather than SQL, so its own interpolations and concatenations are left to
+ * Kotlin: `"... LIKE ${"%" + name + "%"}"` interpolates a single string.
+ *
  * Example transformation:
  *
  * Source:
@@ -56,7 +62,15 @@ class StormTemplateIrTransformer(
     companion object {
         private val TEMPLATE_CONTEXT_FQN = FqName("st.orm.template.TemplateContext")
         private val TEMPLATE_CONTEXT_CLASS_ID = ClassId(FqName("st.orm.template"), Name.identifier("TemplateContext"))
+        private val STRING_FQN = FqName("kotlin.String")
     }
+
+    /**
+     * Tracks whether the expression being visited contributes SQL text. Text position covers the statements of a
+     * TemplateBuilder lambda; the arguments of a string template (`${...}`) are value position, because they yield
+     * bind values rather than SQL.
+     */
+    private var textPosition: Boolean = false
 
     /**
      * Tracks the `TemplateContext` receiver parameter when we're inside a TemplateBuilder lambda, so we can generate
@@ -96,7 +110,9 @@ class StormTemplateIrTransformer(
         }
         // We're inside a TemplateBuilder lambda. Set the receiver so nested visits can use it.
         val previousReceiver = templateContextReceiver
+        val previousTextPosition = textPosition
         templateContextReceiver = extensionReceiver
+        textPosition = true
         // Resolve function symbols if not already cached.
         if (tFunctionSymbol == null) {
             tFunctionSymbol = resolveTFunction()
@@ -111,21 +127,65 @@ class StormTemplateIrTransformer(
             injectAutoInterpolationCall(function, extensionReceiver, autoInterpolation)
         }
         templateContextReceiver = previousReceiver
+        textPosition = previousTextPosition
         return result
     }
 
     override fun visitStringConcatenation(expression: IrStringConcatenation): IrExpression {
-        val receiver = templateContextReceiver ?: return super.visitStringConcatenation(expression)
-        val tFunction = tFunctionSymbol ?: return super.visitStringConcatenation(expression)
-        // We're inside a TemplateBuilder lambda and found a string template. Wrap each non-constant argument in t().
-        // First, recursively transform each argument so that nested TemplateBuilder lambdas (e.g., inside subquery
+        if (templateContextReceiver == null || tFunctionSymbol == null) {
+            return super.visitStringConcatenation(expression)
+        }
+        if (!textPosition) {
+            // Value position: the string is computed as an ordinary Kotlin expression and interpolated as a single
+            // bind value, so its own interpolations are left alone. Nested TemplateBuilder lambdas are still visited.
+            return super.visitStringConcatenation(expression)
+        }
+        return processConcatenation(expression, isOperatorConcatenation(expression))
+    }
+
+    override fun visitCall(expression: IrCall): IrExpression {
+        val tFunction = tFunctionSymbol
+        if (templateContextReceiver == null || tFunction == null || !textPosition || !isStringPlus(expression)) {
+            return super.visitCall(expression)
+        }
+        // `a + b` in text position means the same as "$a$b", so rewrite it into a concatenation and apply the
+        // template rules to its operands. Nested `+` calls become concatenations in turn and are flattened below.
+        val operands = listOfNotNull(expression.dispatchReceiver, valueArgument(expression))
+        if (operands.size != 2) {
+            return super.visitCall(expression)
+        }
+        val builder = DeclarationIrBuilder(pluginContext, tFunction.symbol, expression.startOffset, expression.endOffset)
+        val concatenation = builder.irConcat()
+        concatenation.arguments.addAll(operands)
+        return processConcatenation(concatenation, operatorConcatenation = true)
+    }
+
+    /**
+     * Applies the template rules to the arguments of [expression]: literal text stays a fragment and every other
+     * argument is wrapped in a `t()` call.
+     *
+     * When [operatorConcatenation] is true, the node represents a `+` chain rather than a single string literal. Its
+     * arguments are operands that contribute SQL text, so they are visited in text position and nested concatenations
+     * are spliced in rather than interpolated as a value. The arguments of a string literal are `${...}` expressions,
+     * which are visited in value position.
+     */
+    private fun processConcatenation(
+        expression: IrStringConcatenation,
+        operatorConcatenation: Boolean,
+    ): IrExpression {
+        val receiver = templateContextReceiver ?: return expression
+        val tFunction = tFunctionSymbol ?: return expression
+        // Recursively transform each argument first, so that nested TemplateBuilder lambdas (e.g., inside subquery
         // calls) are processed before we wrap the argument in t().
         val newArguments = expression.arguments.flatMap { argument ->
-            val transformed = argument.transform(this, null)
+            val transformed = transformInPosition(argument, operatorConcatenation)
             when {
                 transformed is IrConst && isFragment(transformed) -> listOf(transformed)
                 transformed is IrConst && hasMergedConstant(transformed) ->
                     splitMergedConstant(transformed, receiver, tFunction)
+                // A literal operand of a `+` chain is SQL text, like the literal part of a string template.
+                transformed is IrConst && operatorConcatenation -> listOf(transformed)
+                transformed is IrStringConcatenation && operatorConcatenation -> transformed.arguments.toList()
                 isAlreadyWrappedInT(transformed) -> listOf(transformed)
                 else -> listOf(wrapInT(transformed, receiver, tFunction))
             }
@@ -133,6 +193,43 @@ class StormTemplateIrTransformer(
         expression.arguments.clear()
         expression.arguments.addAll(newArguments)
         return expression
+    }
+
+    /** Transforms [expression] with [textPosition] set for the duration of the visit. */
+    private fun transformInPosition(expression: IrExpression, textPosition: Boolean): IrExpression {
+        val previousTextPosition = this.textPosition
+        this.textPosition = textPosition
+        val result = expression.transform(this, null)
+        this.textPosition = previousTextPosition
+        return result
+    }
+
+    /**
+     * Checks whether an [IrStringConcatenation] represents a `+` chain rather than a single string literal.
+     *
+     * The compiler folds `"a${b}" + "c"` into one concatenation node whose arguments are the operands, which is
+     * indistinguishable in shape from the arguments of a string literal. The source range tells them apart: the
+     * arguments of a string literal all start after its opening quote, while the first operand of a `+` chain starts
+     * where the chain itself starts.
+     */
+    private fun isOperatorConcatenation(expression: IrStringConcatenation): Boolean {
+        val first = expression.arguments.firstOrNull() ?: return false
+        if (expression.startOffset < 0 || first.startOffset < 0) return false
+        return first.startOffset <= expression.startOffset
+    }
+
+    /** Checks whether a call is `String.plus`, the desugared form of the `+` operator on strings. */
+    private fun isStringPlus(expression: IrCall): Boolean {
+        if (expression.symbol.owner.name.asString() != "plus") return false
+        val receiverType = expression.dispatchReceiver?.type ?: return false
+        return receiverType.classOrNull?.owner?.fqNameWhenAvailable == STRING_FQN
+    }
+
+    /** Returns the single regular argument of a call, or null when the call takes a different shape. */
+    private fun valueArgument(expression: IrCall): IrExpression? {
+        val index = expression.symbol.owner.parameters.indexOfFirst { it.kind == IrParameterKind.Regular }
+        if (index < 0) return null
+        return expression.arguments.getOrNull(index)
     }
 
     /**

--- a/storm-compiler-plugin/src/test/kotlin/st/orm/kotlin/plugin/StormTemplatePluginTest.kt
+++ b/storm-compiler-plugin/src/test/kotlin/st/orm/kotlin/plugin/StormTemplatePluginTest.kt
@@ -619,6 +619,270 @@ class StormTemplatePluginTest {
         assertEquals("[1, 2, 3]", lines[1])
     }
 
+    // -- String concatenation (+) tests --
+
+    @Test
+    fun `interpolation concatenated with a literal is auto-wrapped`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val country = "NL"
+                val builder: TemplateBuilder = { "SELECT ${'$'}{country}, " + "COUNT(*) FROM users" }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT |, COUNT(*) FROM users", lines[0])
+        assertEquals("NL", lines[1])
+    }
+
+    @Test
+    fun `literal concatenated with an interpolation is auto-wrapped`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val id = 42
+                val builder: TemplateBuilder = { "SELECT * FROM users " + "WHERE id = ${'$'}id" }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT * FROM users WHERE id = |", lines[0])
+        assertEquals("42", lines[1])
+    }
+
+    @Test
+    fun `value concatenated with a literal is auto-wrapped`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val id = 42
+                val builder: TemplateBuilder = { "SELECT * FROM users WHERE id = " + id }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT * FROM users WHERE id = |", lines[0])
+        assertEquals("42", lines[1])
+    }
+
+    @Test
+    fun `value between literals is auto-wrapped`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val id = 42
+                val builder: TemplateBuilder = { "SELECT * FROM users WHERE id = " + id + " ORDER BY name" }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT * FROM users WHERE id = | ORDER BY name", lines[0])
+        assertEquals("42", lines[1])
+    }
+
+    @Test
+    fun `concatenated literals stay a single fragment`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val builder: TemplateBuilder = { "SELECT COUNT(*) " + "FROM users" }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.size)
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT COUNT(*) FROM users", lines[0])
+        assertEquals("0", lines[1])
+    }
+
+    @Test
+    fun `concatenated interpolations are auto-wrapped in order`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val id = 42
+                val status = "active"
+                val builder: TemplateBuilder = { "SELECT * FROM users WHERE id = ${'$'}id" + " AND status = ${'$'}status" }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT * FROM users WHERE id = | AND status = |", lines[0])
+        assertEquals("42,active", lines[1])
+    }
+
+    @Test
+    fun `explicit t() concatenated with a literal is not double-wrapped`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val id = 42
+                val builder: TemplateBuilder = { "SELECT * FROM users WHERE id = " + t(id) + " ORDER BY name" }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT * FROM users WHERE id = | ORDER BY name", lines[0])
+        assertEquals("42", lines[1])
+    }
+
+    @Test
+    fun `concatenation in a conditional branch is auto-wrapped`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val id = 42
+                val builder: TemplateBuilder = {
+                    if (id > 0) "SELECT * FROM users WHERE id = " + id else "SELECT * FROM users"
+                }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT * FROM users WHERE id = |", lines[0])
+        assertEquals("42", lines[1])
+    }
+
+    @Test
+    fun `concatenation inside an interpolation stays a single value`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val name = "Alice"
+                val builder: TemplateBuilder = { "SELECT * FROM users WHERE name LIKE ${'$'}{"%" + name + "%"}" }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT * FROM users WHERE name LIKE |", lines[0])
+        assertEquals("%Alice%", lines[1])
+    }
+
+    @Test
+    fun `nested template inside an interpolation stays a single value`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val name = "Alice"
+                val builder: TemplateBuilder = { "SELECT * FROM users WHERE name LIKE ${'$'}{"%${'$'}name%"}" }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT * FROM users WHERE name LIKE |", lines[0])
+        assertEquals("%Alice%", lines[1])
+    }
+
+    @Test
+    fun `concatenation outside TemplateBuilder is not rewritten`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val id = 42
+                val regular = "id is " + id
+                println(regular)
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        assertEquals("id is 42", output)
+    }
+
     // -- Multi-dollar string interpolation ($$) tests --
 
     @Test

--- a/storm-compiler-plugin/src/test/kotlin/st/orm/kotlin/plugin/StormTemplatePluginTest.kt
+++ b/storm-compiler-plugin/src/test/kotlin/st/orm/kotlin/plugin/StormTemplatePluginTest.kt
@@ -718,6 +718,29 @@ class StormTemplatePluginTest {
     }
 
     @Test
+    fun `concatenated non-string constant is auto-wrapped`() {
+        val source = SourceFile.kotlin(
+            "Test.kt",
+            """
+            import st.orm.template.*
+
+            fun main() {
+                val builder: TemplateBuilder = { "SELECT * FROM users WHERE id = " + 42 + " ORDER BY name" }
+                val result = builder.build()
+                println(result.fragments.joinToString("|"))
+                println(result.values.joinToString(","))
+            }
+            """,
+        )
+        val result = compile(source)
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        val output = result.runMain()
+        val lines = output.lines()
+        assertEquals("SELECT * FROM users WHERE id = | ORDER BY name", lines[0])
+        assertEquals("42", lines[1])
+    }
+
+    @Test
     fun `concatenated literals stay a single fragment`() {
         val source = SourceFile.kotlin(
             "Test.kt",

--- a/storm-kotlin/src/test/kotlin/st/orm/template/CompilerPluginTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/CompilerPluginTest.kt
@@ -127,6 +127,38 @@ open class CompilerPluginTest(
     }
 
     @Test
+    fun `concatenated template and literal are auto-wrapped`() {
+        val cityId = 1
+        val city = orm.query { "SELECT ${City::class} FROM ${City::class} " + "WHERE id = $cityId" }
+            .getSingleResult(City::class)
+        city.name shouldBe "Sun Paririe"
+    }
+
+    @Test
+    fun `value concatenated with a literal is auto-wrapped`() {
+        val cityId = 2
+        val city = orm.query { "SELECT ${City::class} FROM ${City::class} WHERE id = " + cityId }
+            .getSingleResult(City::class)
+        city.name shouldBe "Madison"
+    }
+
+    @Test
+    fun `element concatenated with a literal is auto-wrapped`() {
+        val cities = orm.query { "SELECT " + City::class + " FROM " + City::class }
+            .getResultList(City::class)
+        cities shouldHaveSize 6
+    }
+
+    @Test
+    fun `concatenation inside an interpolation stays a single bind value`() {
+        val namePart = "adiso"
+        val cities = orm.query { "SELECT ${City::class} FROM ${City::class} WHERE name LIKE ${"%" + namePart + "%"}" }
+            .getResultList(City::class)
+        cities shouldHaveSize 1
+        cities[0].id shouldBe 2
+    }
+
+    @Test
     fun `unsafe element is auto-wrapped in t() and inlined as raw SQL`() {
         val cities = orm.query { "SELECT ${City::class} FROM ${City::class} WHERE ${unsafe("name = 'Madison'")}" }
             .getResultList(City::class)


### PR DESCRIPTION
Fixes #367.

Inside a `TemplateBuilder` lambda, `+` on strings now means what `$` means: literal operands are SQL text, every other operand is interpolated through `t()`, and nested concatenations are spliced into the parent so fragments and values keep their order.

`"SELECT ${City::class}, " + "COUNT(*) FROM city"` previously interpolated the whole left-hand string as a bind parameter, because the compiler folds the two operands into one concatenation node and the plugin could not tell the first operand apart from a `${...}` expression. The source range tells them apart: the arguments of a string literal all start after its opening quote, while the first operand of a `+` chain starts where the chain itself starts.

`"SELECT * FROM city WHERE id = " + cityId` previously concatenated the operand's `toString()` into the SQL text, because an operand of a type other than `String` compiles to a `String.plus` call rather than a concatenation node. Those calls are now rewritten into a concatenation and processed by the same rules, so the operand is parameterized.

An expression inside `${...}` yields a value, so its own interpolations and concatenations are left to Kotlin. That also covers `"... LIKE ${"%$name%"}"`, which resolved the inner interpolation and then interpolated the result, producing two values for one placeholder.

The transformer is versioned per compiler API, so the change is applied to the 2.0, 2.1 and 2.2 sources (the last shared by the 2.2, 2.3 and 2.4 modules). The concatenation node is built with `irConcat()`: `IrStringConcatenationImpl` compiles against 2.0 but is absent from the 2.0.21 compiler runtime.

## Verification

- 11 plugin tests covering the concatenation shapes, green on all five Kotlin variants (37 each).
- 4 end-to-end tests in `storm-kotlin`'s `CompilerPluginTest` running concatenated templates against H2; the module's 1682 tests are green.

## Known limitation

Accumulating SQL in a local (`var sql = "SELECT "; sql += City::class`) reads the local as an operand, so it is interpolated as a value rather than spliced as text. This matches what `"$sql ..."` does today and needs assignment tracking to resolve, which is left out of this change.
