### PR TITLE
docs: document dirty checking and update suppression in the skills and docs

### DIFF
--- a/docs/dirty-checking.md
+++ b/docs/dirty-checking.md
@@ -186,6 +186,7 @@ orm update updated
 
 **Characteristics**
 - UPDATE suppression when nothing changed
+- Unchanged entities are dropped from batch updates before execution
 - Stable SQL shape per entity (enables batching)
 - Low memory overhead (stores one copy of observed state per entity)
 - Minimal CPU overhead (single comparison per update)
@@ -320,24 +321,9 @@ record User(@PK Integer id,
 
 ### How It Works
 
-The `@DynamicUpdate` annotation is processed at compile time by Storm's KSP processor (Kotlin) or annotation processor (Java). The update mode is encoded in the generated metamodel class (`User_`), so there's no runtime reflection cost.
+Storm resolves the effective update mode once, when the repository for an entity type is initialized: an entity-level `@DynamicUpdate` annotation takes precedence over the configured default. Individual updates then use the precomputed mode without further lookups.
 
-```
-┌─────────────────────┐      Compile Time      ┌─────────────────────┐
-│                     │                        │                     │
-│   @DynamicUpdate    │  ───────────────────▶  │   User_ metamodel   │
-│   data class User   │    Annotation          │   updateMode=FIELD  │
-│                     │    Processor           │                     │
-└─────────────────────┘                        └─────────────────────┘
-                                                         │
-                                                         │ Runtime
-                                                         ▼
-                                               ┌─────────────────────┐
-                                               │  Storm reads mode   │
-                                               │  from metamodel     │
-                                               │  (no reflection)    │
-                                               └─────────────────────┘
-```
+The field comparisons themselves run through the generated metamodel classes (KSP for Kotlin, annotation processor for Java), which provide type-specific equality checks with no reflection and no boxing for primitive fields. Without a generated metamodel, Storm falls back to reflective accessors.
 
 ### Mixing Modes in an Application
 
@@ -377,9 +363,9 @@ When comparing an entity to its observed state, Storm needs to determine whether
 
 ### Instance-Based (Default)
 
-Instance-based checking treats a field as changed when the object reference differs (`!=` identity comparison). This is the fastest option because reference comparison is a single pointer check with no method dispatch. It works correctly in the vast majority of cases because Kotlin's `copy()` and Java's `with...()` patterns create new instances for modified fields while reusing the same references for unchanged fields.
+Instance-based checking treats a field as changed when the object reference differs (identity comparison). This is the fastest option because reference comparison is a single pointer check with no method dispatch. It works correctly in the vast majority of cases because Kotlin's `copy()` and Java's `with...()` patterns create new instances for modified fields while reusing the same references for unchanged fields.
 
-The only scenario where instance-based checking produces a false positive is when you construct a new object with identical content. For example, `user.copy(name = user.name)` creates a new `String` reference for `name`, even though the value is unchanged. In practice, this is rare and the cost of an extra column in the UPDATE is negligible.
+The only scenario where instance-based checking produces a false positive is when a field value is rebuilt as a distinct but equal instance. For example, mapping a submitted form or DTO back onto an entity reconstructs field values that may be equal to the current ones without being the same instances. In practice, this is rare and the cost of an extra column in the UPDATE is negligible.
 
 ### Value-Based
 
@@ -408,6 +394,12 @@ val config = StormConfig.of(mapOf(UPDATE_DIRTY_CHECK to "VALUE"))
 ```bash
 -Dstorm.update.dirty_check=VALUE
 ```
+
+### Foreign Keys Compare by Id
+
+For a foreign key field, dirty checking follows the column rather than the object graph. Under value-based checking, the referenced entity is compared by primary key only: a referenced `City` whose own fields changed does not make the referencing `User` dirty, because the `city_id` column is unchanged. Updating the `User` would not write the `City`'s fields anyway; to persist changes inside a referenced entity, update that entity itself.
+
+Under instance-based checking, substituting a different instance with the same id marks the foreign key column dirty and costs a redundant write of the same value. `Ref<T>` fields compare the same way, by the id the ref carries.
 
 ---
 
@@ -625,6 +617,10 @@ Storm uses compile-time generated metamodel classes for dirty checking operation
 
 Ensure your build is configured to run the KSP (Kotlin) or annotation processor (Java) to generate metamodel classes. If the metamodel is not available, Storm falls back to reflection.
 
+### 5. Joined Table Inheritance Always Writes
+
+Entities in a [Joined Table hierarchy](polymorphism.md#joined-table-inheritance) are not dirty-checked. Their updates write both the base and extension tables and always execute; update suppression and field-level updates do not apply to them.
+
 ---
 
 ## Best Practices
@@ -639,7 +635,11 @@ For most applications, the default `ENTITY` mode provides the right balance:
 
 Only switch to `FIELD` mode when you have a specific need (wide tables, high contention, large columns).
 
-### 2. Use FIELD Mode Strategically
+### 2. Update in Place, Don't Delete-and-Reinsert
+
+Delete-and-reinsert and dirty checking are mutually exclusive. Inserts are never dirty-checked, and freshly constructed rows carry no observed state, so a write path that clears rows and re-inserts the desired set writes every row every time. To make a table match a desired state, keep the instances that were read: update the full set and let Storm suppress the unchanged rows, reserving insert and remove for actual additions and removals.
+
+### 3. Use FIELD Mode Strategically
 
 Reserve `FIELD` mode for entities where it provides clear benefits:
 
@@ -670,7 +670,7 @@ data class AuditEntry(       // Keep ENTITY mode
 ) : Entity<Int>
 ```
 
-### 3. Always Use @Version for Concurrency Control
+### 4. Always Use @Version for Concurrency Control
 
 Dirty checking answers "what changed?" but not "did someone else change this?"
 
@@ -684,7 +684,7 @@ data class Account(
 
 Without `@Version`, concurrent updates can silently overwrite each other (lost update problem).
 
-### 4. Match Mode to Workload
+### 5. Match Mode to Workload
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -704,7 +704,7 @@ Without `@Version`, concurrent updates can silently overwrite each other (lost u
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-### 5. Monitor in Production
+### 6. Monitor in Production
 
 If using `FIELD` mode extensively, monitor:
 

--- a/storm-core/src/main/java/st/orm/core/template/Column.java
+++ b/storm-core/src/main/java/st/orm/core/template/Column.java
@@ -153,8 +153,10 @@ public interface Column {
     /**
      * Returns the metamodel for this element.
      *
-     * <p>In case of a foreign key relationship, this metamodel represents the foreign key column on the parent entity.
-     * For non-foreign relationships, this is the only metamodel that applies.</p>
+     * <p>In case of a foreign key relationship, this metamodel represents the foreign key column on the referencing
+     * entity, the entity that declares the foreign key field. The referenced entity's primary key is represented
+     * separately by {@link #secondaryMetamodel()}. For non-foreign relationships, this is the only metamodel that
+     * applies.</p>
      *
      * @return the metamodel for this element.
      * @since 1.7

--- a/storm-java21/src/main/java/st/orm/template/Column.java
+++ b/storm-java21/src/main/java/st/orm/template/Column.java
@@ -119,6 +119,9 @@ public interface Column {
     /**
      * Gets the metamodel of the column.
      *
+     * <p>In case of a foreign key relationship, this metamodel represents the foreign key column on the referencing
+     * entity, the entity that declares the foreign key field.</p>
+     *
      * @return the metamodel of the column.
      * @since 1.7
      */

--- a/website/static/skills/storm-entity-java.md
+++ b/website/static/skills/storm-entity-java.md
@@ -14,6 +14,7 @@ Help the user create Storm entities using Java.
 - `st.orm.DbTable` — custom table name
 - `st.orm.DbColumn` — custom column name
 - `st.orm.Version` — optimistic locking
+- `st.orm.DynamicUpdate` — per-entity update mode and dirty-check strategy
 - `st.orm.Inline` — embedded component
 - `st.orm.Ref` — lazy-loaded reference
 - `st.orm.GenerationStrategy` — PK generation: `IDENTITY`, `SEQUENCE`, `NONE`
@@ -140,6 +141,8 @@ Generation rules:
    ) implements Entity<Integer> {}
    ```
    Use `insertable = false` alone for columns set by the database only on INSERT, or `updatable = false` alone for columns written once and never modified.
+
+11c. Update tuning: `@DynamicUpdate` sets how the entity's UPDATE statements are generated. The default mode (`ENTITY`) skips the UPDATE entirely when nothing changed and writes the full row when anything did. `@DynamicUpdate(FIELD)` writes only the changed columns, at the cost of one SQL shape per distinct change pattern (which splits batches); `@DynamicUpdate(OFF)` always writes all columns without comparison. `dirtyCheck = VALUE` switches change detection from reference identity to `equals()`. Semantics, trade-offs, and the foreign-key comparison rule: /storm-repository-java (Dirty Checking and Update Suppression).
 
 12. Java records are immutable. Consider Lombok `@Builder(toBuilder = true)` for copy-with-modification.
 

--- a/website/static/skills/storm-entity-kotlin.md
+++ b/website/static/skills/storm-entity-kotlin.md
@@ -13,6 +13,7 @@ Help the user create Storm entities using Kotlin.
 - `st.orm.DbTable` — custom table name
 - `st.orm.DbColumn` — custom column name
 - `st.orm.Version` — optimistic locking
+- `st.orm.DynamicUpdate` — per-entity update mode and dirty-check strategy
 - `st.orm.Inline` — embedded component
 - `st.orm.Ref` — lazy-loaded reference
 - `st.orm.GenerationStrategy` — PK generation: `IDENTITY`, `SEQUENCE`, `NONE`
@@ -160,6 +161,8 @@ Generation rules:
    ) : Entity<Int>
    ```
    Use `insertable = false` alone for columns set by the database only on INSERT, or `updatable = false` alone for columns that are written once and never modified.
+
+12c. Update tuning: `@DynamicUpdate` sets how the entity's UPDATE statements are generated. The default mode (`ENTITY`) skips the UPDATE entirely when nothing changed and writes the full row when anything did. `@DynamicUpdate(FIELD)` writes only the changed columns, at the cost of one SQL shape per distinct change pattern (which splits batches); `@DynamicUpdate(OFF)` always writes all columns without comparison. `dirtyCheck = VALUE` switches change detection from reference identity to `equals()`. Semantics, trade-offs, and the foreign-key comparison rule: /storm-repository-kotlin (Dirty Checking and Update Suppression).
 
 13. Use descriptive variable names, never abbreviated.
 

--- a/website/static/skills/storm-repository-java.md
+++ b/website/static/skills/storm-repository-java.md
@@ -270,6 +270,69 @@ List<User> found = users.findAllById(List.of(1, 2, 3));
 List<User> found = users.findAllByRef(List.of(ref1, ref2));
 ```
 
+## Dirty Checking and Update Suppression
+
+Inside a transaction, Storm observes entity state as it reads and compares against that observed
+state when `update()` is called. The observed state lives in the transaction context, never on the
+entity, and is discarded at commit. For an entity read in the same transaction:
+
+- **Nothing changed → no SQL at all.** `users.update(user)` with an unmodified instance executes no
+  statement. Read-modify-write code can pass entities back unconditionally and let Storm drop the
+  no-ops.
+- **Anything changed → full-row UPDATE** (default `ENTITY` mode): one stable SQL shape per entity,
+  which keeps JDBC batching effective.
+
+Suppression needs the observed state to be available: it applies inside a transaction, to entities
+read in that same transaction, through entity-repository updates. In every other case — outside a
+transaction, an entity constructed rather than read, observed state no longer available — Storm
+falls back to a full-row UPDATE. The fallback costs a redundant write, never a wrong one: treat the
+skipped UPDATE as an optimization, not a guarantee. Joined-inheritance entities
+(`@Polymorphic(JOINED)` hierarchies) are the exception: their multi-table updates always write and
+are not dirty-checked.
+
+**Delete-and-reinsert and dirty checking are mutually exclusive.** Inserts are never dirty-checked,
+and freshly constructed rows carry no observed state, so a write path that clears rows and
+re-inserts the desired set writes every row every time. The dirty-checking-native shape for "make
+the table match this desired state" keeps the instances that were read: update the full set and let
+Storm suppress the unchanged rows, reserving `insert`/`remove` (or a write set) for actual
+additions and removals. Batch updates apply this per entity — clean entities are dropped from the
+batch and only dirty ones are written.
+
+What a dirty entity writes is the update mode — `@DynamicUpdate` on the entity
+(/storm-entity-java) or `storm.update.default_mode` globally:
+
+- `ENTITY` (default): any change writes the full row; no change writes nothing.
+- `FIELD`: only the changed columns are written (plus the `@Version` column when present). Narrower
+  writes, but every distinct combination of changed columns is its own SQL shape: batches split per
+  shape, and after `storm.update.max_shapes` distinct shapes (default 5) Storm falls back to
+  full-row updates to preserve batching.
+- `OFF`: no comparison; always write all columns. Predictable unconditional writes for batch/ETL
+  paths.
+
+How a field is compared is a separate axis — `@DynamicUpdate(dirtyCheck = ...)` per entity or
+`storm.update.dirty_check` globally. `INSTANCE` (default) marks a field dirty when its reference
+changed; rebuilding a record (Lombok `toBuilder()` or a constructor call) passes the untouched
+components through by reference, so unchanged fields compare clean at pointer cost. `VALUE`
+compares with `equals()` and differs only when code rebuilds equal values in new instances, e.g.
+mapping the same data back from a form or DTO.
+
+**Foreign keys compare by id, not by content.** The dirty check follows the column. Under `VALUE`,
+an `@FK` field compares the referenced entity's primary key only (the generated metamodel compares
+`city().id()` on both sides): a referenced `City` whose own fields changed does not make the
+referencing `User` dirty, because the `city_id` column is unchanged — and updating the `User` would
+not write the `City`'s fields anyway. To persist changes inside a referenced entity, update that
+entity. Under `INSTANCE`, substituting a different instance with the same id marks the FK column
+dirty and costs a redundant write of the same value. `Ref<T>` fields compare by the id the ref
+carries.
+
+Dirty checking decides what to write; it does not detect concurrent writers. Lost-update protection
+is `@Version` (optimistic locking), unchanged by any of the above.
+
+Bulk mutations bypass dirty checking, and Storm invalidates observed state so later comparisons
+stay truthful: a mutation with a known entity type (`delete(...)` builders, template mutations
+naming the type) clears the observed state of that type; a raw SQL mutation clears all observed
+state in the transaction. Updates after such a mutation fall back to full-row writes.
+
 ## Write Sets (Mixed-Type Graphs)
 
 Apply one write operation to entities of multiple types. Storm orders the writes by foreign-key

