### PR TITLE
fix(core): name the cause and the candidates in column resolution errors

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/impl/AliasMapper.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/AliasMapper.java
@@ -118,7 +118,8 @@ final class AliasMapper {
             if (path != null) {
                 return new SqlTemplateException("Multiple aliases found for: %s at path: '%s'. Use INNER scope to limit alias resolution to the current scope.".formatted(table.getSimpleName(), path));
             }
-            return new SqlTemplateException("Multiple aliases found for: %s.".formatted((table.getSimpleName())));
+            var paths = collectAliasEntries(table, null, 0).map(AliasEntry::path).toList();
+            return multiplePathsFoundException(table, paths);
         }
         var paths = aliasMap.get(table).stream()
                 .map(TableAlias::path)
@@ -166,7 +167,8 @@ final class AliasMapper {
                            @Nonnull ResolveScope scope,
                            @Nonnull SqlDialect dialect) throws SqlTemplateException {
         return getAlias(metamodel, scope, dialect,
-                () -> new SqlTemplateException("Alias for table not found at %s.".formatted(metamodel)));
+                () -> new SqlTemplateException("Alias for table not found at %s: %s is not part of this query. Join the table or reference it through a path from the query root.".formatted(
+                        metamodel, metamodel.tableType().getSimpleName())));
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryModelImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryModelImpl.java
@@ -749,7 +749,8 @@ final class QueryModelImpl implements QueryModel {
                 alias = aliasMapper.findAlias(metamodel.tableType(), null, INNER).orElse(null);
             }
             if (alias == null) {
-                throw new SqlTemplateException("Cannot find alias for column: %s.".formatted(column.qualifiedName(template.dialect())));
+                throw new SqlTemplateException("Cannot find alias for column %s: %s is not part of this query rooted at %s. Join the table or correct the metamodel path.".formatted(
+                        column.qualifiedName(template.dialect()), metamodel.tableType().getSimpleName(), model.type().getSimpleName()));
             }
             // For JOINED sealed entities without a discriminator, the discriminator column (index 1)
             // is replaced by a CASE expression that resolves the concrete type from extension table PKs.

