### PR TITLE
ci: upload coverage to Codecov by token and fail the build on upload errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
     branches: [ main ]
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -45,6 +44,6 @@ jobs:
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v5
         with:
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
-          fail_ci_if_error: false
+          fail_ci_if_error: true


### PR DESCRIPTION
Codecov has ingested nothing since 2026-03-22. The org rename (`storm-repo` → `storm-orm`) left Codecov's OIDC ingest unable to resolve the repository — every upload since then was rejected with `{"message":"Repository not found"}` — while `fail_ci_if_error: false` kept the step green, so the badge and the project/patch status checks have been reporting a codebase four months gone.

The dashboard record, the read API, and the GitHub App installation are all intact; only the OIDC claims-based lookup is broken, and a Codecov resync does not repair it. Token-based uploads resolve the repository correctly (verified with a `create-commit` probe against current `main`, the first successful ingest since March).

- The upload step authenticates with the `CODECOV_TOKEN` secret (already configured) instead of OIDC, and the unused `id-token: write` permission is gone.
- `fail_ci_if_error: true` passes `--fail-on-error` to the codecov CLI, so a rejected upload fails the build instead of logging an error into a green step. Fork PRs are unaffected: the step's guard already skips them.

The CI run on this PR is the end-to-end test: it exercises the token upload with fail-on-error live.

Fixes #381