--- a/website/static/skills/storm-repository-kotlin.md
+++ b/website/static/skills/storm-repository-kotlin.md
@@ -375,6 +375,68 @@ users.upsert(listOf(user1, user2))
 val upserted: List<User> = users.upsertAndFetch(listOf(user1, user2))
 ```
 
+## Dirty Checking and Update Suppression
+
+Inside a transaction, Storm observes entity state as it reads and compares against that observed
+state when `update()` is called. The observed state lives in the transaction context, never on the
+entity, and is discarded at commit. For an entity read in the same transaction:
+
+- **Nothing changed → no SQL at all.** `orm update user` with an unmodified instance executes no
+  statement. Read-modify-write code can pass entities back unconditionally and let Storm drop the
+  no-ops.
+- **Anything changed → full-row UPDATE** (default `ENTITY` mode): one stable SQL shape per entity,
+  which keeps JDBC batching effective.
+
+Suppression needs the observed state to be available: it applies inside a transaction, to entities
+read in that same transaction, through entity-repository updates. In every other case — outside a
+transaction, an entity constructed rather than read, observed state no longer available — Storm
+falls back to a full-row UPDATE. The fallback costs a redundant write, never a wrong one: treat the
+skipped UPDATE as an optimization, not a guarantee. Joined-inheritance entities
+(`@Polymorphic(JOINED)` hierarchies) are the exception: their multi-table updates always write and
+are not dirty-checked.
+
+**Delete-and-reinsert and dirty checking are mutually exclusive.** Inserts are never dirty-checked,
+and freshly constructed rows carry no observed state, so a write path that clears rows and
+re-inserts the desired set writes every row every time. The dirty-checking-native shape for "make
+the table match this desired state" keeps the instances that were read: update the full set and let
+Storm suppress the unchanged rows, reserving `insert`/`remove` (or a write set) for actual
+additions and removals. Batch updates apply this per entity — clean entities are dropped from the
+batch and only dirty ones are written.
+
+What a dirty entity writes is the update mode — `@DynamicUpdate` on the entity
+(/storm-entity-kotlin) or `storm.update.default_mode` globally:
+
+- `ENTITY` (default): any change writes the full row; no change writes nothing.
+- `FIELD`: only the changed columns are written (plus the `@Version` column when present). Narrower
+  writes, but every distinct combination of changed columns is its own SQL shape: batches split per
+  shape, and after `storm.update.max_shapes` distinct shapes (default 5) Storm falls back to
+  full-row updates to preserve batching.
+- `OFF`: no comparison; always write all columns. Predictable unconditional writes for batch/ETL
+  paths.
+
+How a field is compared is a separate axis — `@DynamicUpdate(dirtyCheck = ...)` per entity or
+`storm.update.dirty_check` globally. `INSTANCE` (default) marks a field dirty when its reference
+changed; `copy()` reuses the references of untouched fields, so unchanged fields compare clean at
+pointer cost. `VALUE` compares with `equals()` and differs only when code rebuilds equal values in
+new instances, e.g. mapping the same data back from a form or DTO.
+
+**Foreign keys compare by id, not by content.** The dirty check follows the column. Under `VALUE`,
+an `@FK` field compares the referenced entity's primary key only (the generated metamodel emits
+`a.city.id == b.city.id`): a referenced `City` whose own fields changed does not make the
+referencing `User` dirty, because the `city_id` column is unchanged — and updating the `User` would
+not write the `City`'s fields anyway. To persist changes inside a referenced entity, update that
+entity. Under `INSTANCE`, substituting a different instance with the same id marks the FK column
+dirty and costs a redundant write of the same value. `Ref<T>` fields compare by the id the ref
+carries.
+
+Dirty checking decides what to write; it does not detect concurrent writers. Lost-update protection
+is `@Version` (optimistic locking), unchanged by any of the above.
+
+Bulk mutations bypass dirty checking, and Storm invalidates observed state so later comparisons
+stay truthful: a mutation with a known entity type (`delete(...)` builders, template mutations
+naming the type) clears the observed state of that type; a raw SQL mutation clears all observed
+state in the transaction. Updates after such a mutation fall back to full-row writes.
+
 ## Write Sets (Mixed-Type Graphs)
 
 Apply one write operation to entities of multiple types. Storm orders the writes by foreign-key

--- a/website/static/skills/storm-sql-java.md
+++ b/website/static/skills/storm-sql-java.md
@@ -37,6 +37,13 @@ Even in full SQL templates, users still benefit from bind variables (`\{value}`)
 - Pagination, scrolling — use `page()`, `scroll()`
 - Simple CRUD — use `findBy`, `findAll`, `remove`, `removeAll`, `insert`, `update`
 
+**Mutations bypass dirty checking.** Entity updates through repositories compare against the
+transaction's observed state and can skip or narrow the UPDATE; template and raw SQL mutations
+write unconditionally. To keep later comparisons truthful, a template mutation whose entity type is
+known invalidates the observed state of that type, and a raw SQL string without type information
+clears all observed state in the transaction — repository updates after it fall back to full-row
+writes. Prefer entity updates for row-level changes; keep templates for set-based mutations.
+
 **Inside SQL templates, always use metamodel references** (`\{User_.email}`, `\{City_.id}`) instead of hardcoding column names. This keeps queries type-safe and refactor-proof. Only use `\{unsafe("raw sql")}` when there is truly no metamodel equivalent.
 
 **FK path references:** Use `\{User_.city.country}` (resolves to the FK column, e.g., `country_id`) rather than `\{User_.city.country.id}` (resolves to the PK column on the joined table). The shorter form is preferred — it references the FK directly without requiring a join.

--- a/website/static/skills/storm-sql-kotlin.md
+++ b/website/static/skills/storm-sql-kotlin.md
@@ -37,6 +37,13 @@ Even in full SQL templates, users still benefit from bind variables (`$value`) a
 - Pagination, scrolling — use `page()`, `scroll()`
 - Simple CRUD — use `find`, `findAll`, `remove`, `removeAll`, `insert`, `update`
 
+**Mutations bypass dirty checking.** Entity updates through repositories compare against the
+transaction's observed state and can skip or narrow the UPDATE; template and raw SQL mutations
+write unconditionally. To keep later comparisons truthful, a template mutation whose entity type is
+known invalidates the observed state of that type, and a raw SQL string without type information
+clears all observed state in the transaction — repository updates after it fall back to full-row
+writes. Prefer entity updates for row-level changes; keep templates for set-based mutations.
+
 **Inside SQL templates, always use metamodel references** (`${User_.email}`, `${City_.id}`) instead of hardcoding column names. This keeps queries type-safe and refactor-proof. Only use `${unsafe("raw sql")}` when there is truly no metamodel equivalent.
 
 **FK path references:** Use `${User_.city.country}` (resolves to the FK column, e.g., `country_id`) rather than `${User_.city.country.id}` (resolves to the PK column on the joined table). The shorter form is preferred — it references the FK directly without requiring a join.


### PR DESCRIPTION
Dirty checking was effectively undocumented in the skills: the bundle mentioned it twice in passing ("zero-overhead dirty checking" in storm-docs, the transaction's entity cache in the SQL log summary) without ever explaining that `update()` compares against observed state, suppresses no-op writes, or partitions batches by update shape.

## Skills

- **storm-repository-kotlin / storm-repository-java**: new "Dirty Checking and Update Suppression" section covering suppression semantics and their conditions, the delete-and-reinsert mutual exclusion, the three update modes and both dirty-check strategies, the foreign-key comparison rule, the joined-inheritance exception, and observed-state invalidation by bulk mutations.
- **storm-entity-kotlin / storm-entity-java**: `@DynamicUpdate` in the annotation list and an update-tuning rule beside the persistence rules, pointing to the repository skill for semantics.
- **storm-sql-kotlin / storm-sql-java**: template and raw SQL mutations bypass dirty checking and invalidate observed state (per type when the entity type is known, all types for raw SQL).

## Docs (`docs/dirty-checking.md`)

- New "Foreign Keys Compare by Id" subsection: dirty checking follows the column, and under value-based checking the referenced entity is compared by primary key only.
- New best practice "Update in Place, Don't Delete-and-Reinsert".
- New important note "Joined Table Inheritance Always Writes".
- ENTITY mode characteristics now mention that unchanged entities are dropped from batch updates.
- Corrected "How It Works" under `@DynamicUpdate`: the annotation is resolved once at repository initialization; neither metamodel processor encodes it. The generated metamodel's contribution is the type-specific field comparisons.
- Corrected the instance-based checking example: `user.copy(name = user.name)` passes the same reference and cannot produce a false positive; the example now uses values rebuilt from a form/DTO.

## Javadoc

`Column.metamodel()` (storm-core and storm-java21) described the FK metamodel as living "on the parent entity"; in database terminology the referenced table is the parent, which puts the column on the wrong side of the sentence. It now reads "on the referencing entity, the entity that declares the foreign key field", and the core variant cross-links `secondaryMetamodel()`.

All claims were verified against `DirtySupport.getDirty`, `EntityRepositoryImpl.update(Stream, int)`, the generated metamodel equality from both processors (`isSame` compares primary keys for entity-typed fields, confirmed in KSP output), `QueryImpl.invalidateAffectedEntityCaches()`, and `EntityCacheImpl`.

The `docs/` change shows at `/docs/next` and reaches the live docs with the next release snapshot.

Two points are deliberately left open and asserted nowhere in this PR: whether to recommend `UpdateMode.FIELD` at all (the existing docs recommend it for wide tables; it fragments batching and does not reduce binlog volume under full row images), and whether the reclaim-under-pressure caveat of `CacheRetention.DEFAULT` should be surfaced to callers.