### PR TITLE
docs: ease the landing examples into the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,9 @@ val users = orm.findAll(User_.city.name eq "Sunnyvale")
 interface UserRepository : EntityRepository<User, Int> {
     fun findByCity(name: String) = findAll(User_.city.name eq name)
 }
-
-// Drop to SQL whenever you want it. Interpolations become bind parameters.
-val users = orm.query { """
-    SELECT ${User::class}
-    FROM ${User::class}
-    WHERE ${User_.city.name} = $cityName""" }.resultList<User>()
 ```
 
-The `city` graph loads in a single query, `User_` is generated at compile time so a typo is a compile error, and every interpolation is a bind parameter. What you write is what runs.
+The `city` graph loads in a single query, and `User_` is generated at compile time so a typo is a compile error. What you write is what runs.
 
 ## Why Storm
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,18 +66,11 @@ interface UserRepository : EntityRepository<User, Int> {
     fun findByCityName(name: String) = findAll(User_.city.name eq name)
 }
 
-// Block DSL — build queries with where, orderBy, joins, pagination
-val users = userRepository.select {
-    where(User_.city.name eq "Sunnyvale")
-    orderBy(User_.name)
-}.resultList
-
-// SQL Template for full control; parameterized by default, SQL injection safe
-val users = orm.query { """
-        SELECT ${User::class}
-        FROM ${User::class}
-        WHERE ${User_.city.name} = $cityName"""
-    }.resultList<User>()
+// Query builder — where, orderBy, joins, pagination
+val users = userRepository.select()
+    .where(User_.city.name eq "Sunnyvale")
+    .orderBy(User_.name)
+    .resultList
 ```
 
 Full coroutine support with `Flow` for streaming and programmatic transactions:
@@ -118,13 +111,6 @@ List<User> users = orm.entity(User.class)
     .where(User_.city.name, EQUALS, "Sunnyvale")
     .orderBy(User_.name)
     .getResultList();
-
-// SQL Template for full control; parameterized by default, SQL injection safe
-List<User> users = orm.query(RAW."""
-        SELECT \{User.class}
-        FROM \{User.class}
-        WHERE \{User_.city.name} = \{cityName}
-        """).getResultList(User.class);
 ```
 
 </TabItem>


### PR DESCRIPTION
Removes the SQL-template example from the introductory sequences in `docs/index.md` (both language tabs) and `README.md` — the escape hatch comes too soon at that point in the journey; the dedicated SQL Templates page is unchanged. The Kotlin landing example now uses the chained builder (`select().where(...).orderBy(...)`) instead of the block DSL, matching the Java tab.