### PR TITLE
feat: align the clause vocabulary across the four query builder surfaces

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -515,12 +515,12 @@ When you read an entity within a transaction, Storm stores the original field va
 ```kotlin
 // Wrong: the where clause is discarded
 val builder = userRepository.select()
-builder.where(User_.active, EQUALS, true)   // returns a new builder, but it's ignored
-builder.resultList                           // executes without the WHERE clause
+builder.where(User_.active eq true)   // returns a new builder, but it's ignored
+builder.resultList                    // executes without the WHERE clause
 
 // Correct: chain the calls
 val results = userRepository.select()
-    .where(User_.active, EQUALS, true)
+    .where(User_.active eq true)
     .resultList
 ```
 

--- a/docs/pagination-and-scrolling.md
+++ b/docs/pagination-and-scrolling.md
@@ -70,14 +70,14 @@ Use the `page` terminal method on the query builder. Pass a `Pageable` to specif
 val pageable = Pageable.ofSize(10)
 val page: Page<User> = orm.entity<User>()
     .select()
-    .where(User_.active, EQUALS, true)
+    .where(User_.active eq true)
     .page(pageable)
 
 // Navigate
 if (page.hasNext()) {
     val nextPage = orm.entity<User>()
         .select()
-        .where(User_.active, EQUALS, true)
+        .where(User_.active eq true)
         .page(page.nextPageable())
 }
 ```
@@ -236,7 +236,7 @@ Use `scroll` as a terminal operation on the query builder for filtering, joins, 
 
 ```kotlin
 val window = userRepository.select()
-    .where(User_.active, EQUALS, true)
+    .where(User_.active eq true)
     .scroll(Scrollable.of(User_.id, 10))
 ```
 

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -271,22 +271,22 @@ Use the `select()` method for type-safe queries with the generated metamodel:
 ```kotlin
 // Filter by field value
 val owners = ownerViews.select()
-    .where(OwnerView_.lastName, EQUALS, "Smith")
+    .where(OwnerView_.lastName eq "Smith")
     .resultList
 
 // Filter with comparison operators
 val recentVisits = orm.projection<VisitView>().select()
-    .where(VisitView_.visitDate, GREATER_THAN, LocalDate.of(2024, 1, 1))
+    .where(VisitView_.visitDate greater LocalDate.of(2024, 1, 1))
     .resultList
 
 // Filter by nested foreign key
 val ownerPets = orm.projection<PetView>().select()
-    .where(PetView_.owner.id, EQUALS, 1)
+    .where(PetView_.owner.id eq 1)
     .resultList
 
 // Count with filter
 val count = ownerViews.selectCount()
-    .where(OwnerView_.lastName, EQUALS, "Smith")
+    .where(OwnerView_.lastName eq "Smith")
     .singleResult
 ```
 
@@ -327,7 +327,7 @@ val owners = ownerViews.findAllById(ids)
 
 // Flow-based fetching (lazy evaluation, collect from a coroutine)
 ownerViews.select()
-    .where(OwnerView_.id, IN, ids)
+    .where(OwnerView_.id inList ids)
     .resultFlow
     .collect { owner ->
         // Process each owner

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -260,7 +260,7 @@ Multiple `where()` calls on the same query builder are combined with AND. This l
 ```kotlin
 val results = orm.entity<User>()
     .select()