--- a/storm-core/src/test/java/st/orm/core/ShortFormResolutionIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/ShortFormResolutionIntegrationTest.java
@@ -1,0 +1,115 @@
+package st.orm.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static st.orm.Operator.EQUALS;
+import static st.orm.core.template.TemplateString.raw;
+
+import java.time.LocalDate;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.PersistenceException;
+import st.orm.core.model.PetOwnerRef_;
+import st.orm.core.model.VisitWithTwoPetRefs;
+import st.orm.core.model.VisitWithTwoPetRefs_;
+import st.orm.core.model.VisitWithTwoPets;
+import st.orm.core.model.VisitWithTwoPets_;
+import st.orm.core.template.ORMTemplate;
+
+/**
+ * Short form names a table by its own metamodel root and resolves against the aliases registered in the query; a
+ * nested path names its route and can never be ambiguous. These tests pin the resolution contract for entities that
+ * appear more than once: short form fails loudly, naming the candidate paths, while pinned paths resolve — including
+ * paths beyond a {@link st.orm.Ref}, whose joins materialize per path.
+ */
+@SuppressWarnings("ALL")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IntegrationConfig.class)
+@DataJpaTest(showSql = false)
+public class ShortFormResolutionIntegrationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    public void shortFormAgainstTwoEagerPathsNamesTheCandidates() {
+        var orm = ORMTemplate.of(dataSource);
+        var e = assertThrows(PersistenceException.class, () -> orm.entity(VisitWithTwoPets.class).select()
+                .where(raw("\0 = \0", PetOwnerRef_.name, "Leo"))
+                .getResultList());
+        var message = e.getCause().getMessage();
+        assertTrue(message.contains("Multiple paths found for PetOwnerRef"), message);
+        assertTrue(message.contains("'pet1'") && message.contains("'pet2'"), message);
+    }
+
+    @Test
+    public void nestedPathPinsThroughTwoEagerPaths() {
+        var orm = ORMTemplate.of(dataSource);
+        var visits = orm.entity(VisitWithTwoPets.class).select()
+                .where(VisitWithTwoPets_.pet1.name, EQUALS, "Leo")
+                .getResultList();
+        assertFalse(visits.isEmpty());
+    }
+
+    @Test
+    public void beyondRefPathPinsWithTwoRefsOfTheSameType() {
+        var orm = ORMTemplate.of(dataSource);
+        // Both fields are Ref<PetOwnerRef>: the on-demand join materializes per path, so the path is never ambiguous.
+        var visits = orm.entity(VisitWithTwoPetRefs.class).select()
+                .where(VisitWithTwoPetRefs_.pet1.name, EQUALS, "Leo")
+                .getResultList();
+        assertFalse(visits.isEmpty());
+    }
+
+    @Test
+    public void bothBeyondRefPathsResolveInOneQuery() {
+        var orm = ORMTemplate.of(dataSource);
+        var visits = orm.entity(VisitWithTwoPetRefs.class).select()
+                .where(VisitWithTwoPetRefs_.pet1.name, EQUALS, "Leo")
+                .where(VisitWithTwoPetRefs_.pet2.name, EQUALS, "Leo")
+                .getResultList();
+        assertFalse(visits.isEmpty());
+    }
+
+    @Test
+    public void shortFormAgainstUntraversedRefTargetsStatesTheCause() {
+        var orm = ORMTemplate.of(dataSource);
+        // A Ref registers no alias until a path traverses it, so the table is not part of the query.
+        var e = assertThrows(PersistenceException.class, () -> orm.entity(VisitWithTwoPetRefs.class).select()
+                .where(raw("\0 = \0", PetOwnerRef_.name, "Leo"))
+                .getResultList());
+        var message = e.getCause().getMessage();
+        assertTrue(message.contains("PetOwnerRef is not part of this query"), message);
+    }
+
+    @Test
+    public void shortFormResolvesAgainstASingleTraversedRefPath() {
+        var orm = ORMTemplate.of(dataSource);
+        // One traversal registers one alias, so the short form binds to it. Context-dependent by design: short form
+        // resolves iff exactly one alias for the table is registered in the query.
+        var visits = orm.entity(VisitWithTwoPetRefs.class).select()
+                .where(VisitWithTwoPetRefs_.pet1.name, EQUALS, "Leo")
+                .where(raw("\0 = \0", PetOwnerRef_.birthDate, LocalDate.of(2020, 9, 7)))
+                .getResultList();
+        assertFalse(visits.isEmpty());
+    }
+
+    @Test
+    public void shortFormAfterBothRefPathsTraversedNamesTheCandidates() {
+        var orm = ORMTemplate.of(dataSource);
+        var e = assertThrows(PersistenceException.class, () -> orm.entity(VisitWithTwoPetRefs.class).select()
+                .where(VisitWithTwoPetRefs_.pet1.name, EQUALS, "Leo")
+                .where(VisitWithTwoPetRefs_.pet2.name, EQUALS, "Leo")
+                .where(raw("\0 = \0", PetOwnerRef_.birthDate, LocalDate.of(2020, 9, 7)))
+                .getResultList());
+        var message = e.getCause().getMessage();
+        assertTrue(message.contains("Multiple paths found for PetOwnerRef"), message);
+        assertTrue(message.contains("'pet1'") && message.contains("'pet2'"), message);
+    }
+}


### PR DESCRIPTION
Targets **1.13.1**. Three column resolution errors reported the failure without what the caller needs to act on it; each now states the cause and, where relevant, the candidates.

## Before / after

**Ambiguous short-form reference** (table registered more than once):
```
Multiple aliases found for: PetOwnerRef.
```
```
Multiple paths found for PetOwnerRef in table graph. Specify one of the following paths to uniquely identify the table: 'pet1', 'pet2'.
```
The INNER-scoped branch of the same resolution already listed the candidates; the bare branch now routes through the same listing.

**Reference to a table with no registered alias** (template interpolation):
```
Alias for table not found at Metamodel{root=PetOwnerRef, type=String, path='', field='name'}.
```
```
Alias for table not found at Metamodel{...}: PetOwnerRef is not part of this query. Join the table or reference it through a path from the query root.
```

**Column resolution in the query model**, which additionally knows the query root:
```
Cannot find alias for column: visit_date.
```
```
Cannot find alias for column visit_date: Visit is not part of this query rooted at City. Join the table or correct the metamodel path.
```

## Tests

`ShortFormResolutionIntegrationTest` pins the resolution contract for entities that appear more than once, on models with two same-typed FKs (`VisitWithTwoPets` eager, `VisitWithTwoPetRefs` refs):

- short form against two eager paths fails naming both candidates;
- a nested path pins its route and resolves;
- a path beyond a `Ref` materializes its join per path and is therefore never ambiguous — with two `Ref`s of the same type, `pet1.name` and `pet2.name` each resolve, together or alone;
- short form against `Ref` targets resolves against the traversals the query happens to contain: no traversal is "not part of this query", one traversal binds to it, two are ambiguous with both candidates named.

Full core suite green: 2,513 tests.

Note: the 1.14 draft (#372) will absorb this by merge; the query-model message there is byte-identical, so the merge is clean.