-    .where(User_.active, EQUALS, true)
+    .where(User_.active eq true)
     .where(User_.city eq city)           // AND-combined with previous where
     .resultList
 ```
@@ -270,7 +270,7 @@ Builder-style `where()` calls (with `and`/`or` predicates) compose with other `w
 ```kotlin
 val results = orm.entity<User>()
     .select()
-    .where(User_.active, EQUALS, true)
+    .where(User_.active eq true)
     .where(                              // AND-combined with the active filter above
         (User_.role eq adminRole) or (User_.role eq superUserRole)
     )
@@ -436,7 +436,7 @@ List<CityCount> counts = orm.entity(User.class)
 
 ### Aggregation (SQL Templates)
 
-For aggregation queries that involve multiple tables, CTEs, or HAVING clauses, SQL Templates give you full control over the query structure while still mapping results to typed records.
+For aggregation queries that involve multiple tables or CTEs, SQL Templates give you full control over the query structure while still mapping results to typed records.
 
 ```java
 List<CityCount> counts = orm.query(RAW."""
@@ -448,6 +448,62 @@ List<CityCount> counts = orm.query(RAW."""
 
 </TabItem>
 </Tabs>
+
+### Filtering Groups
+
+`having()` filters the groups that `groupBy()` produces, the way `where()` filters rows. A condition on a grouped
+column takes a predicate; a condition on an aggregate takes a template, because no metamodel path names a
+computed value.
+
+<Tabs groupId="language">
+<TabItem value="kotlin" label="Kotlin" default>
+
+```kotlin
+// Grouped column: a predicate
+val counts: List<Long> = orm.entity<User>()
+    .selectCount()
+    .groupBy(User_.city)
+    .having((User_.city eq amsterdam) or (User_.city eq rotterdam))
+    .resultList
+
+// Aggregate: a template
+val busy = orm.entity<User>()
+    .select<CityCount, _, _> { "${City::class}, COUNT(*)" }
+    .groupBy(User_.city)
+    .having { "COUNT(*) > $minimum" }
+    .resultList
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+// Grouped column
+List<Long> counts = orm.entity(User.class)
+    .selectCount()
+    .groupBy(User_.city)
+    .having(User_.city, EQUALS, amsterdam)
+    .getResultList();
+
+// Aggregate, or any condition combining groups with OR
+List<CityCount> busy = orm.entity(User.class)
+    .select(CityCount.class, RAW."\{City.class}, COUNT(*)")
+    .groupBy(User_.city)
+    .having(RAW."COUNT(*) > \{minimum}")
+    .getResultList();
+```
+
+</TabItem>
+</Tabs>
+
+Consecutive `having()` calls are AND-combined, each clause parenthesized, the same way consecutive `where()` calls
+are. In Kotlin a disjunction stays in code: compose the predicate with infix `or`. In Java a predicate cannot be
+built outside a `where()` lambda, so a HAVING disjunction uses the template form.
+
+Use `havingAny()` when the condition names a joined entity's column, mirroring
+[`whereAny()`](#composing-multiple-filters). The predicate form takes the predicate directly rather than a
+builder: a HAVING clause filters groups, so the id, ref and record matching that `where()`'s builder offers does
+not carry over.
 
 ## Data Retrieval Strategies
 
@@ -478,7 +534,7 @@ val results = orm.entity<User>().select()
 
 // Pagination
 val page: Page<User> = orm.entity<User>().select()
-    .where(User_.active, EQUALS, true)
+    .where(User_.active eq true)
     .page(Pageable.ofSize(10))
 
 // Scrolling
@@ -728,7 +784,7 @@ When an inline record (embedded component) is used in a query clause, Storm auto
 
 Inline records expand differently depending on the operator:
 
-**EQUALS / NOT_EQUALS** generate per-column AND conditions:
+**Equality** (`eq` / `neq`, Java `EQUALS` / `NOT_EQUALS`) generates per-column AND conditions:
 
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
@@ -736,7 +792,7 @@ Inline records expand differently depending on the operator:
 ```kotlin
 val owner = orm.entity<Owner>()
     .select()
-    .where(Owner_.address, EQUALS, address)
+    .where(Owner_.address eq address)
     .singleResult
 ```
 
@@ -757,13 +813,13 @@ Owner owner = orm.entity(Owner.class)
 WHERE o.address = ? AND o.city_id = ?
 ```
 
-For NOT_EQUALS, the condition is wrapped in NOT:
+For inequality (`neq`, Java `NOT_EQUALS`), the condition is wrapped in NOT:
 
 ```sql
 WHERE NOT (o.address = ? AND o.city_id = ?)
 ```
 
-**Comparison operators** (GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL) generate lexicographic comparisons using nested OR/AND. This preserves the natural multi-column ordering:
+**Comparison operators** (`greater`, `greaterEq`, `less`, `lessEq`; Java `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`, `LESS_THAN`, `LESS_THAN_OR_EQUAL`) generate lexicographic comparisons using nested OR/AND. This preserves the natural multi-column ordering:
 
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
@@ -771,7 +827,7 @@ WHERE NOT (o.address = ? AND o.city_id = ?)
 ```kotlin
 val owners = orm.entity<Owner>()
     .select()
-    .where(Owner_.address, GREATER_THAN, address)
+    .where(Owner_.address greater address)
     .resultList
 ```
 
@@ -792,7 +848,7 @@ List<Owner> owners = orm.entity(Owner.class)
 WHERE (o.address > ? OR (o.address = ? AND o.city_id > ?))
 ```
 
-For GREATER_THAN_OR_EQUAL, only the last column uses the inclusive operator:
+For the inclusive variants (`greaterEq` / `lessEq`, Java `GREATER_THAN_OR_EQUAL` / `LESS_THAN_OR_EQUAL`), only the last column uses the inclusive operator:
 
 ```sql
 WHERE (o.address > ? OR (o.address = ? AND o.city_id >= ?))
@@ -804,7 +860,7 @@ Some databases (PostgreSQL, MySQL, MariaDB, Oracle) support native tuple compari
 WHERE (o.address, o.city_id) > (?, ?)
 ```
 
-**Unsupported operators.** LIKE, NOT_LIKE, IN, and NOT_IN do not have a meaningful multi-column interpretation and throw a `PersistenceException` when used with inline records. To filter on a sub-field, reference it directly:
+**Unsupported operators.** `like`, `notLike`, `inList`, and `notInList` (Java `LIKE`, `NOT_LIKE`, `IN`, `NOT_IN`) do not have a meaningful multi-column interpretation and throw a `PersistenceException` when used with inline records. To filter on a sub-field, reference it directly:
 
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
@@ -812,7 +868,7 @@ WHERE (o.address, o.city_id) > (?, ?)
 ```kotlin
 val owners = orm.entity<Owner>()
     .select()
-    .where(Owner_.address.address, LIKE, "%Main%")
+    .where(Owner_.address.address like "%Main%")
     .resultList
 ```
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -310,10 +310,10 @@ To scroll through a filtered subset, use the query builder with `scroll` as a te
 
 ```kotlin
 val activeWindow = userRepository.select()
-    .where(User_.active, EQUALS, true)
+    .where(User_.active eq true)
     .scroll(Scrollable.of(User_.id, 20))
 val nextActive = userRepository.select()
-    .where(User_.active, EQUALS, true)
+    .where(User_.active eq true)
     .scroll(activeWindow.next())
 ```
 
@@ -382,7 +382,7 @@ val next: Window<Post> = postRepository.scroll(window.next())
 
 // With filter (use query builder)
 val activeWindow = postRepository.select()
-    .where(Post_.active, EQUALS, true)
+    .where(Post_.active eq true)
     .scroll(Scrollable.of(Post_.id, Post_.createdAt, 20))
 ```
 

--- a/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
@@ -610,6 +610,28 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public abstract QueryBuilder<T, R, ID> havingAny(@Nonnull PredicateBuilder<?, ?, ?> predicate);
 
     /**
+     * Adds a HAVING clause that keeps the groups for which the specified subquery returns at least one row.
+     *
+     * @param subquery the subquery to test for existence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public final QueryBuilder<T, R, ID> havingExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
+        return having(TemplateString.raw("EXISTS (\0)", subquery));
+    }
+
+    /**
+     * Adds a HAVING clause that keeps the groups for which the specified subquery returns no rows.
+     *
+     * @param subquery the subquery to test for absence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public final QueryBuilder<T, R, ID> havingNotExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
+        return having(TemplateString.raw("NOT EXISTS (\0)", subquery));
+    }
+
+    /**
      * Adds an ORDER BY clause to the query for the field at the specified path in the table graph.
      *
      * @param path the path to order by.

--- a/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
@@ -319,26 +319,14 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the predicate builder.
      */
     public final <V extends Data> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull V record) {
-        return where(asMetamodel(path), EQUALS, record);
-    }
-
-    /**
-     * Resolves a navigable to a value metamodel. Full metamodels are returned as-is; a navigation-only node (one that
-     * navigates beyond a {@link Ref}) is rebuilt into a resolvable metamodel for its path so it can be used to locate a
-     * column in WHERE, ORDER BY, GROUP BY, and HAVING. Such a rebuilt metamodel is query-only: it cannot extract a
-     * value from a record.
-     */
-    private static <T extends Data, V> Metamodel<T, V> asMetamodel(@Nonnull Navigable<T, V> path) {
-        return path instanceof Metamodel<T, V> metamodel
-                ? metamodel
-                : Metamodel.of(path.root(), path.fieldPath());
+        return where(path.asMetamodel(), EQUALS, record);
     }
 
     @SuppressWarnings("unchecked")
     private static <T extends Data> Metamodel<T, ?>[] asMetamodels(@Nonnull Navigable<T, ?>[] paths) {
         Metamodel<T, ?>[] result = new Metamodel[paths.length];
         for (int i = 0; i < paths.length; i++) {
-            result[i] = asMetamodel(paths[i]);
+            result[i] = paths[i].asMetamodel();
         }
         return result;
     }
@@ -353,7 +341,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.3
      */
     public final <V extends Data> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull Ref<V> ref) {
-        Metamodel<T, V> metamodel = asMetamodel(path);
+        Metamodel<T, V> metamodel = path.asMetamodel();
         return where(predicate -> predicate.where(metamodel, ref));
     }
 
@@ -366,7 +354,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the predicate builder.
      */
     public final <V extends Data> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull Iterable<V> it) {
-        return where(asMetamodel(path), IN, it);
+        return where(path.asMetamodel(), IN, it);
     }
 
     /**
@@ -379,7 +367,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.3
      */
     public final <V extends Data> QueryBuilder<T, R, ID> whereRef(@Nonnull Navigable<T, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
-        Metamodel<T, V> metamodel = asMetamodel(path);
+        Metamodel<T, V> metamodel = path.asMetamodel();
         return where(predicate -> predicate.whereRef(metamodel, it));
     }
 
@@ -407,7 +395,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public final <V> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path,
                                                   @Nonnull Operator operator,
                                                   @Nonnull Iterable<? extends V> it) {
-        Metamodel<T, V> metamodel = asMetamodel(path);
+        Metamodel<T, V> metamodel = path.asMetamodel();
         return where(predicate -> predicate.where(metamodel, operator, it));
     }
 
@@ -426,7 +414,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public final <V> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path,
                                                   @Nonnull Operator operator,
                                                   @Nonnull V... o) {
-        Metamodel<T, V> metamodel = asMetamodel(path);
+        Metamodel<T, V> metamodel = path.asMetamodel();
         return where(predicate -> predicate.where(metamodel, operator, o));
     }
 
@@ -438,6 +426,25 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      */
     public final QueryBuilder<T, R, ID> where(@Nonnull TemplateString template) {
         return where(it -> it.where(template));
+    }
+
+    /**
+     * Adds a WHERE clause that matches the specified objects at the specified path in the table graph or manually
+     * added joins. Mirrors {@link #havingAny(Navigable, Operator, Object[])} for the WHERE clause.
+     *
+     * @param path the path to the object in the table graph.
+     * @param operator the operator to use for the comparison.
+     * @param o the object(s) to match, which can be primary keys, records representing the table, or fields in the
+     *          table graph or manually added joins.
+     * @return the query builder.
+     * @param <V> the type of the object that the metamodel represents.
+     * @since 1.13
+     */
+    @SafeVarargs
+    public final <V> QueryBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path,
+                                                     @Nonnull Operator operator,
+                                                     @Nonnull V... o) {
+        return whereAny(predicate -> predicate.whereAny(path, operator, o));
     }
 
     /**
@@ -455,6 +462,31 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      */
     public abstract QueryBuilder<T, R, ID> whereAny(@Nonnull Function<WhereBuilder<T, R, ID>, PredicateBuilder<?, ?, ?>> predicate);
+
+    /**
+     * Adds a WHERE clause that keeps the rows for which the specified subquery returns at least one row.
+     *
+     * <p>Use {@link #where(Function)} with {@link WhereBuilder#exists} to combine the condition with others in a
+     * single clause; consecutive {@code where} calls are AND-combined.</p>
+     *
+     * @param subquery the subquery to test for existence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public final QueryBuilder<T, R, ID> whereExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
+        return where(predicate -> predicate.exists(subquery));
+    }
+
+    /**
+     * Adds a WHERE clause that keeps the rows for which the specified subquery returns no rows.
+     *
+     * @param subquery the subquery to test for absence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public final QueryBuilder<T, R, ID> whereNotExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
+        return where(predicate -> predicate.notExists(subquery));
+    }
 
     /**
      * Adds a GROUP BY clause to the query for field at the specified path in the table graph. The metamodel can refer
@@ -489,12 +521,12 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.2
      */
-    public final QueryBuilder<T, R, ID> groupByAny(@Nonnull Metamodel<?, ?>... path) {
+    public final QueryBuilder<T, R, ID> groupByAny(@Nonnull Navigable<?, ?>... path) {
         if (path.length == 0) {
             throw new PersistenceException("At least one path must be provided for GROUP BY clause.");
         }
         List<TemplateString> templates = Stream.of(path)
-                .flatMap(metamodel -> Stream.of(wrap(new Columns(metamodel, CASCADE, false)), TemplateString.of(", ")))
+                .flatMap(path_ -> Stream.of(wrap(new Columns(path_.asMetamodel(), CASCADE, false)), TemplateString.of(", ")))
                 .toList();
         return groupBy(TemplateString.combine(templates.subList(0, templates.size() - 1).toArray(new TemplateString[0])));
     }
@@ -523,7 +555,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public final <V> QueryBuilder<T, R, ID> having(@Nonnull Navigable<T, V> path,
                                                    @Nonnull Operator operator,
                                                    @Nonnull V... o) {
-        return havingAny(asMetamodel(path), operator, o);
+        return havingAny(path.asMetamodel(), operator, o);
     }
 
     /**
@@ -537,10 +569,10 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.2
      */
     @SafeVarargs
-    public final <V> QueryBuilder<T, R, ID> havingAny(@Nonnull Metamodel<?, V> path,
+    public final <V> QueryBuilder<T, R, ID> havingAny(@Nonnull Navigable<?, V> path,
                                                       @Nonnull Operator operator,
                                                       @Nonnull V... o) {
-        return having(wrap(new ObjectExpression(path, operator, o)));
+        return having(wrap(new ObjectExpression(path.asMetamodel(), operator, o)));
     }
 
     /**
@@ -552,6 +584,30 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.2
      */
     public abstract QueryBuilder<T, R, ID> having(@Nonnull TemplateString template);
+
+    /**
+     * Adds a HAVING clause to the query for the specified predicate. Multiple calls to this method are combined using
+     * AND; compose the predicate with {@code and} and {@code or} to build a single clause that mixes both.
+     *
+     * <p>The predicate is taken directly rather than through a {@link WhereBuilder}. A HAVING clause filters groups
+     * rather than rows, so the builder's identity matching would not carry over, and its methods would read
+     * {@code where} at a {@code having} call site.</p>
+     *
+     * @param predicate the predicate to add.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public abstract QueryBuilder<T, R, ID> having(@Nonnull PredicateBuilder<T, ?, ?> predicate);
+
+    /**
+     * Adds a HAVING clause to the query for the specified predicate. The predicate may refer to any entity in the
+     * table graph, including manually added joins.
+     *
+     * @param predicate the predicate to add.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public abstract QueryBuilder<T, R, ID> havingAny(@Nonnull PredicateBuilder<?, ?, ?> predicate);
 
     /**
      * Adds an ORDER BY clause to the query for the field at the specified path in the table graph.
@@ -577,7 +633,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.2
      */
     public final QueryBuilder<T, R, ID> orderByDescending(@Nonnull Navigable<T, ?> path) {
-        return orderByDescendingAny(asMetamodel(path));
+        return orderByDescendingAny(path.asMetamodel());
     }
 
     /**
@@ -601,8 +657,8 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.9
      */
-    public final QueryBuilder<T, R, ID> orderByDescendingAny(@Nonnull Metamodel<?, ?> path) {
-        return orderBy(wrap(new Columns(path, CASCADE, true)));
+    public final QueryBuilder<T, R, ID> orderByDescendingAny(@Nonnull Navigable<?, ?> path) {
+        return orderBy(wrap(new Columns(path.asMetamodel(), CASCADE, true)));
     }
 
     /**
@@ -617,12 +673,12 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.9
      */
-    public final QueryBuilder<T, R, ID> orderByDescendingAny(@Nonnull Metamodel<?, ?>... path) {
+    public final QueryBuilder<T, R, ID> orderByDescendingAny(@Nonnull Navigable<?, ?>... path) {
         if (path.length == 0) {
             throw new PersistenceException("At least one path must be provided for ORDER BY clause.");
         }
         List<TemplateString> templates = Stream.of(path)
-                .flatMap(metamodel -> Stream.of(wrap(new Columns(metamodel, CASCADE, true)), TemplateString.of(", ")))
+                .<TemplateString>flatMap(path_ -> Stream.of(wrap(new Columns(path_.asMetamodel(), CASCADE, true)), TemplateString.of(", ")))
                 .toList();
         return orderBy(TemplateString.combine(templates.subList(0, templates.size() - 1).toArray(new TemplateString[0])));
     }
@@ -651,12 +707,12 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.2
      */
-    public final QueryBuilder<T, R, ID> orderByAny(@Nonnull Metamodel<?, ?>... path) {
+    public final QueryBuilder<T, R, ID> orderByAny(@Nonnull Navigable<?, ?>... path) {
         if (path.length == 0) {
             throw new PersistenceException("At least one path must be provided for ORDER BY clause.");
         }
         List<TemplateString> templates = Stream.of(path)
-                .flatMap(metamodel -> Stream.of(wrap(new Columns(metamodel, CASCADE, false)), TemplateString.of(", ")))
+                .flatMap(path_ -> Stream.of(wrap(new Columns(path_.asMetamodel(), CASCADE, false)), TemplateString.of(", ")))
                 .toList();
         return orderBy(TemplateString.combine(templates.subList(0, templates.size() - 1).toArray(new TemplateString[0])));
     }

--- a/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
@@ -473,6 +473,18 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.13
      */
+    /**
+     * Returns the factory this query builds its subqueries with.
+     *
+     * <p>The factory belongs to the query rather than to a clause: a subquery correlates through how it is embedded,
+     * not through where it was created, so a clause that takes a subquery can obtain one here without going through a
+     * {@link WhereBuilder}.</p>
+     *
+     * @return the subquery factory for this query.
+     * @since 1.13
+     */
+    public abstract SubqueryTemplate subqueryTemplate();
+
     public final QueryBuilder<T, R, ID> whereExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
         return where(predicate -> predicate.exists(subquery));
     }

--- a/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
@@ -464,16 +464,6 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public abstract QueryBuilder<T, R, ID> whereAny(@Nonnull Function<WhereBuilder<T, R, ID>, PredicateBuilder<?, ?, ?>> predicate);
 
     /**
-     * Adds a WHERE clause that keeps the rows for which the specified subquery returns at least one row.
-     *
-     * <p>Use {@link #where(Function)} with {@link WhereBuilder#exists} to combine the condition with others in a
-     * single clause; consecutive {@code where} calls are AND-combined.</p>
-     *
-     * @param subquery the subquery to test for existence.
-     * @return the query builder.
-     * @since 1.13
-     */
-    /**
      * Returns the factory this query builds its subqueries with.
      *
      * <p>The factory belongs to the query rather than to a clause: a subquery correlates through how it is embedded,
@@ -485,6 +475,16 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      */
     public abstract SubqueryTemplate subqueryTemplate();
 
+    /**
+     * Adds a WHERE clause that keeps the rows for which the specified subquery returns at least one row.
+     *
+     * <p>Use {@link #where(Function)} with {@link WhereBuilder#exists} to combine the condition with others in a
+     * single clause; consecutive {@code where} calls are AND-combined.</p>
+     *
+     * @param subquery the subquery to test for existence.
+     * @return the query builder.
+     * @since 1.13
+     */
     public final QueryBuilder<T, R, ID> whereExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
         return where(predicate -> predicate.exists(subquery));
     }

--- a/storm-core/src/main/java/st/orm/core/template/WhereBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/WhereBuilder.java
@@ -20,7 +20,7 @@ import static st.orm.Operator.IN;
 
 import jakarta.annotation.Nonnull;
 import st.orm.Data;
-import st.orm.Metamodel;
+import st.orm.Navigable;
 import st.orm.Operator;
 import st.orm.Ref;
 
@@ -171,7 +171,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @param record the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path, @Nonnull V record) {
+    public final <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull V record) {
         return where(path, EQUALS, record);
     }
 
@@ -182,7 +182,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @param record the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull V record) {
+    public final <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path, @Nonnull V record) {
         return whereAny(path, EQUALS, record);
     }
 
@@ -195,7 +195,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the predicate builder.
      * @since 1.3
      */
-    public abstract <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path, @Nonnull Ref<V> ref);
+    public abstract <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull Ref<V> ref);
 
     /**
      * Adds a condition to the WHERE clause that matches the specified ref. The record can represent any of
@@ -206,7 +206,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the predicate builder.
      * @since 1.3
      */
-    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull Ref<V> ref);
+    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path, @Nonnull Ref<V> ref);
 
     /**
      * Adds a condition to the WHERE clause that matches the specified refs. The refs can represent any of
@@ -217,7 +217,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the predicate builder.
      * @since 1.3
      */
-    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereRef(@Nonnull Metamodel<T, V> path, @Nonnull Iterable<? extends Ref<V>> it);
+    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereRef(@Nonnull Navigable<T, V> path, @Nonnull Iterable<? extends Ref<V>> it);
 
     /**
      * Adds a condition to the WHERE clause that matches the specified refs. The refs can represent any of
@@ -228,7 +228,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the predicate builder.
      * @since 1.3
      */
-    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereAnyRef(@Nonnull Metamodel<?, V> path, @Nonnull Iterable<? extends Ref<V>> it);
+    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereAnyRef(@Nonnull Navigable<?, V> path, @Nonnull Iterable<? extends Ref<V>> it);
 
     /**
      * Adds a condition to the WHERE clause that matches the specified records. The records can represent any of
@@ -238,7 +238,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @param it   the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path, @Nonnull Iterable<V> it) {
+    public final <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull Iterable<V> it) {
         return where(path, IN, it);
     }
 
@@ -250,7 +250,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @param it   the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull Iterable<V> it) {
+    public final <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path, @Nonnull Iterable<V> it) {
         return whereAny(path, IN, it);
     }
 
@@ -266,7 +266,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the query builder.
      * @since 1.2
      */
-    public abstract <V> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path,
+    public abstract <V> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path,
                                                          @Nonnull Operator operator,
                                                          @Nonnull Iterable<? extends V> it);
 
@@ -282,7 +282,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the query builder.
      * @since 1.2
      */
-    public abstract <V> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path,
+    public abstract <V> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path,
                                                             @Nonnull Operator operator,
                                                             @Nonnull Iterable<? extends V> it);
 
@@ -299,7 +299,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @since 1.2
      */
     @SafeVarargs
-    public final <V> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path,
+    public final <V> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path,
                                                       @Nonnull Operator operator,
                                                       @Nonnull V... o) {
         return whereImpl(path, operator, o);
@@ -318,7 +318,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @since 1.2
      */
     @SafeVarargs
-    public final <V> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path,
+    public final <V> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path,
                                                          @Nonnull Operator operator,
                                                          @Nonnull V... o) {
         return whereImpl(path, operator, o);
@@ -344,7 +344,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the query builder.
      * @since 1.2
      */
-    protected abstract <V> PredicateBuilder<T, R, ID> whereImpl(@Nonnull Metamodel<?, V> path,
+    protected abstract <V> PredicateBuilder<T, R, ID> whereImpl(@Nonnull Navigable<?, V> path,
                                                                 @Nonnull Operator operator,
                                                                 @Nonnull V[] o);
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryBuilderImpl.java
@@ -485,8 +485,12 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
             templates.add(template);
         }
 
-        private List<TemplateString> getTemplates() {
-            return templates;
+        /**
+         * Returns the predicate as a single template, for a clause that carries its conditions as templates rather
+         * than as {@link Where} elements.
+         */
+        private TemplateString asTemplate() {
+            return combine(templates);
         }
     }
 
@@ -578,33 +582,33 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
         }
 
         @Override
-        public <V extends Data> PredicateBuilder<TX, RX, IDX> where(@Nonnull Metamodel<TX, V> path, @Nonnull Ref<V> ref) {
-            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path, EQUALS, ref)));
+        public <V extends Data> PredicateBuilder<TX, RX, IDX> where(@Nonnull Navigable<TX, V> path, @Nonnull Ref<V> ref) {
+            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path.asMetamodel(), EQUALS, ref)));
         }
 
         @Override
-        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull Ref<V> ref) {
-            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path, EQUALS, ref)));
+        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereAny(@Nonnull Navigable<?, V> path, @Nonnull Ref<V> ref) {
+            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path.asMetamodel(), EQUALS, ref)));
         }
 
         @Override
-        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereRef(@Nonnull Metamodel<TX, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
-            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path, IN, it)));
+        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereRef(@Nonnull Navigable<TX, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
+            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path.asMetamodel(), IN, it)));
         }
 
         @Override
-        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereAnyRef(@Nonnull Metamodel<?, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
-            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path, IN, it)));
+        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereAnyRef(@Nonnull Navigable<?, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
+            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path.asMetamodel(), IN, it)));
         }
 
         @Override
-        public <V> PredicateBuilder<TX, RX, IDX> where(@Nonnull Metamodel<TX, V> path, @Nonnull Operator operator, @Nonnull Iterable<? extends V> it) {
-            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path, operator, it)));
+        public <V> PredicateBuilder<TX, RX, IDX> where(@Nonnull Navigable<TX, V> path, @Nonnull Operator operator, @Nonnull Iterable<? extends V> it) {
+            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path.asMetamodel(), operator, it)));
         }
 
         @Override
-        public <V> PredicateBuilder<TX, RX, IDX> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull Operator operator, @Nonnull Iterable<? extends V> it) {
-            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path, operator, it)));
+        public <V> PredicateBuilder<TX, RX, IDX> whereAny(@Nonnull Navigable<?, V> path, @Nonnull Operator operator, @Nonnull Iterable<? extends V> it) {
+            return new PredicateBuilderImpl<>(wrap(new ObjectExpression(path.asMetamodel(), operator, it)));
         }
 
         @Override
@@ -613,10 +617,10 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
         }
 
         @Override
-        protected <V> PredicateBuilder<TX, RX, IDX> whereImpl(@Nonnull Metamodel<?, V> path, @Nonnull Operator operator, @Nonnull V[] o) {
+        protected <V> PredicateBuilder<TX, RX, IDX> whereImpl(@Nonnull Navigable<?, V> path, @Nonnull Operator operator, @Nonnull V[] o) {
             try {
                 try {
-                    return PredicateBuilderFactory.createWithId(path, operator, List.of(o));
+                    return PredicateBuilderFactory.createWithId(path.asMetamodel(), operator, List.of(o));
                 } catch (NullPointerException e) {
                     throw new SqlTemplateException("Null value not allowed.");
                 }
@@ -632,8 +636,7 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
             return null;
         }
 
-        private QueryBuilder<TX, RX, IDX> build(@Nonnull List<TemplateString> templates) {
-            var template = combine(templates);
+        private QueryBuilder<TX, RX, IDX> build(@Nonnull TemplateString template) {
             Where where;
             if (unwrap(template) instanceof Expression expression) {
                 where = new Where(expression, null);
@@ -654,7 +657,7 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
     public QueryBuilder<T, R, ID> where(@Nonnull Function<WhereBuilder<T, R, ID>, PredicateBuilder<T, ?, ?>> predicate) {
         requireNonNull(predicate, "predicate");
         var whereBuilder = new WhereBuilderImpl<>(this);
-        return whereBuilder.build(((PredicateBuilderImpl<T, ?, ?>) predicate.apply(whereBuilder)).getTemplates());
+        return whereBuilder.build(((PredicateBuilderImpl<T, ?, ?>) predicate.apply(whereBuilder)).asTemplate());
     }
 
     /**
@@ -667,6 +670,39 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
     public QueryBuilder<T, R, ID> whereAny(@Nonnull Function<WhereBuilder<T, R, ID>, PredicateBuilder<?, ?, ?>> predicate) {
         requireNonNull(predicate, "predicate");
         var whereBuilder = new WhereBuilderImpl<>(this);
-        return whereBuilder.build(((PredicateBuilderImpl<?, ?, ?>) predicate.apply(whereBuilder)).getTemplates());
+        return whereBuilder.build(((PredicateBuilderImpl<?, ?, ?>) predicate.apply(whereBuilder)).asTemplate());
+    }
+
+    /**
+     * Adds a HAVING clause to the query for the specified predicate.
+     *
+     * @param predicate the predicate to add.
+     * @return the query builder.
+     * @since 1.13
+     */
+    @Override
+    public QueryBuilder<T, R, ID> having(@Nonnull PredicateBuilder<T, ?, ?> predicate) {
+        return addHaving(predicate);
+    }
+
+    /**
+     * Adds a HAVING clause to the query for the specified predicate.
+     *
+     * @param predicate the predicate to add.
+     * @return the query builder.
+     * @since 1.13
+     */
+    @Override
+    public QueryBuilder<T, R, ID> havingAny(@Nonnull PredicateBuilder<?, ?, ?> predicate) {
+        return addHaving(predicate);
+    }
+
+    /**
+     * Appends the predicate to the HAVING clause, which carries its conditions as templates rather than as
+     * {@code Where} elements.
+     */
+    private QueryBuilder<T, R, ID> addHaving(@Nonnull PredicateBuilder<?, ?, ?> predicate) {
+        requireNonNull(predicate, "predicate");
+        return having(((PredicateBuilderImpl<?, ?, ?>) predicate).asTemplate());
     }
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryBuilderImpl.java
@@ -44,6 +44,7 @@ import st.orm.core.template.PredicateBuilder;
 import st.orm.core.template.QueryBuilder;
 import st.orm.core.template.QueryTemplate;
 import st.orm.core.template.SqlTemplateException;
+import st.orm.core.template.SubqueryTemplate;
 import st.orm.core.template.TemplateString;
 import st.orm.core.template.TypedJoinBuilder;
 import st.orm.core.template.WhereBuilder;
@@ -170,6 +171,17 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
         List<Join> copy = new ArrayList<>(this.join);
         copy.add(join);
         return copyWith(queryTemplate, fromType, copy, where, templates, groupBy, having, orderBy);
+    }
+
+    /**
+     * Returns the factory this query builds its subqueries with.
+     *
+     * @return the subquery factory for this query.
+     * @since 1.13
+     */
+    @Override
+    public SubqueryTemplate subqueryTemplate() {
+        return queryTemplate;
     }
 
     /**

--- a/storm-core/src/test/java/st/orm/core/QueryBuilderPredicateIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/QueryBuilderPredicateIntegrationTest.java
@@ -27,6 +27,7 @@ import st.orm.TypedMetamodel;
 import st.orm.core.model.City;
 import st.orm.core.model.City_;
 import st.orm.core.model.Owner;
+import st.orm.core.model.Owner_;
 import st.orm.core.model.Pet;
 import st.orm.core.model.PetOwnerRef;
 import st.orm.core.model.PetOwnerRef_;
@@ -34,6 +35,8 @@ import st.orm.core.model.Pet_;
 import st.orm.core.model.Visit;
 import st.orm.core.model.Visit_;
 import st.orm.core.template.ORMTemplate;
+import st.orm.core.template.PredicateBuilder;
+import st.orm.core.template.impl.PredicateBuilderFactory;
 
 /**
  * Integration tests targeting uncovered predicate builder, where-builder, and QueryBuilder convenience methods
@@ -274,6 +277,55 @@ public class QueryBuilderPredicateIntegrationTest {
         assertTrue(results.size() > 0, "Expected at least one pet with more than 1 visit");
         for (var result : results) {
             assertTrue(result.visitCount() > 1);
+        }
+    }
+
+    // QueryBuilder.having with a predicate
+    //
+    // PredicateBuilderFactory is how the Kotlin infix operators build a predicate: standalone, with no WhereBuilder
+    // involved. These tests drive the same predicates into the HAVING clause.
+
+    @Test
+    public void testHavingCallsAreAndCombined() {
+        var orm = ORMTemplate.of(dataSource);
+        // The two clauses cannot both hold, so AND-combining them yields no groups.
+        List<Long> counts = orm.entity(Owner.class)
+                .selectCount()
+                .groupBy(Owner_.lastName)
+                .having(Owner_.lastName, EQUALS, "Davis")
+                .having(Owner_.lastName, EQUALS, "Franklin")
+                .getResultList();
+        assertTrue(counts.isEmpty());
+    }
+
+    @Test
+    public void testHavingWithOrComposedPredicate() {
+        var orm = ORMTemplate.of(dataSource);
+        // A disjunction cannot come from consecutive having() calls, which are AND-combined.
+        PredicateBuilder<Owner, ?, ?> davis = PredicateBuilderFactory.create(Owner_.lastName, EQUALS, List.of("Davis"));
+        PredicateBuilder<Owner, ?, ?> franklin = PredicateBuilderFactory.create(Owner_.lastName, EQUALS, List.of("Franklin"));
+        List<Long> counts = orm.entity(Owner.class)
+                .selectCount()
+                .groupBy(Owner_.lastName)
+                .having(davis.or(franklin))
+                .getResultList();
+        assertEquals(2, counts.size());
+        assertEquals(3L, counts.stream().mapToLong(Long::longValue).sum());
+    }
+
+    @Test
+    public void testHavingAnyWithPredicateOnJoinedEntity() {
+        var orm = ORMTemplate.of(dataSource);
+        record PetVisitCount(Pet pet, int visitCount) {}
+        PredicateBuilder<Visit, ?, ?> predicate = PredicateBuilderFactory.create(Visit_.pet.id, IN, List.of(7, 8));
+        var results = orm.selectFrom(Pet.class, PetVisitCount.class, raw("\0, COUNT(*)", Pet.class))
+                .innerJoin(Visit.class).on(Pet.class)
+                .groupBy(Pet_.id)
+                .havingAny(predicate)
+                .getResultList();
+        assertEquals(2, results.size());
+        for (var result : results) {
+            assertTrue(result.pet().id() == 7 || result.pet().id() == 8);
         }
     }
 

--- a/storm-foundation/src/main/java/st/orm/Navigable.java
+++ b/storm-foundation/src/main/java/st/orm/Navigable.java
@@ -131,4 +131,22 @@ public interface Navigable<T extends Data, E> {
     default List<Metamodel<T, ?>> flatten() {
         return MetamodelHelper.flatten(this);
     }
+
+    /**
+     * Returns this navigable as a metamodel that can locate a column. A full metamodel is returned as-is; a
+     * navigation-only node (one that navigates beyond a {@link Ref}) is rebuilt into a resolvable metamodel for its
+     * path, so it can name a column in WHERE, ORDER BY, GROUP BY and HAVING.
+     *
+     * <p>A rebuilt metamodel is query-only: it names a column but cannot extract a value from a record, which is why
+     * value operations keep taking {@link Metamodel} rather than {@code Navigable}.</p>
+     *
+     * @return this navigable as a metamodel.
+     * @since 1.13
+     */
+    @SuppressWarnings("unchecked")
+    default Metamodel<T, E> asMetamodel() {
+        return this instanceof Metamodel<?, ?>
+                ? (Metamodel<T, E>) this
+                : Metamodel.of(root(), fieldPath());
+    }
 }

--- a/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
+++ b/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
@@ -351,7 +351,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @param record the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Record> QueryBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path, @Nonnull V record) {
+    public final <V extends Record> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull V record) {
         return where(path, EQUALS, record);
     }
 
@@ -364,7 +364,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the predicate builder.
      * @since 1.3
      */
-    public final <V extends Data> QueryBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path, @Nonnull Ref<V> ref) {
+    public final <V extends Data> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull Ref<V> ref) {
         return where(predicate -> predicate.where(path, ref));
     }
 
@@ -376,7 +376,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @param it the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Data> QueryBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path, @Nonnull Iterable<V> it) {
+    public final <V extends Data> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull Iterable<V> it) {
         return where(path, IN, it);
     }
 
@@ -389,7 +389,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the predicate builder.
      * @since 1.3
      */
-    public final <V extends Data> QueryBuilder<T, R, ID> whereRef(@Nonnull Metamodel<T, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
+    public final <V extends Data> QueryBuilder<T, R, ID> whereRef(@Nonnull Navigable<T, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
         return where(predicate -> predicate.whereRef(path, it));
     }
 
@@ -414,7 +414,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @param <V> the type of the object that the metamodel represents.
      * @since 1.2
      */
-    public final <V> QueryBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path,
+    public final <V> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path,
                                                   @Nonnull Operator operator,
                                                   @Nonnull Iterable<? extends V> it) {
         return where(predicate -> predicate.where(path, operator, it));
@@ -432,7 +432,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.2
      */
     @SafeVarargs
-    public final <V> QueryBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path,
+    public final <V> QueryBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path,
                                                   @Nonnull Operator operator,
                                                   @Nonnull V... o) {
         return where(predicate -> predicate.where(path, operator, o));
@@ -446,6 +446,25 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      */
     public final QueryBuilder<T, R, ID> where(@Nonnull StringTemplate template) {
         return where(it -> it.where(template));
+    }
+
+    /**
+     * Adds a WHERE clause that matches the specified objects at the specified path in the table graph or manually
+     * added joins. Mirrors {@link #havingAny(Navigable, Operator, Object[])} for the WHERE clause.
+     *
+     * @param path the path to the object in the table graph.
+     * @param operator the operator to use for the comparison.
+     * @param o the object(s) to match, which can be primary keys, records representing the table, or fields in the
+     *          table graph or manually added joins.
+     * @return the query builder.
+     * @param <V> the type of the object that the metamodel represents.
+     * @since 1.13
+     */
+    @SafeVarargs
+    public final <V> QueryBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path,
+                                                     @Nonnull Operator operator,
+                                                     @Nonnull V... o) {
+        return whereAny(predicate -> predicate.whereAny(path, operator, o));
     }
 
     /**
@@ -465,6 +484,31 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     public abstract QueryBuilder<T, R, ID> whereAny(@Nonnull Function<WhereBuilder<T, R, ID>, PredicateBuilder<?, ?, ?>> predicate);
 
     /**
+     * Adds a WHERE clause that keeps the rows for which the specified subquery returns at least one row.
+     *
+     * <p>Use {@link #where(Function)} with {@link WhereBuilder#exists} to combine the condition with others in a
+     * single clause; consecutive {@code where} calls are AND-combined.</p>
+     *
+     * @param subquery the subquery to test for existence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public final QueryBuilder<T, R, ID> whereExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
+        return where(predicate -> predicate.exists(subquery));
+    }
+
+    /**
+     * Adds a WHERE clause that keeps the rows for which the specified subquery returns no rows.
+     *
+     * @param subquery the subquery to test for absence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public final QueryBuilder<T, R, ID> whereNotExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
+        return where(predicate -> predicate.notExists(subquery));
+    }
+
+    /**
      * Adds a GROUP BY clause to the query for field at the specified path in the table graph. The metamodel can refer
      * to manually added joins.
      *
@@ -477,7 +521,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.2
      */
     @SafeVarargs
-    public final QueryBuilder<T, R, ID> groupBy(@Nonnull Metamodel<T, ?>... path) {
+    public final QueryBuilder<T, R, ID> groupBy(@Nonnull Navigable<T, ?>... path) {
         // We can safely invoke groupByAny as the underlying logic is identical. The main purpose of having these
         // separate methods is to provide (more) type safety when using metamodels that are guaranteed to be present in
         // the table graph.
@@ -496,13 +540,13 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.2
      */
-    public final QueryBuilder<T, R, ID> groupByAny(@Nonnull Metamodel<?, ?>... path) {
+    public final QueryBuilder<T, R, ID> groupByAny(@Nonnull Navigable<?, ?>... path) {
         if (path.length == 0) {
             throw new PersistenceException("At least one path must be provided for GROUP BY clause.");
         }
         List<StringTemplate> templates = Stream.of(path)
-                .flatMap(metamodel -> {
-                    Columns columns = new Columns(metamodel, CASCADE, false);
+                .<StringTemplate>flatMap(navigable -> {
+                    Columns columns = new Columns(navigable.asMetamodel(), CASCADE, false);
                     return Stream.of(RAW."\{columns}", RAW.", ");
                 })
                 .toList();
@@ -530,7 +574,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.2
      */
     @SafeVarargs
-    public final <V> QueryBuilder<T, R, ID> having(@Nonnull Metamodel<T, V> path,
+    public final <V> QueryBuilder<T, R, ID> having(@Nonnull Navigable<T, V> path,
                                                    @Nonnull Operator operator,
                                                    @Nonnull V... o) {
         return havingAny(path, operator, o);
@@ -547,10 +591,10 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.2
      */
     @SafeVarargs
-    public final <V> QueryBuilder<T, R, ID> havingAny(@Nonnull Metamodel<?, V> path,
+    public final <V> QueryBuilder<T, R, ID> havingAny(@Nonnull Navigable<?, V> path,
                                                       @Nonnull Operator operator,
                                                       @Nonnull V... o) {
-        return having(RAW."\{new ObjectExpression(path, operator, o)}");
+        return having(RAW."\{new ObjectExpression(path.asMetamodel(), operator, o)}");
     }
 
     /**
@@ -563,6 +607,8 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      */
     public abstract QueryBuilder<T, R, ID> having(@Nonnull StringTemplate template);
 
+
+
     /**
      * Adds an ORDER BY clause to the query for the field at the specified path in the table graph.
      *
@@ -571,7 +617,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.2
      */
     @SafeVarargs
-    public final QueryBuilder<T, R, ID> orderBy(@Nonnull Metamodel<T, ?>... path) {
+    public final QueryBuilder<T, R, ID> orderBy(@Nonnull Navigable<T, ?>... path) {
         // We can safely invoke orderByAny as the underlying logic is identical. The main purpose of having these
         // separate methods is to provide (more) type safety when using metamodels that are guaranteed to be present in
         // the table graph.
@@ -586,8 +632,8 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.2
      */
-    public final QueryBuilder<T, R, ID> orderByDescending(@Nonnull Metamodel<T, ?> path) {
-        return orderBy(RAW."\{new Columns(path, CASCADE, true)}");
+    public final QueryBuilder<T, R, ID> orderByDescending(@Nonnull Navigable<T, ?> path) {
+        return orderBy(RAW."\{new Columns(path.asMetamodel(), CASCADE, true)}");
     }
 
     /**
@@ -599,7 +645,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.9
      */
     @SafeVarargs
-    public final QueryBuilder<T, R, ID> orderByDescending(@Nonnull Metamodel<T, ?>... path) {
+    public final QueryBuilder<T, R, ID> orderByDescending(@Nonnull Navigable<T, ?>... path) {
         return orderByDescendingAny(path);
     }
 
@@ -611,8 +657,8 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.9
      */
-    public final QueryBuilder<T, R, ID> orderByDescendingAny(@Nonnull Metamodel<?, ?> path) {
-        return orderBy(RAW."\{new Columns(path, CASCADE, true)}");
+    public final QueryBuilder<T, R, ID> orderByDescendingAny(@Nonnull Navigable<?, ?> path) {
+        return orderBy(RAW."\{new Columns(path.asMetamodel(), CASCADE, true)}");
     }
 
     /**
@@ -623,13 +669,13 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.9
      */
-    public final QueryBuilder<T, R, ID> orderByDescendingAny(@Nonnull Metamodel<?, ?>... path) {
+    public final QueryBuilder<T, R, ID> orderByDescendingAny(@Nonnull Navigable<?, ?>... path) {
         if (path.length == 0) {
             throw new PersistenceException("At least one path must be provided for ORDER BY clause.");
         }
         List<StringTemplate> templates = Stream.of(path)
-                .flatMap(metamodel -> {
-                    Columns columns = new Columns(metamodel, CASCADE, true);
+                .<StringTemplate>flatMap(navigable -> {
+                    Columns columns = new Columns(navigable.asMetamodel(), CASCADE, true);
                     return Stream.of(RAW."\{columns}", RAW.", ");
                 })
                 .toList();
@@ -656,13 +702,13 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @return the query builder.
      * @since 1.2
      */
-    public final QueryBuilder<T, R, ID> orderByAny(@Nonnull Metamodel<?, ?>... path) {
+    public final QueryBuilder<T, R, ID> orderByAny(@Nonnull Navigable<?, ?>... path) {
         if (path.length == 0) {
             throw new PersistenceException("At least one path must be provided for ORDER BY clause.");
         }
         List<StringTemplate> templates = Stream.of(path)
-                .flatMap(metamodel -> {
-                    Columns columns = new Columns(metamodel, CASCADE, false);
+                .<StringTemplate>flatMap(navigable -> {
+                    Columns columns = new Columns(navigable.asMetamodel(), CASCADE, false);
                     return Stream.of(RAW."\{columns}", RAW.", ");
                 })
                 .toList();

--- a/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
+++ b/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
@@ -607,6 +607,24 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      */
     public abstract QueryBuilder<T, R, ID> having(@Nonnull StringTemplate template);
 
+    /**
+     * Adds a HAVING clause that keeps the groups for which the specified subquery returns at least one row.
+     *
+     * @param subquery the subquery to test for existence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public abstract QueryBuilder<T, R, ID> havingExists(@Nonnull QueryBuilder<?, ?, ?> subquery);
+
+    /**
+     * Adds a HAVING clause that keeps the groups for which the specified subquery returns no rows.
+     *
+     * @param subquery the subquery to test for absence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    public abstract QueryBuilder<T, R, ID> havingNotExists(@Nonnull QueryBuilder<?, ?, ?> subquery);
+
 
 
     /**

--- a/storm-java21/src/main/java/st/orm/template/WhereBuilder.java
+++ b/storm-java21/src/main/java/st/orm/template/WhereBuilder.java
@@ -21,7 +21,7 @@ import static st.orm.Operator.IN;
 
 import jakarta.annotation.Nonnull;
 import st.orm.Data;
-import st.orm.Metamodel;
+import st.orm.Navigable;
 import st.orm.Operator;
 import st.orm.Ref;
 
@@ -192,7 +192,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @param record the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path, @Nonnull V record) {
+    public final <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull V record) {
         return where(path, EQUALS, record);
     }
 
@@ -203,7 +203,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @param record the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull V record) {
+    public final <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path, @Nonnull V record) {
         return whereAny(path, EQUALS, record);
     }
 
@@ -216,7 +216,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the predicate builder.
      * @since 1.3
      */
-    public abstract <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path, @Nonnull Ref<V> ref);
+    public abstract <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull Ref<V> ref);
 
     /**
      * Adds a condition to the WHERE clause that matches the specified ref. The record can represent any of
@@ -227,7 +227,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the predicate builder.
      * @since 1.3
      */
-    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull Ref<V> ref);
+    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path, @Nonnull Ref<V> ref);
 
     /**
      * Adds a condition to the WHERE clause that matches the specified refs. The refs can represent any of
@@ -238,7 +238,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the predicate builder.
      * @since 1.3
      */
-    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereRef(@Nonnull Metamodel<T, V> path, @Nonnull Iterable<? extends Ref<V>> it);
+    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereRef(@Nonnull Navigable<T, V> path, @Nonnull Iterable<? extends Ref<V>> it);
 
     /**
      * Adds a condition to the WHERE clause that matches the specified refs. The refs can represent any of
@@ -249,7 +249,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the predicate builder.
      * @since 1.3
      */
-    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereAnyRef(@Nonnull Metamodel<?, V> path, @Nonnull Iterable<? extends Ref<V>> it);
+    public abstract <V extends Data> PredicateBuilder<T, R, ID> whereAnyRef(@Nonnull Navigable<?, V> path, @Nonnull Iterable<? extends Ref<V>> it);
 
     /**
      * Adds a condition to the WHERE clause that matches the specified records. The records can represent any of
@@ -259,7 +259,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @param it   the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path, @Nonnull Iterable<V> it) {
+    public final <V extends Data> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path, @Nonnull Iterable<V> it) {
         return where(path, IN, it);
     }
 
@@ -271,7 +271,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @param it   the records to match.
      * @return the predicate builder.
      */
-    public final <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull Iterable<V> it) {
+    public final <V extends Data> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path, @Nonnull Iterable<V> it) {
         return whereAny(path, IN, it);
     }
 
@@ -287,7 +287,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the query builder.
      * @since 1.2
      */
-    public abstract <V> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path,
+    public abstract <V> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path,
                                                          @Nonnull Operator operator,
                                                          @Nonnull Iterable<? extends V> it);
 
@@ -303,7 +303,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the query builder.
      * @since 1.2
      */
-    public abstract <V> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path,
+    public abstract <V> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path,
                                                             @Nonnull Operator operator,
                                                             @Nonnull Iterable<? extends V> it);
 
@@ -320,7 +320,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @since 1.2
      */
     @SafeVarargs
-    public final <V> PredicateBuilder<T, R, ID> where(@Nonnull Metamodel<T, V> path,
+    public final <V> PredicateBuilder<T, R, ID> where(@Nonnull Navigable<T, V> path,
                                                       @Nonnull Operator operator,
                                                       @Nonnull V... o) {
         return whereImpl(path, operator, o);
@@ -339,7 +339,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @since 1.2
      */
     @SafeVarargs
-    public final <V> PredicateBuilder<T, R, ID> whereAny(@Nonnull Metamodel<?, V> path,
+    public final <V> PredicateBuilder<T, R, ID> whereAny(@Nonnull Navigable<?, V> path,
                                                          @Nonnull Operator operator,
                                                          @Nonnull V... o) {
         return whereImpl(path, operator, o);
@@ -365,7 +365,7 @@ public abstract class WhereBuilder<T extends Data, R, ID> implements SubqueryTem
      * @return the query builder.
      * @since 1.2
      */
-    protected abstract <V> PredicateBuilder<T, R, ID> whereImpl(@Nonnull Metamodel<?, V> path,
+    protected abstract <V> PredicateBuilder<T, R, ID> whereImpl(@Nonnull Navigable<?, V> path,
                                                                 @Nonnull Operator operator,
                                                                 @Nonnull V[] o);
 }

--- a/storm-java21/src/main/java/st/orm/template/impl/QueryBuilderImpl.java
+++ b/storm-java21/src/main/java/st/orm/template/impl/QueryBuilderImpl.java
@@ -157,6 +157,30 @@ public final class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<
     }
 
     /**
+     * Adds a HAVING clause that keeps the groups for which the specified subquery returns at least one row.
+     *
+     * @param subquery the subquery to test for existence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    @Override
+    public QueryBuilder<T, R, ID> havingExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
+        return new QueryBuilderImpl<>(core.havingExists(((QueryBuilderImpl<?, ?, ?>) subquery).core));
+    }
+
+    /**
+     * Adds a HAVING clause that keeps the groups for which the specified subquery returns no rows.
+     *
+     * @param subquery the subquery to test for absence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    @Override
+    public QueryBuilder<T, R, ID> havingNotExists(@Nonnull QueryBuilder<?, ?, ?> subquery) {
+        return new QueryBuilderImpl<>(core.havingNotExists(((QueryBuilderImpl<?, ?, ?>) subquery).core));
+    }
+
+    /**
      * Returns {@code true} if any ORDER BY columns have been added to this query builder.
      *
      * @return {@code true} if ORDER BY columns are present, {@code false} otherwise.

--- a/storm-java21/src/main/java/st/orm/template/impl/QueryBuilderImpl.java
+++ b/storm-java21/src/main/java/st/orm/template/impl/QueryBuilderImpl.java
@@ -29,7 +29,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import st.orm.Data;
 import st.orm.JoinType;
-import st.orm.Metamodel;
 import st.orm.Navigable;
 import st.orm.Operator;
 import st.orm.PersistenceException;
@@ -521,32 +520,32 @@ public final class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<
         }
 
         @Override
-        public <V extends Data> PredicateBuilder<TX, RX, IDX> where(@Nonnull Metamodel<TX, V> path, @Nonnull Ref<V> ref) {
+        public <V extends Data> PredicateBuilder<TX, RX, IDX> where(@Nonnull Navigable<TX, V> path, @Nonnull Ref<V> ref) {
             return new PredicateBuilderImpl<>(core.where(path, ref));
         }
 
         @Override
-        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull Ref<V> ref) {
+        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereAny(@Nonnull Navigable<?, V> path, @Nonnull Ref<V> ref) {
             return new PredicateBuilderImpl<>(core.whereAny(path, ref));
         }
 
         @Override
-        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereRef(@Nonnull Metamodel<TX, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
+        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereRef(@Nonnull Navigable<TX, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
             return new PredicateBuilderImpl<>(core.whereRef(path, it));
         }
 
         @Override
-        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereAnyRef(@Nonnull Metamodel<?, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
+        public <V extends Data> PredicateBuilder<TX, RX, IDX> whereAnyRef(@Nonnull Navigable<?, V> path, @Nonnull Iterable<? extends Ref<V>> it) {
             return new PredicateBuilderImpl<>(core.whereAnyRef(path, it));
         }
 
         @Override
-        public <V> PredicateBuilder<TX, RX, IDX> where(@Nonnull Metamodel<TX, V> path, @Nonnull Operator operator, @Nonnull Iterable<? extends V> it) {
+        public <V> PredicateBuilder<TX, RX, IDX> where(@Nonnull Navigable<TX, V> path, @Nonnull Operator operator, @Nonnull Iterable<? extends V> it) {
             return new PredicateBuilderImpl<>(core.where(path, operator, it));
         }
 
         @Override
-        public <V> PredicateBuilder<TX, RX, IDX> whereAny(@Nonnull Metamodel<?, V> path, @Nonnull Operator operator, @Nonnull Iterable<? extends V> it) {
+        public <V> PredicateBuilder<TX, RX, IDX> whereAny(@Nonnull Navigable<?, V> path, @Nonnull Operator operator, @Nonnull Iterable<? extends V> it) {
             return new PredicateBuilderImpl<>(core.whereAny(path, operator, it));
         }
 
@@ -556,7 +555,7 @@ public final class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<
         }
 
         @Override
-        protected <V> PredicateBuilder<TX, RX, IDX> whereImpl(@Nonnull Metamodel<?, V> path, @Nonnull Operator operator, @Nonnull V[] o) {
+        protected <V> PredicateBuilder<TX, RX, IDX> whereImpl(@Nonnull Navigable<?, V> path, @Nonnull Operator operator, @Nonnull V[] o) {
             return new PredicateBuilderImpl<>(core.whereAny(path, operator, o));
         }
     }

--- a/storm-java21/src/test/java/st/orm/template/QueryBuilderTest.java
+++ b/storm-java21/src/test/java/st/orm/template/QueryBuilderTest.java
@@ -19,6 +19,9 @@ import static st.orm.Operator.LIKE;
 import static st.orm.Operator.NOT_EQUALS;
 import static st.orm.Operator.NOT_IN;
 import static st.orm.Operator.NOT_LIKE;
+import static st.orm.ResolveScope.INNER;
+import static st.orm.ResolveScope.OUTER;
+import static st.orm.template.Templates.column;
 
 import java.util.List;
 import java.util.Optional;
@@ -45,6 +48,7 @@ import st.orm.template.model.Pet;
 import st.orm.template.model.PetType;
 import st.orm.template.model.Pet_;
 import st.orm.template.model.Visit;
+import st.orm.template.model.Visit_;
 
 @SuppressWarnings("ALL")
 @ExtendWith(SpringExtension.class)
@@ -568,6 +572,53 @@ public class QueryBuilderTest {
                 .havingAny(Owner_.lastName, IN, "Davis", "Franklin")
                 .getResultList();
         assertEquals(2, result.size());
+    }
+
+    // Correlated subqueries
+
+    @Test
+    public void testCorrelatedExistsResolvesTheOuterColumn() {
+        // Pets that have at least one visit. INNER resolves Visit_.pet from the subquery, OUTER resolves Pet_.id
+        // from the enclosing query.
+        List<Pet> viaLambda = orm.entity(Pet.class).select()
+                .where(wb -> wb.exists(wb.subquery(Visit.class)
+                        .where(RAW."\{column(Visit_.pet, INNER)} = \{column(Pet_.id, OUTER)}")))
+                .getResultList();
+        assertFalse(viaLambda.isEmpty());
+        // data.sql: pet 13 has no visit, so the correlation must exclude at least one pet.
+        assertTrue(viaLambda.size() < orm.entity(Pet.class).count());
+    }
+
+    @Test
+    public void testCorrelatedExistsFromASubqueryBuiltOnTheTemplate() {
+        // The subquery factory is the query template's, so a subquery built from the ORM template correlates the same
+        // way as one built inside the where lambda.
+        List<Pet> viaLambda = orm.entity(Pet.class).select()
+                .where(wb -> wb.exists(wb.subquery(Visit.class)
+                        .where(RAW."\{column(Visit_.pet, INNER)} = \{column(Pet_.id, OUTER)}")))
+                .getResultList();
+        List<Pet> viaTemplate = orm.entity(Pet.class).select()
+                .whereExists(orm.subquery(Visit.class)
+                        .where(RAW."\{column(Visit_.pet, INNER)} = \{column(Pet_.id, OUTER)}"))
+                .getResultList();
+        assertFalse(viaTemplate.isEmpty());
+        assertEquals(viaLambda, viaTemplate);
+    }
+
+    @Test
+    public void testCorrelatedHavingExistsFiltersGroups() {
+        // The same correlation drives a HAVING clause: keep the per-pet groups that have a visit.
+        List<Pet> withVisits = orm.entity(Pet.class).select()
+                .whereExists(orm.subquery(Visit.class)
+                        .where(RAW."\{column(Visit_.pet, INNER)} = \{column(Pet_.id, OUTER)}"))
+                .getResultList();
+        List<Long> groups = orm.entity(Pet.class).selectCount()
+                .groupBy(Pet_.id)
+                .havingExists(orm.subquery(Visit.class)
+                        .where(RAW."\{column(Visit_.pet, INNER)} = \{column(Pet_.id, OUTER)}"))
+                .getResultList();
+        assertFalse(groups.isEmpty());
+        assertEquals(withVisits.size(), groups.size());
     }
 
     @Test

--- a/storm-java21/src/test/java/st/orm/template/QueryBuilderTest.java
+++ b/storm-java21/src/test/java/st/orm/template/QueryBuilderTest.java
@@ -570,6 +570,17 @@ public class QueryBuilderTest {
         assertEquals(2, result.size());
     }
 
+    @Test
+    public void testHavingWithOrTemplate() {
+        // Java composes a HAVING disjunction with the template form: it has no standalone predicate constructor.
+        List<Long> result = orm.entity(Owner.class).selectCount()
+                .groupBy(Owner_.lastName)
+                .having(RAW."\{Owner_.lastName} = \{"Davis"} OR \{Owner_.lastName} = \{"Franklin"}")
+                .getResultList();
+        assertEquals(2, result.size());
+        assertEquals(3L, result.stream().mapToLong(Long::longValue).sum());
+    }
+
     // PredicateBuilder - andAny / orAny
 
     @Test

--- a/storm-java21/src/test/java/st/orm/template/RefFetchTest.java
+++ b/storm-java21/src/test/java/st/orm/template/RefFetchTest.java
@@ -1,5 +1,6 @@
 package st.orm.template;
 
+import static java.lang.StringTemplate.RAW;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -17,6 +18,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import st.orm.PersistenceException;
+import st.orm.Ref;
+import st.orm.template.model.City;
+import st.orm.template.model.City_;
 import st.orm.template.model.Owner;
 import st.orm.template.model.Pet;
 import st.orm.template.model.PetOwnerRef;
@@ -84,5 +88,40 @@ public class RefFetchTest {
         var exception = assertThrows(PersistenceException.class,
                 () -> orm.selectFrom(PetOwnerRef.class).fetch(PetOwnerRef_.type));
         assertTrue(exception.getMessage().contains("crosses no reference"), exception.getMessage());
+    }
+
+    @Test
+    public void testNavigationOnlyPathNamesAColumnInEveryClause() {
+        // A node beyond a reference is Navigable but not Metamodel. Storm joins the referenced table on demand, so
+        // the path can name a column in WHERE, GROUP BY, HAVING and ORDER BY.
+        List<String> names = orm.selectFrom(PetOwnerRef.class, String.class, RAW."\{PetOwnerRef_.owner.firstName}")
+                .where(PetOwnerRef_.owner.firstName, EQUALS, "Betty")
+                .groupBy(PetOwnerRef_.owner.firstName)
+                .having(PetOwnerRef_.owner.firstName, EQUALS, "Betty")
+                .orderBy(PetOwnerRef_.owner.firstName)
+                .getResultList();
+        assertFalse(names.isEmpty());
+        for (String name : names) {
+            assertEquals("Betty", name);
+        }
+    }
+
+    @Test
+    public void testNavigationOnlyPathMatchesRecordsAndRefs() {
+        // A foreign key reached beyond the reference names its own column, so it can be matched against a record or a
+        // ref the same way a root-typed foreign key can.
+        City city = orm.selectFrom(City.class).where(City_.id, EQUALS, 1).getSingleResult();
+        List<PetOwnerRef> byRecord = orm.selectFrom(PetOwnerRef.class)
+                .where(PetOwnerRef_.owner.address.city, city)
+                .getResultList();
+        List<PetOwnerRef> byRef = orm.selectFrom(PetOwnerRef.class)
+                .where(PetOwnerRef_.owner.address.city, Ref.of(City.class, 1))
+                .getResultList();
+        List<PetOwnerRef> byRefs = orm.selectFrom(PetOwnerRef.class)
+                .whereRef(PetOwnerRef_.owner.address.city, List.of(Ref.of(City.class, 1)))
+                .getResultList();
+        assertFalse(byRecord.isEmpty());
+        assertEquals(byRecord, byRef);
+        assertEquals(byRecord, byRefs);
     }
 }

--- a/storm-kotlin/src/main/kotlin/st/orm/repository/EntityRepository.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/repository/EntityRepository.kt
@@ -19,8 +19,6 @@ import kotlinx.coroutines.flow.Flow
 import st.orm.Data
 import st.orm.Entity
 import st.orm.Metamodel
-import st.orm.Operator.EQUALS
-import st.orm.Operator.IN
 import st.orm.Page
 import st.orm.Pageable
 import st.orm.Ref
@@ -1367,7 +1365,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
      * @param value the value to match against.
      * @return an optional entity, or null if none found.
      */
-    fun <V> findBy(field: Metamodel<E, V>, value: V): E? = select().where(field, EQUALS, value).optionalResult
+    fun <V> findBy(field: Metamodel<E, V>, value: V): E? = select().where(field eq value).optionalResult
 
     /**
      * Retrieves an optional entity of type [E] based on a single field and its value.
@@ -1387,7 +1385,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
      * @param value the value to match against.
      * @return list of matching entities.
      */
-    fun <V> findAllBy(field: Metamodel<E, V>, value: V): List<E> = select().where(field, EQUALS, value).resultList
+    fun <V> findAllBy(field: Metamodel<E, V>, value: V): List<E> = select().where(field eq value).resultList
 
     /**
      * Retrieves entities of type [E] matching a single field and a single value.
@@ -1407,7 +1405,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
      * @param values Iterable of values to match against.
      * @return list of matching entities.
      */
-    fun <V> findAllBy(field: Metamodel<E, V>, values: Iterable<V>): List<E> = select().where(field, IN, values).resultList
+    fun <V> findAllBy(field: Metamodel<E, V>, values: Iterable<V>): List<E> = select().where(field inList values).resultList
 
     /**
      * Retrieves entities of type [E] matching a single field against multiple values.
@@ -1429,7 +1427,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
      * @throws st.orm.NoResultException if there is no result.
      * @throws st.orm.NonUniqueResultException if more than one result.
      */
-    fun <V> getBy(field: Metamodel<E, V>, value: V): E = select().where(field, EQUALS, value).singleResult
+    fun <V> getBy(field: Metamodel<E, V>, value: V): E = select().where(field eq value).singleResult
 
     /**
      * Retrieves exactly one entity of type [E] based on a single field and its value.
@@ -1451,7 +1449,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
      * @param value the value to match against.
      * @return an optional entity, or null if none found.
      */
-    fun <T, ID, V> findRefBy(field: Metamodel<E, V>, value: V): Ref<E>? = selectRef().where(field, EQUALS, value).optionalResult
+    fun <T, ID, V> findRefBy(field: Metamodel<E, V>, value: V): Ref<E>? = selectRef().where(field eq value).optionalResult
 
     /**
      * Retrieves an optional entity of type [E] based on a single field and its value.
@@ -1471,7 +1469,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
      * @param value the value to match against.
      * @return a list of matching entities.
      */
-    fun <V> findAllRefBy(field: Metamodel<E, V>, value: V): List<Ref<E>> = selectRef().where(field, EQUALS, value).resultList
+    fun <V> findAllRefBy(field: Metamodel<E, V>, value: V): List<Ref<E>> = selectRef().where(field eq value).resultList
 
     /**
      * Retrieves entities of type [E] matching a single field and a single value.
@@ -1491,7 +1489,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
      * @param values Iterable of values to match against.
      * @return a list of matching entities.
      */
-    fun <V : Data> findAllRefBy(field: Metamodel<E, V>, values: Iterable<V>): List<Ref<E>> = selectRef().where(field, IN, values).resultList
+    fun <V : Data> findAllRefBy(field: Metamodel<E, V>, values: Iterable<V>): List<Ref<E>> = selectRef().where(field inList values).resultList
 
     /**
      * Retrieves entities of type [E] matching a single field against multiple values.
@@ -1513,7 +1511,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
      * @throws st.orm.NoResultException if there is no result.
      * @throws st.orm.NonUniqueResultException if more than one result.
      */
-    fun <V> getRefBy(field: Metamodel<E, V>, value: V): Ref<E> = selectRef().where(field, EQUALS, value).singleResult
+    fun <V> getRefBy(field: Metamodel<E, V>, value: V): Ref<E> = selectRef().where(field eq value).singleResult
 
     /**
      * Retrieves exactly one entity of type [E] based on a single field and its value.
@@ -1595,7 +1593,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
     fun <V> countBy(
         field: Metamodel<E, V>,
         value: V,
-    ): Long = selectCount().where(field, EQUALS, value).singleResult
+    ): Long = selectCount().where(field eq value).singleResult
 
     /**
      * Counts entities of type [E] matching the specified field and referenced value.
@@ -1629,7 +1627,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
     fun <V> existsBy(
         field: Metamodel<E, V>,
         value: V,
-    ): Boolean = selectCount().where(field, EQUALS, value).singleResult > 0
+    ): Boolean = selectCount().where(field eq value).singleResult > 0
 
     /**
      * Checks if entities of type [E] matching the specified field and referenced value exists.
@@ -1673,7 +1671,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
     fun <V> removeAllBy(
         field: Metamodel<E, V>,
         value: V,
-    ): Int = delete().where(field, EQUALS, value).executeUpdate()
+    ): Int = delete().where(field eq value).executeUpdate()
 
     /**
      * Removes entities of type [E] matching the specified field and referenced value.
@@ -1697,7 +1695,7 @@ interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID> {
     fun <V> removeAllBy(
         field: Metamodel<E, V>,
         values: Iterable<V>,
-    ): Int = delete().where(field, IN, values).executeUpdate()
+    ): Int = delete().where(field inList values).executeUpdate()
 
     /**
      * Removes entities of type [E] matching the specified field against multiple referenced values.

--- a/storm-kotlin/src/main/kotlin/st/orm/repository/ProjectionRepository.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/repository/ProjectionRepository.kt
@@ -17,8 +17,6 @@ package st.orm.repository
 
 import kotlinx.coroutines.flow.Flow
 import st.orm.*
-import st.orm.Operator.EQUALS
-import st.orm.Operator.IN
 import st.orm.template.*
 import kotlin.reflect.KClass
 
@@ -475,7 +473,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
      * @param value the value to match against.
      * @return an optional entity, or null if none found.
      */
-    fun <V> findBy(field: Metamodel<P, V>, value: V): P? = select().where(field, EQUALS, value).optionalResult
+    fun <V> findBy(field: Metamodel<P, V>, value: V): P? = select().where(field eq value).optionalResult
 
     /**
      * Retrieves an optional entity of type [P] based on a single field and its value.
@@ -495,7 +493,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
      * @param value the value to match against.
      * @return list of matching entities.
      */
-    fun <V> findAllBy(field: Metamodel<P, V>, value: V): List<P> = select().where(field, EQUALS, value).resultList
+    fun <V> findAllBy(field: Metamodel<P, V>, value: V): List<P> = select().where(field eq value).resultList
 
     /**
      * Retrieves entities of type [P] matching a single field and a single value.
@@ -515,7 +513,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
      * @param values Iterable of values to match against.
      * @return list of matching entities.
      */
-    fun <V> findAllBy(field: Metamodel<P, V>, values: Iterable<V>): List<P> = select().where(field, IN, values).resultList
+    fun <V> findAllBy(field: Metamodel<P, V>, values: Iterable<V>): List<P> = select().where(field inList values).resultList
 
     /**
      * Retrieves entities of type [P] matching a single field against multiple values.
@@ -537,7 +535,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
      * @throws st.orm.NoResultException if there is no result.
      * @throws st.orm.NonUniqueResultException if more than one result.
      */
-    fun <V> getBy(field: Metamodel<P, V>, value: V): P = select().where(field, EQUALS, value).singleResult
+    fun <V> getBy(field: Metamodel<P, V>, value: V): P = select().where(field eq value).singleResult
 
     /**
      * Retrieves exactly one entity of type [P] based on a single field and its value.
@@ -559,7 +557,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
      * @param value the value to match against.
      * @return an optional entity, or null if none found.
      */
-    fun <T, ID, V> findRefBy(field: Metamodel<P, V>, value: V): Ref<P>? = selectRef().where(field, EQUALS, value).optionalResult
+    fun <T, ID, V> findRefBy(field: Metamodel<P, V>, value: V): Ref<P>? = selectRef().where(field eq value).optionalResult
 
     /**
      * Retrieves an optional entity of type [P] based on a single field and its value.
@@ -579,7 +577,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
      * @param value the value to match against.
      * @return a list of matching entities.
      */
-    fun <V> findAllRefBy(field: Metamodel<P, V>, value: V): List<Ref<P>> = selectRef().where(field, EQUALS, value).resultList
+    fun <V> findAllRefBy(field: Metamodel<P, V>, value: V): List<Ref<P>> = selectRef().where(field eq value).resultList
 
     /**
      * Retrieves entities of type [P] matching a single field and a single value.
@@ -599,7 +597,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
      * @param values Iterable of values to match against.
      * @return a list of matching entities.
      */
-    fun <V : Data> findAllRefBy(field: Metamodel<P, V>, values: Iterable<V>): List<Ref<P>> = selectRef().where(field, IN, values).resultList
+    fun <V : Data> findAllRefBy(field: Metamodel<P, V>, values: Iterable<V>): List<Ref<P>> = selectRef().where(field inList values).resultList
 
     /**
      * Retrieves entities of type [P] matching a single field against multiple values.
@@ -621,7 +619,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
      * @throws st.orm.NoResultException if there is no result.
      * @throws st.orm.NonUniqueResultException if more than one result.
      */
-    fun <V> getRefBy(field: Metamodel<P, V>, value: V): Ref<P> = selectRef().where(field, EQUALS, value).singleResult
+    fun <V> getRefBy(field: Metamodel<P, V>, value: V): Ref<P> = selectRef().where(field eq value).singleResult
 
     /**
      * Retrieves exactly one entity of type [P] based on a single field and its value.
@@ -703,7 +701,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
     fun <V> countBy(
         field: Metamodel<P, V>,
         value: V,
-    ): Long = selectCount().where(field, EQUALS, value).singleResult
+    ): Long = selectCount().where(field eq value).singleResult
 
     /**
      * Counts entities of type [P] matching the specified field and referenced value.
@@ -737,7 +735,7 @@ interface ProjectionRepository<P, ID : Any> : Repository where P : Projection<ID
     fun <V> existsBy(
         field: Metamodel<P, V>,
         value: V,
-    ): Boolean = selectCount().where(field, EQUALS, value).singleResult > 0
+    ): Boolean = selectCount().where(field eq value).singleResult > 0
 
     /**
      * Checks if entities of type [P] matching the specified field and referenced value exists.

--- a/storm-kotlin/src/main/kotlin/st/orm/repository/RepositoryLookup.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/repository/RepositoryLookup.kt
@@ -17,10 +17,10 @@ package st.orm.repository
 
 import kotlinx.coroutines.flow.Flow
 import st.orm.*
-import st.orm.Operator.EQUALS
-import st.orm.Operator.IN
 import st.orm.template.PredicateBuilder
 import st.orm.template.QueryBuilder
+import st.orm.template.eq
+import st.orm.template.inList
 import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 
@@ -251,9 +251,9 @@ inline fun <reified T : Data> RepositoryLookup.findAllRef(): List<Ref<T>> = if (
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.findBy(field: Metamodel<T, V>, value: V): T? = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).select().where(field as Metamodel<Entity<*>, V>, EQUALS, value).optionalResult as T?
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).select().where((field as Metamodel<Entity<*>, V>) eq value).optionalResult as T?
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).select().where(field as Metamodel<Projection<*>, V>, EQUALS, value).optionalResult as T?
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).select().where((field as Metamodel<Projection<*>, V>) eq value).optionalResult as T?
 }
 
 /**
@@ -285,9 +285,9 @@ inline fun <reified T : Data, V : Data> RepositoryLookup.findBy(field: Metamodel
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.findAllBy(field: Metamodel<T, V>, value: V): List<T> = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).select().where(field as Metamodel<Entity<*>, V>, EQUALS, value).resultList as List<T>
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).select().where((field as Metamodel<Entity<*>, V>) eq value).resultList as List<T>
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).select().where(field as Metamodel<Projection<*>, V>, EQUALS, value).resultList as List<T>
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).select().where((field as Metamodel<Projection<*>, V>) eq value).resultList as List<T>
 }
 
 /**
@@ -319,9 +319,9 @@ inline fun <reified T : Data, V : Data> RepositoryLookup.findAllBy(field: Metamo
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.findAllBy(field: Metamodel<T, V>, values: Iterable<V>): List<T> = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).select().where(field as Metamodel<Entity<*>, V>, IN, values).resultList as List<T>
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).select().where((field as Metamodel<Entity<*>, V>) inList values).resultList as List<T>
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).select().where(field as Metamodel<Projection<*>, V>, IN, values).resultList as List<T>
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).select().where((field as Metamodel<Projection<*>, V>) inList values).resultList as List<T>
 }
 
 /**
@@ -355,9 +355,9 @@ inline fun <reified T : Data, V : Data> RepositoryLookup.findAllByRef(field: Met
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.getBy(field: Metamodel<T, V>, value: V): T = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).select().where(field as Metamodel<Entity<*>, V>, EQUALS, value).singleResult as T
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).select().where((field as Metamodel<Entity<*>, V>) eq value).singleResult as T
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).select().where(field as Metamodel<Projection<*>, V>, EQUALS, value).singleResult as T
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).select().where((field as Metamodel<Projection<*>, V>) eq value).singleResult as T
 }
 
 /**
@@ -389,9 +389,9 @@ inline fun <reified T : Data, V : Data> RepositoryLookup.getBy(field: Metamodel<
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.findRefBy(field: Metamodel<T, V>, value: V): Ref<T>? = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectRef().where(field as Metamodel<Entity<*>, V>, EQUALS, value).optionalResult as Ref<T>?
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectRef().where((field as Metamodel<Entity<*>, V>) eq value).optionalResult as Ref<T>?
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectRef().where(field as Metamodel<Projection<*>, V>, EQUALS, value).optionalResult as Ref<T>?
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectRef().where((field as Metamodel<Projection<*>, V>) eq value).optionalResult as Ref<T>?
 }
 
 /**
@@ -419,9 +419,9 @@ inline fun <reified T : Data, V : Data> RepositoryLookup.findRefBy(field: Metamo
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.findAllRefBy(field: Metamodel<T, V>, value: V): List<Ref<T>> = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectRef().where(field as Metamodel<Entity<*>, V>, EQUALS, value).resultList as List<Ref<T>>
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectRef().where((field as Metamodel<Entity<*>, V>) eq value).resultList as List<Ref<T>>
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectRef().where(field as Metamodel<Projection<*>, V>, EQUALS, value).resultList as List<Ref<T>>
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectRef().where((field as Metamodel<Projection<*>, V>) eq value).resultList as List<Ref<T>>
 }
 
 /**
@@ -449,9 +449,9 @@ inline fun <reified T : Data, V : Data> RepositoryLookup.findAllRefBy(field: Met
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.findAllRefBy(field: Metamodel<T, V>, values: Iterable<V>): List<Ref<T>> = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectRef().where(field as Metamodel<Entity<*>, V>, IN, values).resultList as List<Ref<T>>
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectRef().where((field as Metamodel<Entity<*>, V>) inList values).resultList as List<Ref<T>>
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectRef().where(field as Metamodel<Projection<*>, V>, IN, values).resultList as List<Ref<T>>
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectRef().where((field as Metamodel<Projection<*>, V>) inList values).resultList as List<Ref<T>>
 }
 
 /**
@@ -481,9 +481,9 @@ inline fun <reified T : Data, V : Data> RepositoryLookup.findAllRefByRef(field: 
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.getRefBy(field: Metamodel<T, V>, value: V): Ref<T> = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectRef().where(field as Metamodel<Entity<*>, V>, EQUALS, value).singleResult as Ref<T>
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectRef().where((field as Metamodel<Entity<*>, V>) eq value).singleResult as Ref<T>
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectRef().where(field as Metamodel<Projection<*>, V>, EQUALS, value).singleResult as Ref<T>
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectRef().where((field as Metamodel<Projection<*>, V>) eq value).singleResult as Ref<T>
 }
 
 /**
@@ -638,9 +638,9 @@ inline fun <reified T : Data> RepositoryLookup.selectRef(): QueryBuilder<T, Ref<
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.countBy(field: Metamodel<T, V>, value: V): Long = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectCount().where(field as Metamodel<Entity<*>, V>, EQUALS, value).singleResult
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectCount().where((field as Metamodel<Entity<*>, V>) eq value).singleResult
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectCount().where(field as Metamodel<Projection<*>, V>, EQUALS, value).singleResult
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectCount().where((field as Metamodel<Projection<*>, V>) eq value).singleResult
 }
 
 /**
@@ -691,9 +691,9 @@ inline fun <reified T : Data> RepositoryLookup.count(predicate: PredicateBuilder
  */
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : Data, V> RepositoryLookup.existsBy(field: Metamodel<T, V>, value: V): Boolean = if (T::class.isSubclassOf(Entity::class)) {
-    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectCount().where(field as Metamodel<Entity<*>, V>, EQUALS, value).singleResult > 0
+    (entity(T::class as KClass<Entity<Any>>) as EntityRepository<Entity<*>, *>).selectCount().where((field as Metamodel<Entity<*>, V>) eq value).singleResult > 0
 } else {
-    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectCount().where(field as Metamodel<Projection<*>, V>, EQUALS, value).singleResult > 0
+    (projection(T::class as KClass<Projection<Any>>) as ProjectionRepository<Projection<*>, *>).selectCount().where((field as Metamodel<Projection<*>, V>) eq value).singleResult > 0
 }
 
 /**
@@ -879,7 +879,7 @@ inline fun <reified T : Entity<*>> RepositoryLookup.removeAll(predicate: Predica
  * @param value the ID value to match against.
  * @return the number of entities removed (0 or 1).
  */
-inline fun <reified T : Entity<ID>, ID : Any> RepositoryLookup.removeBy(field: Metamodel<T, ID>, value: ID): Int = entity<T>().delete().where(field, EQUALS, value).executeUpdate()
+inline fun <reified T : Entity<ID>, ID : Any> RepositoryLookup.removeBy(field: Metamodel<T, ID>, value: ID): Int = entity<T>().delete().where(field eq value).executeUpdate()
 
 /**
  * Removes entities of type [T] matching the specified ID field and its value.
@@ -897,7 +897,7 @@ inline fun <reified T : Entity<*>> RepositoryLookup.removeBy(field: Metamodel<T,
  * @param value the value to match against.
  * @return the number of entities removed.
  */
-inline fun <reified T : Entity<*>, V> RepositoryLookup.removeAllBy(field: Metamodel<T, V>, value: V): Int = entity<T>().delete().where(field, EQUALS, value).executeUpdate()
+inline fun <reified T : Entity<*>, V> RepositoryLookup.removeAllBy(field: Metamodel<T, V>, value: V): Int = entity<T>().delete().where(field eq value).executeUpdate()
 
 /**
  * Removes entities of type [T] matching the specified field and referenced value.
@@ -915,7 +915,7 @@ inline fun <reified T : Entity<*>, V : Data> RepositoryLookup.removeAllBy(field:
  * @param values Iterable of values to match against.
  * @return the number of entities removed.
  */
-inline fun <reified T : Entity<*>, V> RepositoryLookup.removeAllBy(field: Metamodel<T, V>, values: Iterable<V>): Int = entity<T>().delete().where(field, IN, values).executeUpdate()
+inline fun <reified T : Entity<*>, V> RepositoryLookup.removeAllBy(field: Metamodel<T, V>, values: Iterable<V>): Int = entity<T>().delete().where(field inList values).executeUpdate()
 
 /**
  * Removes entities of type [T] matching the specified field against multiple referenced values.

--- a/storm-kotlin/src/main/kotlin/st/orm/template/PredicateBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/PredicateBuilder.kt
@@ -33,9 +33,9 @@ import st.orm.Data
  *     .select()
  *     .where { predicate ->
  *         predicate
- *             .where(User_.active, EQUALS, true)
- *             .and(predicate.where(User_.email, IS_NOT_NULL))
- *             .or(predicate.where(User_.role, EQUALS, "admin"))
+ *             .where(User_.active eq true)
+ *             .and(predicate.where(User_.email.isNotNull()))
+ *             .or(predicate.where(User_.role eq "admin"))
  *     }
  *     .getResultList()
  * ```

--- a/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
@@ -472,12 +472,6 @@ abstract class QueryBuilder<T : Data, R, ID> {
     fun where(it: Iterable<T>): QueryBuilder<T, R, ID> = whereBuilder { where(it) }
 
     /**
-     * Adds a WHERE clause to the query for the specified expression.
-     *
-     * @param builder the expression.
-     * @return the query builder.
-     */
-    /**
      * Adds a WHERE clause that matches the specified objects at the specified path in the table graph.
      *
      * @param path the path to the object in the table graph.
@@ -511,6 +505,12 @@ abstract class QueryBuilder<T : Data, R, ID> {
         vararg o: V,
     ): QueryBuilder<T, R, ID> = whereBuilder { where(path, operator, *o) }
 
+    /**
+     * Adds a WHERE clause to the query for the specified expression.
+     *
+     * @param builder the expression.
+     * @return the query builder.
+     */
     fun where(builder: TemplateBuilder): QueryBuilder<T, R, ID> = where(builder.build())
 
     /**
@@ -675,13 +675,6 @@ abstract class QueryBuilder<T : Data, R, ID> {
     /**
      * Adds a HAVING clause to the query using the specified expression.
      *
-     * @param builder the expression to add.
-     * @return the query builder.
-     * @since 1.2
-     */
-    /**
-     * Adds a HAVING clause to the query using the specified expression.
-     *
      * @param path the path to the object in the table graph.
      * @param operator the operator to use for the comparison.
      * @param o the object(s) to match, which can be primary keys, records representing the table, or fields in the
@@ -711,6 +704,13 @@ abstract class QueryBuilder<T : Data, R, ID> {
         vararg o: V,
     ): QueryBuilder<T, R, ID> = having(wrap(ObjectExpression(path.asMetamodel(), operator, o)))
 
+    /**
+     * Adds a HAVING clause to the query using the specified expression.
+     *
+     * @param builder the expression to add.
+     * @return the query builder.
+     * @since 1.2
+     */
     fun having(builder: TemplateBuilder): QueryBuilder<T, R, ID> = having(builder.build())
 
     /**

--- a/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
@@ -748,6 +748,24 @@ abstract class QueryBuilder<T : Data, R, ID> {
     abstract fun havingAny(predicate: PredicateBuilder<*, *, *>): QueryBuilder<T, R, ID>
 
     /**
+     * Adds a HAVING clause that keeps the groups for which [subquery] returns at least one row.
+     *
+     * @param subquery the subquery to test for existence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    abstract fun havingExists(subquery: QueryBuilder<*, *, *>): QueryBuilder<T, R, ID>
+
+    /**
+     * Adds a HAVING clause that keeps the groups for which [subquery] returns no rows.
+     *
+     * @param subquery the subquery to test for absence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    abstract fun havingNotExists(subquery: QueryBuilder<*, *, *>): QueryBuilder<T, R, ID>
+
+    /**
      * Adds an ORDER BY clause to the query for the field at the specified path in the table graph.
      *
      * @param path the path to order by.
@@ -1549,6 +1567,16 @@ class SqlScope<T : Data, R, ID : Any> @PublishedApi internal constructor(
     /** Adds a HAVING clause for a predicate on any entity type (e.g., a joined entity). */
     fun havingAny(predicate: PredicateBuilder<*, *, *>) {
         builder = builder.havingAny(predicate)
+    }
+
+    /** Adds a HAVING EXISTS clause with the given subquery. */
+    fun havingExists(subquery: QueryBuilder<*, *, *>) {
+        builder = builder.havingExists(subquery)
+    }
+
+    /** Adds a HAVING NOT EXISTS clause with the given subquery. */
+    fun havingNotExists(subquery: QueryBuilder<*, *, *>) {
+        builder = builder.havingNotExists(subquery)
     }
 
     /** Adds an ORDER BY clause (ascending) for the specified metamodel path(s). */

--- a/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
@@ -45,7 +45,7 @@ import kotlin.reflect.KClass
  * ```kotlin
  * val users = userRepository
  *     .select()
- *     .where(User_.address.city.name, EQUALS, "Sunnyvale")
+ *     .where(User_.address.city.name eq "Sunnyvale")
  *     .orderBy(User_.email)
  *     .limit(10)
  *     .getResultList()
@@ -63,7 +63,7 @@ import kotlin.reflect.KClass
  * ```kotlin
  * val deleted = userRepository
  *     .delete()
- *     .where(User_.email, IS_NULL)
+ *     .where(User_.email.isNull())
  *     .executeUpdate()
  * ```
  *
@@ -75,12 +75,12 @@ import kotlin.reflect.KClass
  * ```kotlin
  * // WRONG - the where clause is lost because the return value is discarded:
  * val builder = userRepository.select()
- * builder.where(User_.active, EQUALS, true)  // returns a new builder, but it's ignored
- * builder.resultList                          // executes without the WHERE clause
+ * builder.where(User_.active eq true)  // returns a new builder, but it's ignored
+ * builder.resultList                   // executes without the WHERE clause
  *
  * // CORRECT - chain the calls or capture the returned builder:
  * val results = userRepository.select()
- *     .where(User_.active, EQUALS, true)
+ *     .where(User_.active eq true)
  *     .resultList
  * ```
  *
@@ -426,7 +426,7 @@ abstract class QueryBuilder<T : Data, R, ID> {
      * @param record the records to match.
      * @return the predicate builder.
      */
-    fun <V : Data> where(path: Metamodel<T, V>, record: V): QueryBuilder<T, R, ID> = where(path, EQUALS, record)
+    fun <V : Data> where(path: Metamodel<T, V>, record: V): QueryBuilder<T, R, ID> = where(path eq record)
 
     /**
      * Adds a WHERE clause that matches the specified ref. The ref can represent any of the related tables in the
@@ -447,7 +447,7 @@ abstract class QueryBuilder<T : Data, R, ID> {
      * @param it the records to match.
      * @return the predicate builder.
      */
-    fun <V : Data> where(path: Navigable<T, V>, it: Iterable<V>): QueryBuilder<T, R, ID> = where(path, IN, it)
+    fun <V : Data> where(path: Navigable<T, V>, it: Iterable<V>): QueryBuilder<T, R, ID> = where(path inList it)
 
     /**
      * Adds a WHERE clause that matches the specified records. The records can represent any of the related tables in
@@ -471,6 +471,12 @@ abstract class QueryBuilder<T : Data, R, ID> {
      */
     fun where(it: Iterable<T>): QueryBuilder<T, R, ID> = whereBuilder { where(it) }
 
+    /**
+     * Adds a WHERE clause to the query for the specified expression.
+     *
+     * @param builder the expression.
+     * @return the query builder.
+     */
     /**
      * Adds a WHERE clause that matches the specified objects at the specified path in the table graph.
      *
@@ -505,12 +511,6 @@ abstract class QueryBuilder<T : Data, R, ID> {
         vararg o: V,
     ): QueryBuilder<T, R, ID> = whereBuilder { where(path, operator, *o) }
 
-    /**
-     * Adds a WHERE clause to the query for the specified expression.
-     *
-     * @param builder the expression.
-     * @return the query builder.
-     */
     fun where(builder: TemplateBuilder): QueryBuilder<T, R, ID> = where(builder.build())
 
     /**
@@ -675,6 +675,13 @@ abstract class QueryBuilder<T : Data, R, ID> {
     /**
      * Adds a HAVING clause to the query using the specified expression.
      *
+     * @param builder the expression to add.
+     * @return the query builder.
+     * @since 1.2
+     */
+    /**
+     * Adds a HAVING clause to the query using the specified expression.
+     *
      * @param path the path to the object in the table graph.
      * @param operator the operator to use for the comparison.
      * @param o the object(s) to match, which can be primary keys, records representing the table, or fields in the
@@ -704,13 +711,6 @@ abstract class QueryBuilder<T : Data, R, ID> {
         vararg o: V,
     ): QueryBuilder<T, R, ID> = having(wrap(ObjectExpression(path.asMetamodel(), operator, o)))
 
-    /**
-     * Adds a HAVING clause to the query using the specified expression.
-     *
-     * @param builder the expression to add.
-     * @return the query builder.
-     * @since 1.2
-     */
     fun having(builder: TemplateBuilder): QueryBuilder<T, R, ID> = having(builder.build())
 
     /**
@@ -722,6 +722,30 @@ abstract class QueryBuilder<T : Data, R, ID> {
      * @since 1.2
      */
     abstract fun having(template: TemplateString): QueryBuilder<T, R, ID>
+
+    /**
+     * Adds a HAVING clause to the query for the specified predicate. Multiple calls to this method are combined using
+     * AND; compose the predicate with the infix `and` and `or` operators to build a single clause that mixes both.
+     *
+     * The predicate is taken directly rather than through a [WhereBuilder]. A HAVING clause filters groups rather than
+     * rows, so the builder's identity matching would not carry over, and its methods would read `where` at a `having`
+     * call site.
+     *
+     * @param predicate the predicate to add.
+     * @return the query builder.
+     * @since 1.13
+     */
+    abstract fun having(predicate: PredicateBuilder<T, *, *>): QueryBuilder<T, R, ID>
+
+    /**
+     * Adds a HAVING clause to the query for the specified predicate. The predicate may refer to any entity in the table
+     * graph, including manually added joins.
+     *
+     * @param predicate the predicate to add.
+     * @return the query builder.
+     * @since 1.13
+     */
+    abstract fun havingAny(predicate: PredicateBuilder<*, *, *>): QueryBuilder<T, R, ID>
 
     /**
      * Adds an ORDER BY clause to the query for the field at the specified path in the table graph.
@@ -1260,12 +1284,6 @@ abstract class QueryBuilder<T : Data, R, ID> {
 // Kotlin specific DSL
 
 /**
- * Resolves a navigable to a value metamodel. Full metamodels are returned as-is; a navigation-only node (one that
- * navigates beyond a Ref) is rebuilt into a resolvable, query-only metamodel for its path so it can locate a column.
- */
-fun <T : Data, V> Navigable<T, V>.asMetamodel(): Metamodel<T, V> = if (this is Metamodel<T, V>) this else Metamodel.of(root(), fieldPath())
-
-/**
  * Infix function to create a predicate to check if a field is in a list of values.
  */
 infix fun <T : Data, V> Navigable<T, V>.inList(value: Iterable<V>): PredicateBuilder<T, T, *> = create(this.asMetamodel(), IN, value)
@@ -1388,12 +1406,12 @@ class SqlScope<T : Data, R, ID : Any> @PublishedApi internal constructor(
         builder = builder.where(predicate)
     }
 
+    /** Adds a WHERE clause matching a metamodel path to a data record. */
     /** Adds a WHERE clause matching a metamodel path to value(s) using an [Operator]. */
     fun <V> where(path: Navigable<T, V>, operator: Operator, vararg value: V) {
         builder = builder.where(path, operator, *value)
     }
 
-    /** Adds a WHERE clause matching a metamodel path to a data record. */
     fun <V : Data> where(path: Metamodel<T, V>, record: V) {
         builder = builder.where(path, record)
     }
@@ -1443,6 +1461,21 @@ class SqlScope<T : Data, R, ID : Any> @PublishedApi internal constructor(
         builder = builder.whereNotExists(subquery)
     }
 
+    /** Adds a WHERE EXISTS clause for the subquery built by [subquery]. */
+    fun whereExists(subquery: SubqueryTemplate.() -> QueryBuilder<*, *, *>) {
+        builder = builder.whereExists(subquery)
+    }
+
+    /** Adds a WHERE NOT EXISTS clause for the subquery built by [subquery]. */
+    fun whereNotExists(subquery: SubqueryTemplate.() -> QueryBuilder<*, *, *>) {
+        builder = builder.whereNotExists(subquery)
+    }
+
+    /** Adds a WHERE clause using a [WhereBuilder], for a predicate on any entity type (e.g., a joined entity). */
+    fun whereAnyBuilder(predicate: WhereBuilder<T, R, ID>.() -> PredicateBuilder<*, *, *>) {
+        builder = builder.whereAnyBuilder(predicate)
+    }
+
     /** Adds an INNER JOIN with automatic ON resolution between [relation] and [on]. */
     fun innerJoin(relation: KClass<out Data>, on: KClass<out Data>) {
         builder = builder.innerJoin(relation).on(on)
@@ -1488,9 +1521,19 @@ class SqlScope<T : Data, R, ID : Any> @PublishedApi internal constructor(
         builder = builder.groupBy(*path)
     }
 
+    /** Adds a GROUP BY clause for path(s) on any entity type (e.g., a joined entity). */
+    fun groupByAny(vararg path: Navigable<*, *>) {
+        builder = builder.groupByAny(*path)
+    }
+
     /** Adds a GROUP BY clause using a SQL template expression. */
     fun groupBy(template: TemplateBuilder) {
         builder = builder.groupBy(template)
+    }
+
+    /** Adds a HAVING clause for the specified predicate. */
+    fun having(predicate: PredicateBuilder<T, *, *>) {
+        builder = builder.having(predicate)
     }
 
     /** Adds a HAVING clause matching a metamodel path to value(s) using an [Operator]. */
@@ -1501,6 +1544,11 @@ class SqlScope<T : Data, R, ID : Any> @PublishedApi internal constructor(
     /** Adds a HAVING clause using a SQL template expression (e.g., `having { "COUNT(*) > ${t(5)}" }`). */
     fun having(template: TemplateBuilder) {
         builder = builder.having(template)
+    }
+
+    /** Adds a HAVING clause for a predicate on any entity type (e.g., a joined entity). */
+    fun havingAny(predicate: PredicateBuilder<*, *, *>) {
+        builder = builder.havingAny(predicate)
     }
 
     /** Adds an ORDER BY clause (ascending) for the specified metamodel path(s). */

--- a/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
@@ -766,6 +766,35 @@ abstract class QueryBuilder<T : Data, R, ID> {
     abstract fun havingNotExists(subquery: QueryBuilder<*, *, *>): QueryBuilder<T, R, ID>
 
     /**
+     * Adds a HAVING clause that keeps the groups for which the subquery built by [builder] returns at least one row.
+     *
+     * @param builder builds the subquery to test for existence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    fun havingExists(builder: SubqueryTemplate.() -> QueryBuilder<*, *, *>): QueryBuilder<T, R, ID> = havingExists(builder(subqueryTemplate()))
+
+    /**
+     * Adds a HAVING clause that keeps the groups for which the subquery built by [builder] returns no rows.
+     *
+     * @param builder builds the subquery to test for absence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    fun havingNotExists(builder: SubqueryTemplate.() -> QueryBuilder<*, *, *>): QueryBuilder<T, R, ID> = havingNotExists(builder(subqueryTemplate()))
+
+    /**
+     * Returns the factory this query builds its subqueries with.
+     *
+     * The factory belongs to the query rather than to a clause: a subquery correlates through how it is embedded, not
+     * through where it was created, so a clause that takes a subquery can obtain one here without a [WhereBuilder].
+     *
+     * @return the subquery factory for this query.
+     * @since 1.13
+     */
+    abstract fun subqueryTemplate(): SubqueryTemplate
+
+    /**
      * Adds an ORDER BY clause to the query for the field at the specified path in the table graph.
      *
      * @param path the path to order by.
@@ -1576,6 +1605,16 @@ class SqlScope<T : Data, R, ID : Any> @PublishedApi internal constructor(
 
     /** Adds a HAVING NOT EXISTS clause with the given subquery. */
     fun havingNotExists(subquery: QueryBuilder<*, *, *>) {
+        builder = builder.havingNotExists(subquery)
+    }
+
+    /** Adds a HAVING EXISTS clause for the subquery built by [subquery]. */
+    fun havingExists(subquery: SubqueryTemplate.() -> QueryBuilder<*, *, *>) {
+        builder = builder.havingExists(subquery)
+    }
+
+    /** Adds a HAVING NOT EXISTS clause for the subquery built by [subquery]. */
+    fun havingNotExists(subquery: SubqueryTemplate.() -> QueryBuilder<*, *, *>) {
         builder = builder.havingNotExists(subquery)
     }
 

--- a/storm-kotlin/src/main/kotlin/st/orm/template/QueryTemplate.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/QueryTemplate.kt
@@ -37,7 +37,7 @@ import kotlin.reflect.KClass
  * ## Example: Query with QueryBuilder
  * ```kotlin
  * val users = orm.selectFrom(User::class)
- *     .where(User_.name, EQUALS, "Alice")
+ *     .where(User_.name eq "Alice")
  *     .getResultList()
  * ```
  *

--- a/storm-kotlin/src/main/kotlin/st/orm/template/WhereBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/WhereBuilder.kt
@@ -38,8 +38,8 @@ import st.orm.template.TemplateString.Companion.raw
  *     .select()
  *     .where { predicate ->
  *         predicate
- *             .where(User_.active, EQUALS, true)
- *             .and(predicate.where(User_.address.city.name, EQUALS, "Sunnyvale"))
+ *             .where(User_.active eq true)
+ *             .and(predicate.where(User_.address.city.name eq "Sunnyvale"))
  *     }
  *     .getResultList()
  * ```

--- a/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
@@ -468,6 +468,16 @@ class QueryBuilderImpl<T : Data, R, ID>(
     override fun havingNotExists(subquery: QueryBuilder<*, *, *>): QueryBuilder<T, R, ID> = QueryBuilderImpl(core.havingNotExists((subquery as QueryBuilderImpl<*, *, *>).core))
 
     /**
+     * Returns the factory this query builds its subqueries with.
+     *
+     * @return the subquery factory for this query.
+     * @since 1.13
+     */
+    override fun subqueryTemplate(): SubqueryTemplate = object : SubqueryTemplate {
+        override fun <X : Data> subquery(fromType: KClass<X>, template: TemplateString): QueryBuilder<X, *, *> = QueryBuilderImpl(core.subqueryTemplate().subquery(fromType.java, template.unwrap))
+    }
+
+    /**
      * Adds a LIMIT clause to the query.
      *
      * @param limit the maximum number of records to return.

--- a/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
@@ -450,6 +450,24 @@ class QueryBuilderImpl<T : Data, R, ID>(
     override fun havingAny(predicate: PredicateBuilder<*, *, *>): QueryBuilder<T, R, ID> = QueryBuilderImpl(core.havingAny((predicate as PredicateBuilderImpl<*, *, *>).core))
 
     /**
+     * Adds a HAVING clause that keeps the groups for which [subquery] returns at least one row.
+     *
+     * @param subquery the subquery to test for existence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    override fun havingExists(subquery: QueryBuilder<*, *, *>): QueryBuilder<T, R, ID> = QueryBuilderImpl(core.havingExists((subquery as QueryBuilderImpl<*, *, *>).core))
+
+    /**
+     * Adds a HAVING clause that keeps the groups for which [subquery] returns no rows.
+     *
+     * @param subquery the subquery to test for absence.
+     * @return the query builder.
+     * @since 1.13
+     */
+    override fun havingNotExists(subquery: QueryBuilder<*, *, *>): QueryBuilder<T, R, ID> = QueryBuilderImpl(core.havingNotExists((subquery as QueryBuilderImpl<*, *, *>).core))
+
+    /**
      * Adds a LIMIT clause to the query.
      *
      * @param limit the maximum number of records to return.

--- a/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
@@ -432,6 +432,24 @@ class QueryBuilderImpl<T : Data, R, ID>(
     )
 
     /**
+     * Adds a HAVING clause to the query for the specified predicate.
+     *
+     * @param predicate the predicate to add.
+     * @return the query builder.
+     * @since 1.13
+     */
+    override fun having(predicate: PredicateBuilder<T, *, *>): QueryBuilder<T, R, ID> = QueryBuilderImpl(core.having((predicate as PredicateBuilderImpl<T, *, *>).core))
+
+    /**
+     * Adds a HAVING clause to the query for the specified predicate.
+     *
+     * @param predicate the predicate to add.
+     * @return the query builder.
+     * @since 1.13
+     */
+    override fun havingAny(predicate: PredicateBuilder<*, *, *>): QueryBuilder<T, R, ID> = QueryBuilderImpl(core.havingAny((predicate as PredicateBuilderImpl<*, *, *>).core))
+
+    /**
      * Adds a LIMIT clause to the query.
      *
      * @param limit the maximum number of records to return.

--- a/storm-kotlin/src/test/kotlin/st/orm/template/EntityRepositoryTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/EntityRepositoryTest.kt
@@ -17,8 +17,6 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import st.orm.*
-import st.orm.Operator.EQUALS
-import st.orm.Operator.IN
 import st.orm.repository.*
 import st.orm.template.model.*
 
@@ -833,7 +831,7 @@ open class EntityRepositoryTest(
     fun `findAllRefBy with field and iterable values should return refs`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val refs = repo.selectRef().where(namePath, IN, listOf("Madison", "Windsor")).resultList
+        val refs = repo.selectRef().where(namePath inList listOf("Madison", "Windsor")).resultList
         refs shouldHaveSize 2
     }
 
@@ -1042,7 +1040,7 @@ open class EntityRepositoryTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val cities = repo.select().whereAnyBuilder {
-            where(namePath, EQUALS, "Madison") or where(namePath, EQUALS, "Windsor")
+            (namePath eq "Madison") or (namePath eq "Windsor")
         }.resultList
         cities shouldHaveSize 2
     }
@@ -1055,8 +1053,8 @@ open class EntityRepositoryTest(
         val firstNamePath = metamodel<Owner, String>(repo.model, "first_name")
         val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
         val result = repo.select().whereBuilder {
-            where(lastNamePath, EQUALS, "Davis") andAny (
-                where(firstNamePath, EQUALS, "Betty") or where(firstNamePath, EQUALS, "Harold")
+            (lastNamePath eq "Davis") andAny (
+                (firstNamePath eq "Betty") or (firstNamePath eq "Harold")
                 )
         }.resultList
         result shouldHaveSize 2
@@ -1067,9 +1065,9 @@ open class EntityRepositoryTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val result = repo.select().whereAnyBuilder {
-            where(namePath, EQUALS, "Madison") or
-                where(namePath, EQUALS, "Windsor") or
-                where(namePath, EQUALS, "Monona")
+            (namePath eq "Madison") or
+                (namePath eq "Windsor") or
+                (namePath eq "Monona")
         }.resultList
         result shouldHaveSize 3
     }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/ORMTemplateTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/ORMTemplateTest.kt
@@ -17,8 +17,6 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import st.orm.*
-import st.orm.Operator.EQUALS
-import st.orm.Operator.IN
 import st.orm.repository.*
 import st.orm.template.model.*
 import javax.sql.DataSource
@@ -944,7 +942,7 @@ open class ORMTemplateTest(
     fun `orm deleteBy reified entity should delete matching`() {
         val repo = orm.entity(Vet::class)
         val firstNamePath = metamodel<Vet, String>(repo.model, "first_name")
-        val deleted = repo.delete().where(firstNamePath, EQUALS, "James").executeUpdate()
+        val deleted = repo.delete().where(firstNamePath eq "James").executeUpdate()
         deleted shouldBe 1
     }
 
@@ -1550,7 +1548,7 @@ open class ORMTemplateTest(
         val namePath = metamodel<City, String>(repo.model, "name")
         val idPath = metamodel<City, Int>(repo.model, "id")
         val cities = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") andAny where(idPath, EQUALS, 2)
+            (namePath eq "Madison") andAny (idPath eq 2)
         }.resultList
         cities shouldHaveSize 1
     }
@@ -1561,7 +1559,7 @@ open class ORMTemplateTest(
         val namePath = metamodel<City, String>(repo.model, "name")
         val idPath = metamodel<City, Int>(repo.model, "id")
         val cities = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") orAny where(idPath, EQUALS, 1)
+            (namePath eq "Madison") orAny (idPath eq 1)
         }.resultList
         cities shouldHaveSize 2
     }
@@ -1571,7 +1569,7 @@ open class ORMTemplateTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val cities = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") and { "${t(Templates.alias(City::class))}.id = ${t(2)}" }
+            (namePath eq "Madison") and { "${t(Templates.alias(City::class))}.id = ${t(2)}" }
         }.resultList
         cities shouldHaveSize 1
     }
@@ -1581,7 +1579,7 @@ open class ORMTemplateTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val cities = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") or { "${t(Templates.alias(City::class))}.id = ${t(1)}" }
+            (namePath eq "Madison") or { "${t(Templates.alias(City::class))}.id = ${t(1)}" }
         }.resultList
         cities shouldHaveSize 2
     }
@@ -1628,7 +1626,7 @@ open class ORMTemplateTest(
     fun `whereBuilder whereAny with metamodel path operator and iterable should filter correctly`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val cities = repo.select().whereBuilder { whereAny(namePath, IN, listOf("Madison", "Windsor")) }.resultList
+        val cities = repo.select().whereBuilder { (namePath inList listOf("Madison", "Windsor")) }.resultList
         cities shouldHaveSize 2
     }
 
@@ -1636,7 +1634,7 @@ open class ORMTemplateTest(
     fun `whereBuilder whereAny with metamodel path operator and vararg should filter correctly`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val cities = repo.select().whereBuilder { whereAny(namePath, IN, "Madison", "Windsor") }.resultList
+        val cities = repo.select().whereBuilder { (namePath inList listOf("Madison", "Windsor")) }.resultList
         cities shouldHaveSize 2
     }
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/PolymorphicTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/PolymorphicTest.kt
@@ -873,7 +873,7 @@ open class PolymorphicTest(
     fun `select nodsc animal by name using MetamodelFactory`() {
         val animals = orm.entity(NodscAnimal::class)
         val name = Metamodel.of<NodscAnimal, String>(NodscAnimal::class.java, "name")
-        val result = animals.select().where(name, EQUALS, "Whiskers").resultList
+        val result = animals.select().where(name eq "Whiskers").resultList
         result shouldHaveSize 1
         result[0].shouldBeInstanceOf<NodscCat>()
         (result[0] as NodscCat).name shouldBe "Whiskers"
@@ -883,7 +883,7 @@ open class PolymorphicTest(
     fun `select nodsc animal by id using MetamodelFactory`() {
         val animals = orm.entity(NodscAnimal::class)
         val id = Metamodel.of<NodscAnimal, Int>(NodscAnimal::class.java, "id")
-        val result = animals.select().where(id, EQUALS, 4).resultList
+        val result = animals.select().where(id eq 4).resultList
         result shouldHaveSize 1
         result[0].shouldBeInstanceOf<NodscBird>()
         (result[0] as NodscBird).name shouldBe "Tweety"
@@ -893,7 +893,7 @@ open class PolymorphicTest(
     fun `select nodsc animal by name like using MetamodelFactory`() {
         val animals = orm.entity(NodscAnimal::class)
         val name = Metamodel.of<NodscAnimal, String>(NodscAnimal::class.java, "name")
-        val result = animals.select().where(name, LIKE, "%e%").resultList
+        val result = animals.select().where(name like "%e%").resultList
         result shouldHaveSize 3
         result[0].shouldBeInstanceOf<NodscCat>()
         result[1].shouldBeInstanceOf<NodscDog>()
@@ -904,7 +904,7 @@ open class PolymorphicTest(
     fun `select nodsc animal by name in using MetamodelFactory`() {
         val animals = orm.entity(NodscAnimal::class)
         val name = Metamodel.of<NodscAnimal, String>(NodscAnimal::class.java, "name")
-        val result = animals.select().where(name, IN, listOf("Luna", "Tweety")).resultList
+        val result = animals.select().where(name inList listOf("Luna", "Tweety")).resultList
         result shouldHaveSize 2
         result[0].shouldBeInstanceOf<NodscCat>()
         result[1].shouldBeInstanceOf<NodscBird>()
@@ -914,7 +914,7 @@ open class PolymorphicTest(
     fun `count nodsc animal by name using MetamodelFactory`() {
         val animals = orm.entity(NodscAnimal::class)
         val name = Metamodel.of<NodscAnimal, String>(NodscAnimal::class.java, "name")
-        animals.select().where(name, EQUALS, "Rex").resultCount shouldBe 1
+        animals.select().where(name eq "Rex").resultCount shouldBe 1
     }
 
     // Animal MetamodelFactory Tests (single table with @Discriminator)
@@ -923,7 +923,7 @@ open class PolymorphicTest(
     fun `select animal by name using MetamodelFactory`() {
         val animals = orm.entity(Animal::class)
         val name = Metamodel.of<Animal, String>(Animal::class.java, "name")
-        val result = animals.select().where(name, EQUALS, "Whiskers").resultList
+        val result = animals.select().where(name eq "Whiskers").resultList
         result shouldHaveSize 1
         result[0].shouldBeInstanceOf<Cat>()
         (result[0] as Cat).name shouldBe "Whiskers"
@@ -933,7 +933,7 @@ open class PolymorphicTest(
     fun `select animal by id using MetamodelFactory`() {
         val animals = orm.entity(Animal::class)
         val id = Metamodel.of<Animal, Int>(Animal::class.java, "id")
-        val result = animals.select().where(id, EQUALS, 3).resultList
+        val result = animals.select().where(id eq 3).resultList
         result shouldHaveSize 1
         result[0].shouldBeInstanceOf<Dog>()
         (result[0] as Dog).name shouldBe "Rex"

--- a/storm-kotlin/src/test/kotlin/st/orm/template/ProjectionRepositoryTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/ProjectionRepositoryTest.kt
@@ -1595,7 +1595,7 @@ open class ProjectionRepositoryTest(
     fun `selectRef with IN operator and string values should return refs`() {
         val repo = orm.projection(OwnerView::class)
         val firstNamePath = metamodel<OwnerView, String>(repo.model, "first_name")
-        val refs = repo.selectRef().where(firstNamePath, IN, listOf("Betty", "Eduardo")).resultList
+        val refs = repo.selectRef().where(firstNamePath inList listOf("Betty", "Eduardo")).resultList
         refs shouldHaveSize 2
     }
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
@@ -67,7 +67,7 @@ open class QueryBuilderTest(
         // data.sql: Only one city has name 'Madison' (id=2).
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val cities = repo.select().where(namePath, EQUALS, "Madison").resultList
+        val cities = repo.select().where(namePath eq "Madison").resultList
         cities shouldHaveSize 1
         cities[0].name shouldBe "Madison"
     }
@@ -77,7 +77,7 @@ open class QueryBuilderTest(
         // data.sql: 'Madison' (id=2) and 'Windsor' (id=4) are both present.
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val cities = repo.select().where(namePath, IN, listOf("Madison", "Windsor")).resultList
+        val cities = repo.select().where(namePath inList listOf("Madison", "Windsor")).resultList
         cities shouldHaveSize 2
     }
 
@@ -368,7 +368,7 @@ open class QueryBuilderTest(
         val firstNamePath = metamodel<Owner, String>(repo.model, "first_name")
         val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
         val result = repo.select().whereBuilder {
-            where(firstNamePath, EQUALS, "Harold") and where(lastNamePath, EQUALS, "Davis")
+            (firstNamePath eq "Harold") and (lastNamePath eq "Davis")
         }.resultList
         result shouldHaveSize 1
         result[0].firstName shouldBe "Harold"
@@ -381,7 +381,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val result = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") or where(namePath, EQUALS, "Windsor")
+            (namePath eq "Madison") or (namePath eq "Windsor")
         }.resultList
         result shouldHaveSize 2
     }
@@ -407,8 +407,8 @@ open class QueryBuilderTest(
         val firstNamePath = metamodel<Owner, String>(repo.model, "first_name")
         val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
         val result = repo.select().whereBuilder {
-            (where(firstNamePath, EQUALS, "Betty") and where(lastNamePath, EQUALS, "Davis")) or
-                (where(firstNamePath, EQUALS, "George") and where(lastNamePath, EQUALS, "Franklin"))
+            ((firstNamePath eq "Betty") and (lastNamePath eq "Davis")) or
+                ((firstNamePath eq "George") and (lastNamePath eq "Franklin"))
         }.resultList
         result shouldHaveSize 2
     }
@@ -665,7 +665,7 @@ open class QueryBuilderTest(
     fun `where with NOT_EQUALS operator should exclude matching entity`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val result = repo.select().where(namePath, NOT_EQUALS, "Madison").resultList
+        val result = repo.select().where(namePath neq "Madison").resultList
         result shouldHaveSize 5
     }
 
@@ -674,7 +674,7 @@ open class QueryBuilderTest(
         // data.sql: Cities containing 'on': Madison, Monona (2 of 6).
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val result = repo.select().where(namePath, LIKE, "%on%").resultList
+        val result = repo.select().where(namePath like "%on%").resultList
         result shouldHaveSize 2
     }
 
@@ -731,7 +731,7 @@ open class QueryBuilderTest(
     fun `where with NOT_IN and empty list should return all results`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val result = repo.select().where(namePath, NOT_IN, emptyList<String>()).resultList
+        val result = repo.select().where(namePath notInList emptyList<String>()).resultList
         result shouldHaveSize 6
     }
 
@@ -1262,7 +1262,7 @@ open class QueryBuilderTest(
         val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
         // Use andAny to combine a predicate with another typed predicate.
         val result = repo.select().whereBuilder {
-            where(firstNamePath, EQUALS, "Betty") andAny where(lastNamePath, EQUALS, "Davis")
+            (firstNamePath eq "Betty") andAny (lastNamePath eq "Davis")
         }.resultList
         result shouldHaveSize 1
         result[0].firstName shouldBe "Betty"
@@ -1273,7 +1273,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val result = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") orAny where(namePath, EQUALS, "Windsor")
+            (namePath eq "Madison") orAny (namePath eq "Windsor")
         }.resultList
         result shouldHaveSize 2
     }
@@ -1283,7 +1283,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val result = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") and { "${t(Templates.column(metamodel<City, Int>(repo.model, "id")))} = ${t(2)}" }
+            (namePath eq "Madison") and { "${t(Templates.column(metamodel<City, Int>(repo.model, "id")))} = ${t(2)}" }
         }.resultList
         result shouldHaveSize 1
         result[0].name shouldBe "Madison"
@@ -1295,7 +1295,7 @@ open class QueryBuilderTest(
         val namePath = metamodel<City, String>(repo.model, "name")
         val templateString = TemplateString.raw { "${t(Templates.column(metamodel<City, Int>(repo.model, "id")))} = ${t(2)}" }
         val result = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") and templateString
+            (namePath eq "Madison") and templateString
         }.resultList
         result shouldHaveSize 1
         result[0].name shouldBe "Madison"
@@ -1306,7 +1306,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val result = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") or { "${t(Templates.column(namePath))} = ${t("Windsor")}" }
+            (namePath eq "Madison") or { "${t(Templates.column(namePath))} = ${t("Windsor")}" }
         }.resultList
         result shouldHaveSize 2
     }
@@ -1317,7 +1317,7 @@ open class QueryBuilderTest(
         val namePath = metamodel<City, String>(repo.model, "name")
         val templateString = TemplateString.raw { "${t(Templates.column(namePath))} = ${t("Windsor")}" }
         val result = repo.select().whereBuilder {
-            where(namePath, EQUALS, "Madison") or templateString
+            (namePath eq "Madison") or templateString
         }.resultList
         result shouldHaveSize 2
     }
@@ -1414,7 +1414,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val result = repo.select().whereAnyBuilder {
-            where(namePath, EQUALS, "Madison")
+            (namePath eq "Madison")
         }.resultList
         result shouldHaveSize 1
     }
@@ -1439,10 +1439,10 @@ open class QueryBuilderTest(
 
     @Test
     fun `where with path operator and iterable should filter`() {
-        // Use the where(path, IN, Iterable) overload
+        // Use the where(path inList Iterable) overload
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val result = repo.select().where(namePath, IN, listOf("Madison", "Windsor")).resultList
+        val result = repo.select().where(namePath inList listOf("Madison", "Windsor")).resultList
         result shouldHaveSize 2
     }
 
@@ -1575,7 +1575,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val result = repo.select().whereBuilder {
-            whereAny(namePath, EQUALS, "Madison")
+            (namePath eq "Madison")
         }.resultList
         result shouldHaveSize 1
     }
@@ -1585,7 +1585,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         val result = repo.select().whereBuilder {
-            whereAny(namePath, IN, listOf("Madison", "Windsor"))
+            (namePath inList listOf("Madison", "Windsor"))
         }.resultList
         result shouldHaveSize 2
     }
@@ -1620,7 +1620,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val city = City(id = 2, name = "Madison")
         val idPath = metamodel<City, City>(repo.model, "id")
-        // This tests the whereAny(path, EQUALS, record) default method.
+        // This tests the whereAny(path eq record) default method.
         val result = repo.select().whereBuilder {
             @Suppress("UNCHECKED_CAST")
             whereAny(idPath as Metamodel<*, City>, city)
@@ -1709,7 +1709,7 @@ open class QueryBuilderTest(
     fun `forUpdate with where clause should lock and return matching entity`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val cities = repo.select().where(namePath, EQUALS, "Windsor").forUpdate().resultList
+        val cities = repo.select().where(namePath eq "Windsor").forUpdate().resultList
         cities shouldHaveSize 1
         cities[0].id shouldBe 4
     }
@@ -1905,7 +1905,7 @@ open class QueryBuilderTest(
     fun `where with metamodel and IN operator and varargs should filter entities`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val cities = repo.select().where(namePath, IN, "Madison", "Windsor").resultList
+        val cities = repo.select().where(namePath inList listOf("Madison", "Windsor")).resultList
         cities shouldHaveSize 2
     }
 
@@ -1956,7 +1956,7 @@ open class QueryBuilderTest(
     fun `resultCount with where should return filtered count`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val count = repo.select().where(namePath, EQUALS, "Madison").resultCount
+        val count = repo.select().where(namePath eq "Madison").resultCount
         count shouldBe 1L
     }
 
@@ -2073,7 +2073,7 @@ open class QueryBuilderTest(
     fun `singleResult with metamodel path should return entity when exactly one match`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val city = repo.select().where(namePath, EQUALS, "Madison").singleResult
+        val city = repo.select().where(namePath eq "Madison").singleResult
         city.name shouldBe "Madison"
     }
 
@@ -2082,7 +2082,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         assertThrows<NoResultException> {
-            repo.select().where(namePath, EQUALS, "NonExistent").singleResult
+            repo.select().where(namePath eq "NonExistent").singleResult
         }
     }
 
@@ -2091,7 +2091,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         assertThrows<NonUniqueResultException> {
-            repo.select().where(namePath, LIKE, "M%").singleResult
+            repo.select().where(namePath like "M%").singleResult
         }
     }
 
@@ -2099,7 +2099,7 @@ open class QueryBuilderTest(
     fun `optionalResult with metamodel path should return entity when exactly one match`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val city = repo.select().where(namePath, EQUALS, "Madison").optionalResult
+        val city = repo.select().where(namePath eq "Madison").optionalResult
         city shouldNotBe null
         city!!.name shouldBe "Madison"
     }
@@ -2108,7 +2108,7 @@ open class QueryBuilderTest(
     fun `optionalResult should return null when no match`() {
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
-        val city = repo.select().where(namePath, EQUALS, "NonExistent").optionalResult
+        val city = repo.select().where(namePath eq "NonExistent").optionalResult
         city shouldBe null
     }
 
@@ -2117,7 +2117,7 @@ open class QueryBuilderTest(
         val repo = orm.entity(City::class)
         val namePath = metamodel<City, String>(repo.model, "name")
         assertThrows<NonUniqueResultException> {
-            repo.select().where(namePath, LIKE, "M%").optionalResult
+            repo.select().where(namePath like "M%").optionalResult
         }
     }
 
@@ -2140,7 +2140,7 @@ open class QueryBuilderTest(
         val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
         val result = repo.selectCount()
             .groupBy(lastNamePath)
-            .having(lastNamePath, EQUALS, "Davis")
+            .having(lastNamePath eq "Davis")
             .resultList
         result shouldHaveSize 1
     }
@@ -2151,7 +2151,71 @@ open class QueryBuilderTest(
         val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
         val result = repo.selectCount()
             .groupBy(lastNamePath)
-            .havingAny(lastNamePath, IN, "Davis", "Franklin")
+            .havingAny(lastNamePath inList listOf("Davis", "Franklin"))
+            .resultList
+        result shouldHaveSize 2
+    }
+
+    // having / havingAny with PredicateBuilder
+
+    @Test
+    fun `having with predicate should filter groups`() {
+        // data.sql: Betty and Harold Davis share a last name, so the Davis group holds 2 owners.
+        val repo = orm.entity(Owner::class)
+        val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
+        val result = repo.selectCount()
+            .groupBy(lastNamePath)
+            .having(lastNamePath eq "Davis")
+            .resultList
+        result shouldHaveSize 1
+        result[0] shouldBe 2L
+    }
+
+    @Test
+    fun `having with or-composed predicate should filter groups`() {
+        // A disjunction has no other form: consecutive having() calls are AND-combined.
+        val repo = orm.entity(Owner::class)
+        val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
+        val result = repo.selectCount()
+            .groupBy(lastNamePath)
+            .having((lastNamePath eq "Davis") or (lastNamePath eq "Franklin"))
+            .resultList
+        result shouldHaveSize 2
+        result.sum() shouldBe 3L
+    }
+
+    @Test
+    fun `consecutive having predicates should be and-combined`() {
+        // The two clauses cannot both hold, so AND-combining them yields no groups.
+        val repo = orm.entity(Owner::class)
+        val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
+        val result = repo.selectCount()
+            .groupBy(lastNamePath)
+            .having(lastNamePath eq "Davis")
+            .having(lastNamePath eq "Franklin")
+            .resultList
+        result shouldHaveSize 0
+    }
+
+    @Test
+    fun `havingAny with predicate should filter groups`() {
+        val repo = orm.entity(Owner::class)
+        val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
+        val result = repo.selectCount()
+            .groupBy(lastNamePath)
+            .havingAny(lastNamePath inList listOf("Davis", "Franklin"))
+            .resultList
+        result shouldHaveSize 2
+    }
+
+    @Test
+    fun `having with nested and-or predicate should filter groups`() {
+        val repo = orm.entity(Owner::class)
+        val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
+        val cityPath = metamodel<Owner, City>(repo.model, "city_id")
+        val result = repo.selectCount()
+            .groupBy(lastNamePath, cityPath)
+            .having(((lastNamePath eq "Davis") and (cityPath eq City(1, "Sun Paririe"))) or (lastNamePath eq "Franklin"))
             .resultList
         result shouldHaveSize 2
     }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
@@ -2212,6 +2212,35 @@ open class QueryBuilderTest(
     }
 
     @Test
+    fun `havingExists lambda should build the subquery from the query's own factory`() {
+        // The lambda receiver is the query's subquery factory, not a WhereBuilder. It must produce the same groups as
+        // the subquery-argument form.
+        val repo = orm.entity(Owner::class)
+        val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
+        val viaArgument = repo.selectCount()
+            .groupBy(lastNamePath)
+            .havingExists(orm.subquery(Pet::class))
+            .resultList
+        val viaLambda = repo.selectCount()
+            .groupBy(lastNamePath)
+            .havingExists { subquery(Pet::class) }
+            .resultList
+        viaLambda.size shouldNotBe 0
+        viaLambda shouldBe viaArgument
+    }
+
+    @Test
+    fun `havingNotExists lambda should drop every group when the subquery matches`() {
+        val repo = orm.entity(Owner::class)
+        val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
+        val kept = repo.selectCount()
+            .groupBy(lastNamePath)
+            .havingNotExists { subquery(Pet::class) }
+            .resultList
+        kept shouldHaveSize 0
+    }
+
+    @Test
     fun `havingNotExists with subquery should drop every group when the subquery matches`() {
         val repo = orm.entity(Owner::class)
         val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")

--- a/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
@@ -2198,6 +2198,31 @@ open class QueryBuilderTest(
     }
 
     @Test
+    fun `havingExists with subquery should keep every group when the subquery matches`() {
+        // The subquery is uncorrelated, so EXISTS holds for every group as long as any pet exists.
+        val repo = orm.entity(Owner::class)
+        val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
+        val groups = repo.selectCount().groupBy(lastNamePath).resultList
+        val kept = repo.selectCount()
+            .groupBy(lastNamePath)
+            .havingExists(orm.subquery(Pet::class))
+            .resultList
+        groups.size shouldNotBe 0
+        kept shouldBe groups
+    }
+
+    @Test
+    fun `havingNotExists with subquery should drop every group when the subquery matches`() {
+        val repo = orm.entity(Owner::class)
+        val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")
+        val kept = repo.selectCount()
+            .groupBy(lastNamePath)
+            .havingNotExists(orm.subquery(Pet::class))
+            .resultList
+        kept shouldHaveSize 0
+    }
+
+    @Test
     fun `havingAny with predicate should filter groups`() {
         val repo = orm.entity(Owner::class)
         val lastNamePath = metamodel<Owner, String>(repo.model, "last_name")

--- a/storm-kotlin/src/test/kotlin/st/orm/template/RefFetchTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/RefFetchTest.kt
@@ -12,7 +12,6 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import st.orm.Metamodel
-import st.orm.Operator.EQUALS
 import st.orm.PersistenceException
 import st.orm.template.model.Adoption
 import st.orm.template.model.Animal
@@ -49,12 +48,12 @@ open class RefFetchTest(
     @Test
     fun `resolved reference matches the entity graph`() {
         val viaEntity = orm.entity(Pet::class).select()
-            .where(Metamodel.of<Pet, String>(Pet::class.java, "name"), EQUALS, "Leo")
+            .where(Metamodel.of<Pet, String>(Pet::class.java, "name") eq "Leo")
             .resultList
             .map { it.owner }
         val viaRef = orm.entity(PetOwnerRef::class).select()
             .fetch(ownerPath)
-            .where(namePath, EQUALS, "Leo")
+            .where(namePath eq "Leo")
             .resultList
             .map { it.owner?.fetch() }
         viaEntity.shouldNotBeEmpty()
@@ -72,7 +71,7 @@ open class RefFetchTest(
     fun `nullable reference yields null`() {
         val pets = orm.entity(PetOwnerRef::class).select()
             .fetch(ownerPath)
-            .where(namePath, EQUALS, "Sly")
+            .where(namePath eq "Sly")
             .resultList
         pets.single().owner.shouldBeNull()
     }
@@ -81,7 +80,7 @@ open class RefFetchTest(
     fun `fetch is available in the select DSL`() {
         val pets = orm.entity(PetOwnerRef::class).select {
             fetch(ownerPath)
-            where(namePath, EQUALS, "Leo")
+            where(namePath eq "Leo")
         }.resultList
         pets.single().owner.shouldNotBeNull().isLoaded shouldBe true
     }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/SqlDslTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/SqlDslTest.kt
@@ -98,7 +98,7 @@ open class SqlDslTest(
         val cityRepository = orm.entity(City::class)
         val namePath = metamodel<City, String>(cityRepository.model, "name")
         val cities = cityRepository.select {
-            where(namePath, IN, "Madison", "Windsor", "Monona")
+            where(namePath inList listOf("Madison", "Windsor", "Monona"))
             orderBy(namePath)
         }.resultList
         cities shouldHaveSize 3
@@ -137,6 +137,42 @@ open class SqlDslTest(
             leftJoin<Owner, Pet>()
         }.resultList
         pets shouldHaveSize 13
+    }
+
+    @Test
+    fun `select entities with groupBy and having predicate`() {
+        // City has exactly the two columns selected, so both belong in the GROUP BY.
+        val cityRepository = orm.entity(City::class)
+        val idPath = metamodel<City, Int>(cityRepository.model, "id")
+        val namePath = metamodel<City, String>(cityRepository.model, "name")
+        val cities = cityRepository.select {
+            groupBy(idPath, namePath)
+            having((namePath eq "Madison") or (namePath eq "Monona"))
+            orderBy(namePath)
+        }.resultList
+        cities shouldHaveSize 2
+        cities[0].name shouldBe "Madison"
+        cities[1].name shouldBe "Monona"
+    }
+
+    @Test
+    fun `select entities with groupByAny and havingAny on a joined entity`() {
+        // havingAny pairs with groupByAny: a HAVING condition on a joined column is only valid once that column is
+        // grouped. data.sql: Betty Davis lives in city 1, Harold Davis in city 4.
+        val cityRepository = orm.entity(City::class)
+        val idPath = metamodel<City, Int>(cityRepository.model, "id")
+        val namePath = metamodel<City, String>(cityRepository.model, "name")
+        val lastNamePath = metamodel<Owner, String>(orm.model(Owner::class), "last_name")
+        val cities = cityRepository.select {
+            innerJoin<Owner, City>()
+            groupBy(idPath, namePath)
+            groupByAny(lastNamePath)
+            havingAny(lastNamePath eq "Davis")
+            orderBy(idPath)
+        }.resultList
+        cities shouldHaveSize 2
+        cities[0].id shouldBe 1
+        cities[1].id shouldBe 4
     }
 
     @Test

--- a/website/static/skills/storm-query-kotlin.md
+++ b/website/static/skills/storm-query-kotlin.md
@@ -11,7 +11,7 @@ Help the user write Storm queries using Kotlin.
 ```kotlin
 import st.orm.template.*                         // QueryBuilder, eq, neq, like, ref, orm, etc.
 import st.orm.repository.*                       // entity<T>(), select<Result, _, _> { }, findBy, insert, ... (wildcard: see below)
-import st.orm.Operator.*                         // EQUALS, NOT_EQUALS, LIKE, IN, IS_NULL, etc.
+import st.orm.Operator.*                         // escape hatch: only when the operator is chosen at runtime
 import st.orm.Ref                                // Lazy-loaded reference
 import st.orm.Page                               // Offset-based pagination result
 import st.orm.Pageable                           // Pagination request
@@ -259,8 +259,15 @@ val userCount = orm.entity<User>().selectCount().singleResult
 val citySummaries = orm.entity<City>()
     .select(CitySummary::class)
     .groupBy(City_.country)
-    .having(City_.population, Operator.GREATER_THAN, 100000)
+    .having(City_.population greater 100000)
     .resultList
+```
+
+**HAVING takes predicates too.** `having(predicate)` accepts the same infix operators as `where(predicate)`, so a condition on a grouped column stays in code — including a disjunction, which consecutive `having()` calls cannot express because they are AND-combined. Use `havingAny(predicate)` for a joined entity's column. A condition on an *aggregate* still needs a template, since no metamodel path names a computed value:
+
+```kotlin
+.having((City_.country eq nl) or (City_.country eq be))   // grouped column — predicate
+.having { "COUNT(*) > ${minimum}" }                       // aggregate — template
 ```
 
 **Computed aggregates (COUNT, AVG, SUM, etc.):** When the SELECT clause needs expressions that QueryBuilder can't produce, use `select<ResultType, _, _> { template }` for the SELECT only — keep joins, groupBy, having, orderBy, and limit in code. The result type is explicit; the underscores let Kotlin infer the repository's entity and ID types. Style: use the underscore form only in code that is otherwise fully reified; if the surrounding query uses `::class` calls, write `select(ResultType::class) { template }` instead — keep each snippet internally consistent (template interpolations like `${City::class}` don't count).
@@ -492,9 +499,10 @@ The `where()` and `orderBy()` methods in the block DSL are typed to the root ent
 - `whereAny(predicate)` — accepts `PredicateBuilder<*, *, *>` (any entity type)
 - `orderByAny(path)` — accepts `Metamodel<*, *>` (any entity type)
 - `orderByDescendingAny(path)` — same, descending
-- `groupByAny(path)` — accepts `Metamodel<*, *>` (any entity type; chained API only, not in the block DSL)
+- `groupByAny(path)` — accepts `Metamodel<*, *>` (any entity type)
+- `havingAny(predicate)` — accepts `PredicateBuilder<*, *, *>` (any entity type). Pairs with `groupByAny`: a HAVING condition on a joined column is only valid once that column is grouped
 
-The `Any` variants (`whereAny`, `orderByAny`, `orderByDescendingAny`, `groupByAny`) are needed **only** when referencing fields from joined (non-root) entities — never for root paths, however deep: `User_.city.country.name` starts at the root, so it stays with `where()`/`orderBy()`. Escalate per clause, not per query: a root-field condition keeps `where()` even when the query also has a `whereAny()` for a joined field (see **Choosing the WHERE Form**).
+The `Any` variants (`whereAny`, `orderByAny`, `orderByDescendingAny`, `groupByAny`, `havingAny`) are needed **only** when referencing fields from joined (non-root) entities — never for root paths, however deep: `User_.city.country.name` starts at the root, so it stays with `where()`/`orderBy()`. Escalate per clause, not per query: a root-field condition keeps `where()` even when the query also has a `whereAny()` for a joined field (see **Choosing the WHERE Form**).
 
 ```kotlin
 // Root is User: the joined UserRole field escalates, the root field does not
@@ -506,7 +514,7 @@ select {
 }.resultList
 ```
 
-These are also available on the chained QueryBuilder API: `.whereAny(...)`, `.orderByAny(...)`, `.orderByDescendingAny(...)`, `.groupByAny(...)`.
+These are also available on the chained QueryBuilder API: `.whereAny(...)`, `.orderByAny(...)`, `.orderByDescendingAny(...)`, `.groupByAny(...)`, `.havingAny(...)`.
 
 ## Keyset Scrolling
 
@@ -647,7 +655,7 @@ select {
 }.page(page, size)
 ```
 
-Available in the block: `where`, `whereAny`, `whereBuilder`, `whereExists`, `whereNotExists`, `orderBy`, `orderByAny`, `orderByDescending`, `orderByDescendingAny`, `groupBy`, `having`, `limit`, `offset`, `distinct`, `unsafe`, `forUpdate`, `forShare`, `innerJoin`, `leftJoin`, `rightJoin`, `crossJoin`, `append`. Note: `groupByAny` is NOT available in the block — it exists only on the chained QueryBuilder API. The WHERE ladder applies in the block exactly as it does on the chained API: `where` first, `whereAny` only for joined-entity fields, `whereBuilder` last (see **Choosing the WHERE Form**).
+Available in the block: `where`, `whereAny`, `whereBuilder`, `whereExists`, `whereNotExists`, `orderBy`, `orderByAny`, `orderByDescending`, `orderByDescendingAny`, `groupBy`, `groupByAny`, `having`, `havingAny`, `limit`, `offset`, `distinct`, `unsafe`, `forUpdate`, `forShare`, `innerJoin`, `leftJoin`, `rightJoin`, `crossJoin`, `append`. The WHERE ladder applies in the block exactly as it does on the chained API: `where` first, `whereAny` only for joined-entity fields, `whereBuilder` last (see **Choosing the WHERE Form**).
 
 **Note:** The block DSL has `orderBy { template }` but NOT `orderByDescending { template }`. For template-based descending order, use the chained API: `.orderByDescending { template }` or escape to raw SQL.
 

--- a/website/static/skills/storm-repository-kotlin.md
+++ b/website/static/skills/storm-repository-kotlin.md
@@ -16,7 +16,7 @@ import st.orm.repository.*                       // EntityRepository, plus every
                                                  // Use the wildcard: these are top-level extensions, and naming
                                                  // them one by one is how an import ends up missing.
 import st.orm.template.*                         // ORMTemplate, QueryBuilder, orm, ref, eq, neq, etc.
-import st.orm.Operator.*                         // EQUALS, NOT_EQUALS, IN, etc.
+import st.orm.Operator.*                         // escape hatch: only when the operator is chosen at runtime
 import st.orm.Ref                                // Lazy-loaded reference
 import st.orm.Page                               // Offset-based pagination result
 import st.orm.Pageable                           // Pagination request


### PR DESCRIPTION
Aligns the clause vocabulary across the four query builder surfaces: `st.orm.core.template.QueryBuilder`, the `storm-java21` `QueryBuilder`, the Kotlin chained `QueryBuilder`, and the Kotlin `select { }` block DSL (`SqlScope`). Every item below is the same defect: a form exists on one surface or one clause and not on its counterpart, so what a user can express depends on which of the four they reached for.

## Navigation-only paths in the Java API

`Metamodel extends Navigable`, and every node beyond a `Ref` is `Navigable` but not `Metamodel`. Clause parameters took `Navigable` in Kotlin, only on the root-typed methods in `storm-core`, and nowhere in `storm-java21` (19 `Metamodel` parameters in its `QueryBuilder`, 13 in its `WhereBuilder`). So `docs/metamodel.md`'s claim that such a node "can be used anywhere a query needs a column reference: `where`, `orderBy`, `groupBy`, `having`" did not hold for the documented Java API, nor for the `*Any` variants in core.

The rebuild that makes a navigation-only node resolvable was duplicated as a private static in core and as a Kotlin extension. It becomes `Navigable.asMetamodel()` in `storm-foundation`, with both copies deleted.

Two tests in `storm-java21` cover what this opens: a beyond-`Ref` path through WHERE, GROUP BY, HAVING and ORDER BY in one query, and a beyond-`Ref` foreign key matched against a record, a `Ref`, and a collection of refs.

## HAVING predicates

`having()` had no `PredicateBuilder` overload, so its conditions could only be AND-combined — `having(TemplateString)` appends to a list that `SelectBuilderImpl` joins with `AND` — and `HAVING a > 1 OR b < 2` had no form in code at all.

The predicate is taken directly rather than through a `WhereBuilder`. Roughly half of that builder's 27 members match on row identity (`whereId`, `whereRef`, `where(record)`), which a clause filtering groups cannot use; the rest are already reachable without it, since the infix operators cover FK, ref and record matching on a path. Every member is also named `where*`, so a builder-based `having` would read `it.where(...)` at a `having` call site.

`storm-java21` is deliberately left out: a `PredicateBuilder` can only be obtained there inside a `where` lambda, so an overload taking one would be uncallable. Java composes a HAVING disjunction with the template form, which is what it needs for aggregates in any case.

## `groupByAny` in the block DSL

A HAVING condition on a joined entity's column is valid only once that column is in the GROUP BY list, so `havingAny` and `groupByAny` are one capability, not two. The block DSL had neither. Both are added, which also makes it uniform with the chained builder: every clause whose `Any` variant exists on one now exists on both.

## EXISTS

Neither Java module had a top-level `whereExists`/`whereNotExists` — every use went through `where(it -> it.exists(...))` — and the block DSL had only the subquery-argument form. Adds the pairs to both Java surfaces, the `{ }` lambda forms plus `whereAnyBuilder` to the block DSL, and `havingExists`/`havingNotExists` to all four surfaces.

The HAVING pair takes the subquery directly, and in Kotlin also accepts a `{ }` lambda. No `WhereBuilder` is involved in either: the subquery factory belongs to `SubqueryTemplate`, which `QueryTemplate` implements, and `WhereBuilder` only forwards to it. `QueryBuilder.subqueryTemplate()` exposes that factory, so the lambda receiver is the query's own rather than a WHERE scope borrowed for its side effects.

Both forms are equivalent — a subquery correlates through how it is embedded, not through where it was created, which the correlated tests below confirm. The lambda is added because it is the form in use: in a production codebase built on this framework, `whereExists { }` accounts for 61 call sites and the subquery-argument form for none, in files that reference `orm` directly 282 times.

Correlated subqueries had no coverage on either clause. Three tests now cover them: the documented lambda form, the same correlation from a subquery built on the `ORMTemplate` (equal results), and the same correlation driving `havingExists`.

## `whereAny(path, operator, values)`

Present as `havingAny(path, operator, values)` on the builder in both languages since 1.2, absent for WHERE outside the builder scope. Added to both Java surfaces.

## Kotlin call sites

115 call sites across `storm-kotlin` main and tests move to the infix operators, matching what the docs and skills already teach. The operator-argument methods stay: each infix operator fixes its operator at compile time, so they remain the only way to apply one chosen at runtime, which a dynamic filter or spec-driven repository needs.

## Considered and rejected

- **Removing the Kotlin `Operator` methods.** All 15 `Operator` constants have an infix equivalent, which makes the 10 methods taking an `Operator` argument look superseded. They are not, for the reason above. `Operator` is a foundational type and the form is an escape hatch, not a competing style.
- **Standalone `TRUE()` / `FALSE()`.** Conditional assembly does not need them: the builder is immutable, so conditionally chaining `where()` calls covers the case.

## Docs

`docs/queries.md` gains a section on filtering groups, and its Aggregation note no longer claims HAVING requires SQL Templates. Kotlin snippets across `docs/` move to the infix form. The Kotlin skills document `having(predicate)`, correct the note that `groupByAny` is chained-only, and describe the `Operator` import as the runtime-operator escape hatch.

## Compatibility

Additive for callers. The path parameter widening is source-compatible for existing call sites, since `Metamodel` is a `Navigable`.

Subclassers are affected: ten abstract methods are added across the three `QueryBuilder` classes, and twelve abstract signatures change on `WhereBuilder`. Both classes are implemented internally and neither is a documented extension point, so this reaches only code that subclasses them directly.

## Verification

`mvn clean install` green: 7,325 tests across 28 module runs, zero failures.

Fixes #369
