### PR TITLE
refactor!: qualify the impl-package exports and move SqlLog's rendering internals out of the public class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ A join widens the query: from the join onward, every clause accepts paths from a
 - Renamed `typed(pkType)` to `typedId(pkType)` — it types the erased primary-key parameter, while `narrow` types the root — and added its missing null check.
 - `fetch(...)` comes right after `select()`, before any join, enforced at compile time: resolving references is defined relative to the root, and a join widens the builder past it.
 - Kotlin's `select { }` block is widened from the start — joined-entity fields use the plain calls with no escalation — and returns the widened builder, so joins made inside the block stay queryable in chained continuations. Record, id and ref matching remain typed to the entity inside the block.
+- The `st.orm.core.template.impl` and `st.orm.core.repository.impl` packages are exported to Storm's own modules only, stating in the module descriptor that their types were never API. On the class path nothing changes; an application on the module path that reached into them no longer compiles.
+- `SqlLog` carries the diagnostics API only: summary rendering and hydration-shape analysis live in `SqlLogRenderer`, call-site capture in `CallSiteCapture`, both internal. The display setters moved with them — how summaries render is configured, not programmed: the `storm.sql_log.*` system properties, or the corresponding Spring and Ktor keys.
 
 ## [1.13.1] - 2026-08-07
 

--- a/storm-core/src/main/java/module-info.java
+++ b/storm-core/src/main/java/module-info.java
@@ -11,10 +11,34 @@ module storm.core {
     uses st.orm.core.spi.CursorCodecProvider;
     uses st.orm.mapping.Instantiator;
     exports st.orm.core.template;
-    exports st.orm.core.template.impl;
+    // The impl packages are reachable by Storm's own modules only; to everyone else they are not API.
+    exports st.orm.core.template.impl to
+            storm.foundation,
+            storm.h2,
+            storm.jackson2,
+            storm.jackson3,
+            storm.java,
+            storm.kotlin,
+            storm.ktor,
+            storm.mariadb,
+            storm.mssqlserver,
+            storm.mysql,
+            storm.oracle,
+            storm.postgresql,
+            storm.spring,
+            storm.sqlite,
+            storm.test;
     exports st.orm.core.spi;
     exports st.orm.core.repository;
-    exports st.orm.core.repository.impl;
+    exports st.orm.core.repository.impl to
+            storm.h2,
+            storm.kotlin,
+            storm.mariadb,
+            storm.mssqlserver,
+            storm.mysql,
+            storm.oracle,
+            storm.postgresql,
+            storm.sqlite;
     requires java.management;
     requires java.sql;
     requires static jakarta.persistence;

--- a/storm-core/src/main/java/st/orm/core/template/SqlLog.java
+++ b/storm-core/src/main/java/st/orm/core/template/SqlLog.java
@@ -17,14 +17,9 @@ package st.orm.core.template;
 
 import static java.util.Comparator.comparingLong;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static st.orm.core.spi.StormConfigHelper.getEnum;
-import static st.orm.core.spi.StormConfigHelper.getInt;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,10 +33,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import st.orm.Data;
 import st.orm.PersistenceException;
-import st.orm.StormConfig;
 import st.orm.core.spi.QueryContext;
 import st.orm.core.template.SqlTemplate.Parameter;
+import st.orm.core.template.impl.CallSiteCapture;
 import st.orm.core.template.impl.SqlInterceptorManager;
+import st.orm.core.template.impl.SqlLogRenderer;
 import st.orm.core.template.impl.StatementListener;
 
 /**
@@ -60,6 +56,11 @@ import st.orm.core.template.impl.StatementListener;
  *
  * <p>A scope is bound to the thread that opened it, so it records the statements of a blocking call. Statements
  * issued after a suspension that resumed on another thread fall outside it.</p>
+ *
+ * <p>How summaries render — hydration shapes, line width, call-site skips — is a property of the deployment,
+ * configured rather than programmed: the {@code storm.sql_log.hydration}, {@code storm.sql_log.line_width} and
+ * {@code storm.sql_log.call_site_skip} system properties on a plain JVM, or the corresponding keys of the Spring
+ * and Ktor integrations.</p>
  *
  * @since 1.13
  */
@@ -243,7 +244,7 @@ public final class SqlLog {
         /**
          * Returns the recorded statements grouped by their text, heaviest first, which is the view that answers
          * where the time went: a statement run many times cheaply outranks one slow statement when it cost more in
-         * total. When {@link #hydrationShapes(HydrationShapes)} enables shapes, each read's line carries the
+         * total. When hydration shapes are enabled ({@code storm.sql_log.hydration}), each read's line carries the
          * declared hydration shape of its type in the configured form.
          *
          * @return one line per distinct statement, ordered by total time.
@@ -271,7 +272,7 @@ public final class SqlLog {
                             group.texts.size(), group.durationNanos,
                             group.sites.isEmpty() ? null : group.sites.iterator().next(), group.sites.size(),
                             group.rows, group.exactRows,
-                            hydrationOf(group, hydrationShapes)))
+                            SqlLogRenderer.hydrationOf(group.operation, group.dataType)))
                     .sorted(comparingLong(StatementLine::durationNanos).reversed())
                     .toList();
         }
@@ -305,51 +306,7 @@ public final class SqlLog {
          * @return the rendered summary, followed by the full statements.
          */
         public String toDetailedString() {
-            var rendered = new StringBuilder(render(name, recorded, count(StatementOrigin.FETCH), cacheHits,
-                    NANOSECONDS.toMillis(databaseNanos()), NANOSECONDS.toMillis(databaseElapsedNanos()),
-                    peakConcurrency(), NANOSECONDS.toMillis(durationNanos), byStatement(),
-                    recorded - statements.size()));
-            var lines = byStatement();
-            if (!lines.isEmpty()) {
-                rendered.append(String.format("%n\tstatements:"));
-            }
-            for (var line : lines) {
-                rendered.append(String.format("%n\t  ")).append(flatten(line.statement()));
-            }
-            return rendered.toString();
-        }
-
-        /**
-         * Returns the rendered hydration shape of the group's type in the configured form, or {@code null} when
-         * shapes are off, the group is not a read, or its type has none.
-         */
-        @Nullable
-        private static String hydrationOf(@Nonnull Group group, @Nonnull HydrationShapes shapes) {
-            if (shapes == HydrationShapes.OFF) {
-                return null;
-            }
-            if (group.operation != SqlOperation.SELECT) {
-                // The shape states what reading the type joins and maps. A write touches its own table only, so
-                // the shape would describe a graph its statement never traverses and columns it never sets; a
-                // statement whose operation is undetermined cannot claim to be a read either.
-                return null;
-            }
-            if (group.dataType == null) {
-                return null;
-            }
-            var shape = HYDRATION.get(group.dataType);
-            if (shape == NO_HYDRATION) {
-                return null;
-            }
-            if (shapes == HydrationShapes.FULL) {
-                return "joins=%d columns=%d graph=%s".formatted(shape.joins(), shape.columns(), shape.graph());
-            }
-            if (shape.joins() == 0) {
-                // A flat type says nothing its row does not already say; the short token appears when hydration
-                // reaches beyond the statement's own table.
-                return null;
-            }
-            return "j%d c%d d%d".formatted(shape.joins(), shape.columns(), shape.depth());
+            return SqlLogRenderer.renderDetailed(this);
         }
 
         /**
@@ -357,10 +314,7 @@ public final class SqlLog {
          */
         @Override
         public String toString() {
-            return render(name, recorded, count(StatementOrigin.FETCH), cacheHits,
-                    NANOSECONDS.toMillis(databaseNanos()), NANOSECONDS.toMillis(databaseElapsedNanos()),
-                    peakConcurrency(), NANOSECONDS.toMillis(durationNanos), byStatement(),
-                    recorded - statements.size());
+            return SqlLogRenderer.render(this);
         }
     }
 
@@ -420,220 +374,6 @@ public final class SqlLog {
 
         /** Every mapped read ends with the full shape, {@code joins=2 columns=12 graph=Pet(Owner(City))}. */
         FULL
-    }
-
-    /**
-     * How shapes render, a property of the log viewer rather than of any scope: derived at rendering and cached
-     * per type, the setting costs nothing while calls run. Set once at startup; read at rendering only.
-     */
-    private static volatile HydrationShapes hydrationShapes = HydrationShapes.OFF;
-
-    /**
-     * Sets how a read's summary row renders the declared hydration shape of its type. Off by default; intended to
-     * be called once at startup.
-     *
-     * @param shapes how shapes render.
-     */
-    public static void hydrationShapes(@Nonnull HydrationShapes shapes) {
-        hydrationShapes = requireNonNull(shapes, "shapes");
-    }
-
-    /**
-     * Width a summary row aims for, a property of the log viewer rather than of any scope. The statement text
-     * receives what the row's other columns leave, down to a floor that keeps it identifiable. Set once at
-     * startup; read at rendering only.
-     */
-    private static volatile int lineWidth = 200;
-
-    /** The least statement text a row keeps, whatever its other columns consume. */
-    private static final int MIN_STATEMENT_WIDTH = 40;
-
-    /**
-     * Sets the width summary rows aim for, such as {@code 120} for narrow viewers or {@code 240} for wide
-     * ones. The statement text elides to what the row's other columns leave. Intended to be called once at
-     * startup.
-     *
-     * @param width the display width; at least 80.
-     */
-    public static void lineWidth(int width) {
-        lineWidth = Math.max(80, width);
-    }
-
-    /**
-     * Renders a summary as a headline plus a line per distinct statement, heaviest first.
-     *
-     * <p>The headline separates the time the database spent from the time the call took, so a call that is slow for
-     * other reasons says so. Under a fan-out the summed database time exceeds the elapsed time, and their ratio is
-     * the concurrency the work achieved.</p>
-     *
-     * <p>Statements that ran past the recording limit are counted but not retained, so they contribute no duration
-     * and no row. The database times are then lower bounds and are marked {@code +}, and a closing line reports how
-     * many statements went unrecorded. The statement count and the call's own duration stay exact.</p>
-     *
-     * @param name what the scope covered.
-     * @param statementCount the statements the call executed.
-     * @param fetchCount how many of those resolved a reference.
-     * @param cacheHits the reads the transaction's entity cache served without a statement.
-     * @param databaseMillis the summed duration of the recorded statements.
-     * @param databaseElapsedMillis the time during which at least one recorded statement was in flight.
-     * @param peakConcurrency the greatest number of recorded statements in flight at once.
-     * @param totalMillis how long the call took.
-     * @param byStatement one line per distinct statement, in any order.
-     * @param notRecorded how many statements ran past the recording limit.
-     * @return the rendered summary.
-     */
-    public static String render(@Nonnull String name,
-                                int statementCount,
-                                int fetchCount,
-                                int cacheHits,
-                                long databaseMillis,
-                                long databaseElapsedMillis,
-                                int peakConcurrency,
-                                long totalMillis,
-                                @Nonnull List<StatementLine> byStatement,
-                                int notRecorded) {
-        var rendered = new StringBuilder("SQL (%s): %s".formatted(name, statements(statementCount)));
-        if (fetchCount > 0) {
-            rendered.append(", ").append(fetches(fetchCount));
-        }
-        if (cacheHits > 0) {
-            rendered.append(", %d from cache".formatted(cacheHits));
-        }
-        // Statements past the recording limit contribute no duration, so the database times cover the recorded
-        // ones only; mark them as lower bounds rather than let a truncated summary understate its own cost.
-        var bound = notRecorded > 0 ? "+" : "";
-        rendered.append(", %d%s ms in database".formatted(databaseMillis, bound));
-        // Concurrency is a count of simultaneous executions, reported only when the work overlapped: summed
-        // database time then exceeds the elapsed time it was compressed into, so both appear.
-        if (peakConcurrency > 1) {
-            rendered.append(" over %d%s ms elapsed (peak %d concurrent)".formatted(
-                    databaseElapsedMillis, bound, peakConcurrency));
-        }
-        rendered.append(", %d ms total".formatted(totalMillis));
-        int width = byStatement.stream()
-                .mapToInt(line -> String.valueOf(NANOSECONDS.toMillis(line.durationNanos())).length())
-                .max()
-                .orElse(1);
-        int executionWidth = byStatement.stream()
-                .mapToInt(line -> String.valueOf(line.executions()).length())
-                .max()
-                .orElse(1);
-        int typeWidth = byStatement.stream()
-                .mapToInt(line -> line.dataType().length())
-                .max()
-                .orElse(1);
-        int rowsWidth = byStatement.stream()
-                .mapToInt(line -> rowsLabel(line).length())
-                .max()
-                .orElse(1);
-        // The identifying columns align and lead; the free-form statement text comes last, where raggedness
-        // does not break the columns after it. The fetch and call-site columns appear only when any row has one.
-        boolean anyFetch = byStatement.stream().anyMatch(StatementLine::fetch);
-        int siteWidth = byStatement.stream()
-                .mapToInt(line -> siteLabel(line).length())
-                .max()
-                .orElse(0);
-        // The row aims for the configured line width: the statement text receives what the fixed columns and
-        // the row's own suffixes leave, down to a floor that keeps it identifiable.
-        int prefixWidth = width + 5 + executionWidth + 3 + rowsWidth + 6 + typeWidth + 2
-                + (anyFetch ? 7 : 0) + (siteWidth > 0 ? siteWidth + 2 : 0);
-        // Ordering is presentation, so the renderer owns it rather than trusting the order it was handed.
-        for (var line : byStatement.stream()
-                .sorted(comparingLong(StatementLine::durationNanos).reversed())
-                .toList()) {
-            rendered.append(String.format(
-                    "%n\t%" + width + "d ms  %" + rowsWidth + "s rows  %" + executionWidth + "dx  %-" + typeWidth + "s",
-                    NANOSECONDS.toMillis(line.durationNanos()),
-                    rowsLabel(line),
-                    line.executions(),
-                    line.dataType()));
-            if (anyFetch) {
-                rendered.append(String.format("  %-5s", line.fetch() ? "fetch" : ""));
-            }
-            if (siteWidth > 0) {
-                rendered.append(String.format("  %-" + siteWidth + "s", siteLabel(line)));
-            }
-            int suffixWidth = (line.variants() > 1 ? 12 + String.valueOf(line.variants()).length() : 0)
-                    + (line.hydration() != null ? 2 + line.hydration().length() : 0);
-            int statementBudget = Math.max(MIN_STATEMENT_WIDTH, lineWidth - prefixWidth - suffixWidth);
-            rendered.append("  ").append(elide(line.statement(), statementBudget));
-            if (line.variants() > 1) {
-                rendered.append(" (%d variants)".formatted(line.variants()));
-            }
-            if (line.hydration() != null) {
-                rendered.append("  ").append(line.hydration());
-            }
-        }
-        if (notRecorded > 0) {
-            rendered.append("%n\t(%s not recorded)".formatted(statements(notRecorded)));
-        }
-        return rendered.toString();
-    }
-
-    /** Returns the row-count column content: the count, marked {@code *} when it is a lower bound. */
-    private static String rowsLabel(@Nonnull StatementLine line) {
-        return line.exactRows() ? String.valueOf(line.rows()) : line.rows() + "*";
-    }
-
-    /** Returns the call-site column content for the line, empty when the scope recorded none. */
-    private static String siteLabel(@Nonnull StatementLine line) {
-        if (line.callSite() == null) {
-            return "";
-        }
-        return line.sites() > 1
-                ? "%s (+%d sites)".formatted(line.callSite(), line.sites() - 1)
-                : line.callSite();
-    }
-
-    /**
-     * Returns the statement on one line, elided from the middle so a summary stays scannable: the head names the
-     * operation and columns, the tail carries the FROM and WHERE clauses that identify what the statement does.
-     */
-    private static String elide(@Nonnull String statement, int width) {
-        // A run of placeholders says nothing its length does not; collapsing it leaves the elision budget to
-        // the clauses that identify the statement. Display only: the detailed rendering keeps the exact text.
-        String flattened = flatten(statement).replaceAll("\\?(?:, \\?){3,}", "?, \u2026, ?");
-        if (flattened.length() <= width) {
-            return flattened;
-        }
-        int head = width / 3;
-        int tail = width - head - 1;
-        return flattened.substring(0, head) + "\u2026" + flattened.substring(flattened.length() - tail);
-    }
-
-    /**
-     * Returns the statement on one line, joining it on the line breaks it was rendered with.
-     *
-     * <p>A nested subquery is rendered on lines of its own, which leaves its closing parenthesis opening a line.
-     * Joining every break with a space reads that back as {@code WHERE id = ? ) ) x}, so a break between characters
-     * that belong together closes up instead.</p>
-     */
-    private static String flatten(@Nonnull String statement) {
-        var flattened = new StringBuilder();
-        statement.lines()
-                .map(String::strip)
-                .filter(line -> !line.isEmpty())
-                .forEach(line -> {
-                    if (!flattened.isEmpty()
-                            && separated(flattened.charAt(flattened.length() - 1), line.charAt(0))) {
-                        flattened.append(' ');
-                    }
-                    flattened.append(line);
-                });
-        return flattened.toString();
-    }
-
-    /** Returns whether a line break between the two characters reads as a space rather than as nothing at all. */
-    private static boolean separated(char before, char after) {
-        return before != '(' && after != ')' && after != ',';
-    }
-
-    private static String statements(int count) {
-        return "%d statement%s".formatted(count, count == 1 ? "" : "s");
-    }
-
-    private static String fetches(int count) {
-        return "%d fetch%s".formatted(count, count == 1 ? "" : "es");
     }
 
     /** Statements recorded per scope before recording stops, keeping a runaway call from retaining the lot. */
@@ -894,7 +634,7 @@ public final class SqlLog {
             if (recorded.incrementAndGet() > limit) {
                 return Handle.NOOP;
             }
-            var callSite = callSites ? callSite() : null;
+            var callSite = callSites ? CallSiteCapture.callSite() : null;
             long start = System.nanoTime();
             var operation = context.operation();
             var dataType = context.dataType().orElse(null);
@@ -914,291 +654,5 @@ public final class SqlLog {
         public void onCacheHit(@Nonnull Class<? extends Data> dataType, int count) {
             cacheHits.addAndGet(count);
         }
-    }
-
-    /**
-     * The declared hydration shape of a type: what an eager read of it joins and maps.
-     *
-     * <p>Derived from the type declaration, not from any statement: an entity component is a join edge and
-     * recurses; an inline record is columns on the same table and no subgraph, so a joined entity it carries
-     * splices into its parent's children; a reference is its foreign key column and stops, which is exactly the
-     * width a {@code Ref} declaration saves. Computed once per type, at display time.</p>
-     *
-     * @param joins the join edges an eager read of the type takes.
-     * @param columns the columns it maps.
-     * @param depth the entity levels along the deepest chain: {@code 1} for a flat entity, {@code 3} for
-     *              {@code Pet(Owner(City))}.
-     * @param graph the joined-entity tree, such as {@code Pet(PetType, Owner(City))}.
-     */
-    record Hydration(int joins, int columns, int depth, @Nonnull String graph) {
-    }
-
-    /** Marks a type without a mapped record structure, for which no shape renders. */
-    private static final Hydration NO_HYDRATION = new Hydration(0, 0, 0, "");
-
-    private static final ClassValue<Hydration> HYDRATION = new ClassValue<>() {
-        @Override
-        protected Hydration computeValue(@Nonnull Class<?> type) {
-            // The reflection provider recognizes the mapped structure of Java records and Kotlin data classes
-            // alike, which is the same bridge the model itself is built over.
-            if (st.orm.core.spi.Providers.getORMReflection().findRecordType(type).isEmpty()) {
-                return NO_HYDRATION;
-            }
-            var shape = shape(type, new java.util.HashSet<>());
-            String graph = type.getSimpleName()
-                    + (shape.children().isEmpty() ? "" : "(" + shape.children() + ")");
-            return new Hydration(shape.joins(), shape.columns(), 1 + shape.depth(), graph);
-        }
-    };
-
-    /**
-     * The shape of one type level: its joins and columns, the entity levels below it, and its joined children
-     * rendered as a list.
-     */
-    private record Shape(int joins, int columns, int depth, @Nonnull String children) {
-    }
-
-    private static Shape shape(@Nonnull Class<?> type, @Nonnull java.util.Set<Class<?>> path) {
-        if (!path.add(type)) {
-            // A cycle recurses no further; the revisited entity contributes its foreign key column.
-            return new Shape(0, 1, 0, "");
-        }
-        try {
-            var reflection = st.orm.core.spi.Providers.getORMReflection();
-            var recordType = reflection.findRecordType(type).orElse(null);
-            if (recordType == null) {
-                return new Shape(0, 1, 0, "");
-            }
-            int joins = 0;
-            int columns = 0;
-            int depth = 0;
-            var children = new StringBuilder();
-            for (var field : recordType.fields()) {
-                Class<?> fieldType = field.type();
-                if (st.orm.Ref.class.isAssignableFrom(fieldType)) {
-                    // The foreign key column; a reference does not widen the read.
-                    columns++;
-                } else if (st.orm.Entity.class.isAssignableFrom(fieldType)) {
-                    var child = shape(fieldType, path);
-                    joins += 1 + child.joins();
-                    columns += child.columns();
-                    depth = Math.max(depth, 1 + child.depth());
-                    if (!children.isEmpty()) {
-                        children.append(", ");
-                    }
-                    children.append(fieldType.getSimpleName());
-                    if (!child.children().isEmpty()) {
-                        children.append('(').append(child.children()).append(')');
-                    }
-                } else if (reflection.findRecordType(fieldType).isPresent()) {
-                    // Any other mapped record structure is an inline record: columns on this table, not a
-                    // subgraph; entities it joins splice up.
-                    // An inline record is not a level of its own, so an entity it joins counts at this level.
-                    var inline = shape(fieldType, path);
-                    joins += inline.joins();
-                    columns += inline.columns();
-                    depth = Math.max(depth, inline.depth());
-                    if (!inline.children().isEmpty()) {
-                        if (!children.isEmpty()) {
-                            children.append(", ");
-                        }
-                        children.append(inline.children());
-                    }
-                } else {
-                    columns++;
-                }
-            }
-            return new Shape(joins, columns, depth, children.toString());
-        } finally {
-            path.remove(type);
-        }
-    }
-
-    private static final StackWalker CALL_SITE_WALKER = StackWalker.getInstance();
-
-    /**
-     * The launch-site fallback for executions whose stack no longer contains the caller, such as work resumed
-     * on a coroutine dispatcher. Bound by integrations that carry a scope onto another thread, alongside the
-     * scope itself.
-     */
-    private static final ThreadLocal<String> CALL_SITE_HINT = new ThreadLocal<>();
-
-    /**
-     * Returns the thread local carrying the launch-site fallback for executions whose stack no longer contains
-     * the caller.
-     *
-     * <p>Intended for integrations that carry a scope onto another thread, such as coroutine context elements,
-     * which bind it alongside the scope. Application code should not modify it.</p>
-     *
-     * @return the thread local holding the current launch site.
-     */
-    public static ThreadLocal<String> callSiteHint() {
-        return CALL_SITE_HINT;
-    }
-
-    /**
-     * Returns the application frame launching work, for an integration to carry as the call-site fallback of a
-     * scope that records call sites.
-     *
-     * <p>At the moment work is launched, the caller is still on the stack; on the thread the work resumes on,
-     * it no longer is. Carrying what this returns, bound through {@link #callSiteHint()}, is what lets a
-     * statement whose stack is plumbing end to end name the frame that launched the work. When the launch
-     * itself has no application frame on its stack, the fallback already carried is returned, so chained
-     * launches preserve the original caller.</p>
-     *
-     * <p>Costs a stack walk; callers gate on whether an observing scope records call sites.</p>
-     *
-     * @return the launching application frame, or {@code null} when there is none to carry.
-     */
-    @Nullable
-    public static String captureCallSite() {
-        var walked = walkFrames();
-        return walked.application() != null ? walked.application() : CALL_SITE_HINT.get();
-    }
-
-    /**
-     * Returns the application frame that caused the execution: the innermost frame that is neither framework
-     * infrastructure nor declared plumbing, as {@code File.ext:line}.
-     *
-     * <p>When every application frame on the stack is declared plumbing, the carried launch site is returned
-     * when one is bound, since it names the caller the stack lost; the innermost plumbing frame otherwise, as a
-     * plumbing site still says more than none.</p>
-     */
-    @Nullable
-    private static String callSite() {
-        var walked = walkFrames();
-        if (walked.application() != null) {
-            return walked.application();
-        }
-        String hint = CALL_SITE_HINT.get();
-        if (hint != null) {
-            return hint;
-        }
-        return walked.plumbing();
-    }
-
-    /** The two frames a walk can surface: the first application frame, and the innermost plumbing frame. */
-    private record WalkedFrames(@Nullable String application, @Nullable String plumbing) {
-    }
-
-    private static WalkedFrames walkFrames() {
-        return CALL_SITE_WALKER.walk(frames -> {
-            String plumbing = null;
-            for (var iterator = frames.iterator(); iterator.hasNext(); ) {
-                var frame = iterator.next();
-                if (isInfrastructure(frame.getClassName())) {
-                    continue;
-                }
-                if (isDeclaredPlumbing(frame.getClassName(), frame.getFileName())) {
-                    if (plumbing == null) {
-                        plumbing = format(frame);
-                    }
-                    continue;
-                }
-                return new WalkedFrames(format(frame), plumbing);
-            }
-            return new WalkedFrames(null, plumbing);
-        });
-    }
-
-    private static String format(@Nonnull StackWalker.StackFrame frame) {
-        String file = frame.getFileName();
-        return file != null
-                ? "%s:%d".formatted(file, frame.getLineNumber())
-                : "%s.%s".formatted(frame.getClassName(), frame.getMethodName());
-    }
-
-    /**
-     * Returns whether the frame belongs to a package or source file the application declared as plumbing.
-     *
-     * <p>Entries naming a source file match the frame's file, which is what covers inline functions: inlining
-     * regenerates a lambda under the caller's class, where a package prefix cannot see it, while the frame keeps
-     * the declaring file's name.</p>
-     */
-    private static boolean isDeclaredPlumbing(@Nonnull String className, @Nullable String fileName) {
-        for (var entry : ignoredCallSitePrefixes) {
-            if (entry.endsWith(".kt") || entry.endsWith(".java")) {
-                if (entry.equals(fileName)) {
-                    return true;
-                }
-            } else if (className.startsWith(entry)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Package prefixes the application declared as its own database plumbing, so call sites name the code that
-     * asked for the work rather than the layer that carried it. Copy-on-write: registered once at startup, read
-     * on every walk.
-     */
-    private static volatile String[] ignoredCallSitePrefixes = {};
-
-    /**
-     * Declares packages whose frames are skipped when attributing an execution to a call site.
-     *
-     * <p>A database layer of the application's own, such as a wrapper that fans a query out over several
-     * templates, sits between the caller and Storm on every statement; its frames identify the plumbing rather
-     * than the code that asked for the work. Declaring its packages here makes call sites name the caller
-     * beyond it.</p>
-     *
-     * <p>An entry is a package prefix matched against the fully qualified class name, or, when it ends in
-     * {@code .kt} or {@code .java}, a source file name matched against the frame's file. The file form covers
-     * inline functions, whose lambdas are regenerated under the caller's class while keeping the declaring
-     * file's name. When every application frame on a stack is declared plumbing, the innermost plumbing frame is
-     * reported rather than none. Intended to be called once at startup.</p>
-     *
-     * @param packagePrefixes the package prefixes or source file names to skip, such as {@code "com.acme.db"} or
-     *                        {@code "DbExtensions.kt"}.
-     */
-    public static void ignoreCallSites(@Nonnull String... packagePrefixes) {
-        var merged = new ArrayList<>(List.of(ignoredCallSitePrefixes));
-        for (var prefix : packagePrefixes) {
-            merged.add(requireNonNull(prefix, "packagePrefix"));
-        }
-        ignoredCallSitePrefixes = merged.toArray(String[]::new);
-    }
-
-    private static boolean isInfrastructure(@Nonnull String className) {
-        if (className.startsWith("st.orm.")
-                || className.startsWith("java.")
-                || className.startsWith("jdk.")
-                || className.startsWith("sun.")
-                || className.startsWith("kotlin.")
-                || className.startsWith("kotlinx.")
-                || className.startsWith("org.springframework.")
-                || className.startsWith("org.apache.")
-                || className.startsWith("io.ktor.")
-                || className.startsWith("io.netty.")
-                || className.startsWith("org.eclipse.jetty.")) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Applies the display settings from configuration ({@link StormConfig#defaults()}, which reads system
-     * properties). How the log renders is a property of the deployment, so it is configured like one —
-     * {@code storm.sql_log.hydration}, {@code storm.sql_log.line_width}, {@code storm.sql_log.call_site_skip} —
-     * rather than through an API. The Spring and Ktor integrations apply their own configuration through the
-     * setters.
-     */
-    private static void applyConfiguredDisplaySettings() {
-        var config = StormConfig.defaults();
-        hydrationShapes(getEnum(config, StormConfig.SQL_LOG_HYDRATION, HydrationShapes.class, HydrationShapes.OFF));
-        lineWidth(getInt(config, StormConfig.SQL_LOG_LINE_WIDTH, 200));
-        String skip = config.getProperty(StormConfig.SQL_LOG_CALL_SITE_SKIP);
-        if (skip != null) {
-            ignoreCallSites(Arrays.stream(skip.split(","))
-                    .map(String::trim)
-                    .filter(entry -> !entry.isEmpty())
-                    .toArray(String[]::new));
-        }
-    }
-
-    // Placed after every field it touches, since static initialization runs in textual order.
-    static {
-        applyConfiguredDisplaySettings();
     }
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/CallSiteCapture.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/CallSiteCapture.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.template.impl;
+
+import static java.util.Objects.requireNonNull;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import st.orm.StormConfig;
+
+/**
+ * Attributes a statement execution to the application frame that caused it: the innermost frame that is neither
+ * framework infrastructure nor declared plumbing, as {@code File.ext:line}.
+ *
+ * <p>Which frames count as plumbing is a property of the deployment, configured like one: the
+ * {@code storm.sql_log.call_site_skip} system property on a plain JVM, or the corresponding keys of the Spring
+ * and Ktor integrations.</p>
+ *
+ * @since 1.14
+ */
+public final class CallSiteCapture {
+
+    private CallSiteCapture() {
+    }
+
+    private static final StackWalker CALL_SITE_WALKER = StackWalker.getInstance();
+
+    /**
+     * The launch-site fallback for executions whose stack no longer contains the caller, such as work resumed
+     * on a coroutine dispatcher. Bound by integrations that carry a scope onto another thread, alongside the
+     * scope itself.
+     */
+    private static final ThreadLocal<String> CALL_SITE_HINT = new ThreadLocal<>();
+
+    /**
+     * Returns the thread local carrying the launch-site fallback for executions whose stack no longer contains
+     * the caller.
+     *
+     * <p>Intended for integrations that carry a scope onto another thread, such as coroutine context elements,
+     * which bind it alongside the scope. Application code should not modify it.</p>
+     *
+     * @return the thread local holding the current launch site.
+     */
+    public static ThreadLocal<String> callSiteHint() {
+        return CALL_SITE_HINT;
+    }
+
+    /**
+     * Returns the application frame launching work, for an integration to carry as the call-site fallback of a
+     * scope that records call sites.
+     *
+     * <p>At the moment work is launched, the caller is still on the stack; on the thread the work resumes on,
+     * it no longer is. Carrying what this returns, bound through {@link #callSiteHint()}, is what lets a
+     * statement whose stack is plumbing end to end name the frame that launched the work. When the launch
+     * itself has no application frame on its stack, the fallback already carried is returned, so chained
+     * launches preserve the original caller.</p>
+     *
+     * <p>Costs a stack walk; callers gate on whether an observing scope records call sites.</p>
+     *
+     * @return the launching application frame, or {@code null} when there is none to carry.
+     */
+    @Nullable
+    public static String captureCallSite() {
+        var walked = walkFrames();
+        return walked.application() != null ? walked.application() : CALL_SITE_HINT.get();
+    }
+
+    /**
+     * Returns the application frame that caused the execution: the innermost frame that is neither framework
+     * infrastructure nor declared plumbing, as {@code File.ext:line}.
+     *
+     * <p>When every application frame on the stack is declared plumbing, the carried launch site is returned
+     * when one is bound, since it names the caller the stack lost; the innermost plumbing frame otherwise, as a
+     * plumbing site still says more than none.</p>
+     */
+    @Nullable
+    public static String callSite() {
+        var walked = walkFrames();
+        if (walked.application() != null) {
+            return walked.application();
+        }
+        String hint = CALL_SITE_HINT.get();
+        if (hint != null) {
+            return hint;
+        }
+        return walked.plumbing();
+    }
+
+    /** The two frames a walk can surface: the first application frame, and the innermost plumbing frame. */
+    private record WalkedFrames(@Nullable String application, @Nullable String plumbing) {
+    }
+
+    private static WalkedFrames walkFrames() {
+        return CALL_SITE_WALKER.walk(frames -> {
+            String plumbing = null;
+            for (var iterator = frames.iterator(); iterator.hasNext(); ) {
+                var frame = iterator.next();
+                if (isInfrastructure(frame.getClassName())) {
+                    continue;
+                }
+                if (isDeclaredPlumbing(frame.getClassName(), frame.getFileName())) {
+                    if (plumbing == null) {
+                        plumbing = format(frame);
+                    }
+                    continue;
+                }
+                return new WalkedFrames(format(frame), plumbing);
+            }
+            return new WalkedFrames(null, plumbing);
+        });
+    }
+
+    private static String format(@Nonnull StackWalker.StackFrame frame) {
+        String file = frame.getFileName();
+        return file != null
+                ? "%s:%d".formatted(file, frame.getLineNumber())
+                : "%s.%s".formatted(frame.getClassName(), frame.getMethodName());
+    }
+
+    /**
+     * Returns whether the frame belongs to a package or source file the application declared as plumbing.
+     *
+     * <p>Entries naming a source file match the frame's file, which is what covers inline functions: inlining
+     * regenerates a lambda under the caller's class, where a package prefix cannot see it, while the frame keeps
+     * the declaring file's name.</p>
+     */
+    private static boolean isDeclaredPlumbing(@Nonnull String className, @Nullable String fileName) {
+        for (var entry : ignoredCallSitePrefixes) {
+            if (entry.endsWith(".kt") || entry.endsWith(".java")) {
+                if (entry.equals(fileName)) {
+                    return true;
+                }
+            } else if (className.startsWith(entry)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Package prefixes the application declared as its own database plumbing, so call sites name the code that
+     * asked for the work rather than the layer that carried it. Copy-on-write: registered once at startup, read
+     * on every walk.
+     */
+    private static volatile String[] ignoredCallSitePrefixes = {};
+
+    /**
+     * Declares packages whose frames are skipped when attributing an execution to a call site.
+     *
+     * <p>A database layer of the application's own, such as a wrapper that fans a query out over several
+     * templates, sits between the caller and Storm on every statement; its frames identify the plumbing rather
+     * than the code that asked for the work. Declaring its packages here makes call sites name the caller
+     * beyond it.</p>
+     *
+     * <p>An entry is a package prefix matched against the fully qualified class name, or, when it ends in
+     * {@code .kt} or {@code .java}, a source file name matched against the frame's file. The file form covers
+     * inline functions, whose lambdas are regenerated under the caller's class while keeping the declaring
+     * file's name. When every application frame on a stack is declared plumbing, the innermost plumbing frame is
+     * reported rather than none. Intended to be called once at startup.</p>
+     *
+     * @param packagePrefixes the package prefixes or source file names to skip, such as {@code "com.acme.db"} or
+     *                        {@code "DbExtensions.kt"}.
+     */
+    public static void ignoreCallSites(@Nonnull String... packagePrefixes) {
+        var merged = new ArrayList<>(List.of(ignoredCallSitePrefixes));
+        for (var prefix : packagePrefixes) {
+            merged.add(requireNonNull(prefix, "packagePrefix"));
+        }
+        ignoredCallSitePrefixes = merged.toArray(String[]::new);
+    }
+
+    private static boolean isInfrastructure(@Nonnull String className) {
+        if (className.startsWith("st.orm.")
+                || className.startsWith("java.")
+                || className.startsWith("jdk.")
+                || className.startsWith("sun.")
+                || className.startsWith("kotlin.")
+                || className.startsWith("kotlinx.")
+                || className.startsWith("org.springframework.")
+                || className.startsWith("org.apache.")
+                || className.startsWith("io.ktor.")
+                || className.startsWith("io.netty.")
+                || className.startsWith("org.eclipse.jetty.")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Applies the configured skip list ({@link StormConfig#defaults()}, which reads system properties). Which
+     * frames are plumbing is a property of the deployment, so it is configured like one; the Spring and Ktor
+     * integrations apply their own configuration through {@link #ignoreCallSites}.
+     */
+    // Placed after every field it touches, since static initialization runs in textual order.
+    static {
+        String skip = StormConfig.defaults().getProperty(StormConfig.SQL_LOG_CALL_SITE_SKIP);
+        if (skip != null) {
+            ignoreCallSites(Arrays.stream(skip.split(","))
+                    .map(String::trim)
+                    .filter(entry -> !entry.isEmpty())
+                    .toArray(String[]::new));
+        }
+    }
+}

--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlLogRenderer.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlLogRenderer.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.template.impl;
+
+import static java.util.Comparator.comparingLong;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static st.orm.core.spi.StormConfigHelper.getEnum;
+import static st.orm.core.spi.StormConfigHelper.getInt;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import st.orm.Data;
+import st.orm.Entity;
+import st.orm.Ref;
+import st.orm.StormConfig;
+import st.orm.core.spi.Providers;
+import st.orm.core.template.SqlLog.HydrationShapes;
+import st.orm.core.template.SqlLog.StatementLine;
+import st.orm.core.template.SqlLog.Summary;
+import st.orm.core.template.SqlOperation;
+import st.orm.core.template.StatementOrigin;
+
+/**
+ * Renders a {@link Summary} as a headline plus an aligned line per distinct statement, and derives the hydration
+ * shape a summary row can carry.
+ *
+ * <p>How a summary renders — hydration shapes, line width — is a property of the log viewer rather than of any
+ * scope, configured like a deployment property: the {@code storm.sql_log.hydration} and
+ * {@code storm.sql_log.line_width} system properties on a plain JVM, or the corresponding keys of the Spring and
+ * Ktor integrations, which apply their configuration through the setters here.</p>
+ *
+ * @since 1.14
+ */
+public final class SqlLogRenderer {
+
+    private SqlLogRenderer() {
+    }
+
+    /**
+     * How shapes render, a property of the log viewer rather than of any scope: derived at rendering and cached
+     * per type, the setting costs nothing while calls run. Set once at startup; read at rendering only.
+     */
+    private static volatile HydrationShapes hydrationShapes = HydrationShapes.OFF;
+
+    /**
+     * Sets how a read's summary row renders the declared hydration shape of its type. Off by default; intended to
+     * be called once at startup.
+     *
+     * @param shapes how shapes render.
+     */
+    public static void hydrationShapes(@Nonnull HydrationShapes shapes) {
+        hydrationShapes = requireNonNull(shapes, "shapes");
+    }
+
+    /**
+     * Width a summary row aims for, a property of the log viewer rather than of any scope. The statement text
+     * receives what the row's other columns leave, down to a floor that keeps it identifiable. Set once at
+     * startup; read at rendering only.
+     */
+    private static volatile int lineWidth = 200;
+
+    /** The least statement text a row keeps, whatever its other columns consume. */
+    private static final int MIN_STATEMENT_WIDTH = 40;
+
+    /**
+     * Sets the width summary rows aim for, such as {@code 120} for narrow viewers or {@code 240} for wide
+     * ones. The statement text elides to what the row's other columns leave. Intended to be called once at
+     * startup.
+     *
+     * @param width the display width; at least 80.
+     */
+    public static void lineWidth(int width) {
+        lineWidth = Math.max(80, width);
+    }
+
+    /**
+     * Renders the summary as a headline plus a line per distinct statement.
+     *
+     * @param summary the summary to render.
+     * @return the rendered summary.
+     */
+    public static String render(@Nonnull Summary summary) {
+        return render(summary.name(), summary.recorded(), summary.count(StatementOrigin.FETCH),
+                summary.cacheHits(), NANOSECONDS.toMillis(summary.databaseNanos()),
+                NANOSECONDS.toMillis(summary.databaseElapsedNanos()), summary.peakConcurrency(),
+                NANOSECONDS.toMillis(summary.durationNanos()), summary.byStatement(),
+                summary.recorded() - summary.statements().size());
+    }
+
+    /**
+     * Renders the summary with the full statement texts appended, one per row in row order, so a row whose
+     * elided text is not enough can be matched to the statement it stands for.
+     *
+     * @param summary the summary to render.
+     * @return the rendered summary, followed by the full statements.
+     */
+    public static String renderDetailed(@Nonnull Summary summary) {
+        var rendered = new StringBuilder(render(summary));
+        var lines = summary.byStatement();
+        if (!lines.isEmpty()) {
+            rendered.append(String.format("%n\tstatements:"));
+        }
+        for (var line : lines) {
+            rendered.append(String.format("%n\t  ")).append(flatten(line.statement()));
+        }
+        return rendered.toString();
+    }
+
+    /**
+     * Renders a summary as a headline plus a line per distinct statement, heaviest first.
+     *
+     * <p>The headline separates the time the database spent from the time the call took, so a call that is slow for
+     * other reasons says so. Under a fan-out the summed database time exceeds the elapsed time, and their ratio is
+     * the concurrency the work achieved.</p>
+     *
+     * <p>Statements that ran past the recording limit are counted but not retained, so they contribute no duration
+     * and no row. The database times are then lower bounds and are marked {@code +}, and a closing line reports how
+     * many statements went unrecorded. The statement count and the call's own duration stay exact.</p>
+     *
+     * @param name what the scope covered.
+     * @param statementCount the statements the call executed.
+     * @param fetchCount how many of those resolved a reference.
+     * @param cacheHits the reads the transaction's entity cache served without a statement.
+     * @param databaseMillis the summed duration of the recorded statements.
+     * @param databaseElapsedMillis the time during which at least one recorded statement was in flight.
+     * @param peakConcurrency the greatest number of recorded statements in flight at once.
+     * @param totalMillis how long the call took.
+     * @param byStatement one line per distinct statement, in any order.
+     * @param notRecorded how many statements ran past the recording limit.
+     * @return the rendered summary.
+     */
+    public static String render(@Nonnull String name,
+                                int statementCount,
+                                int fetchCount,
+                                int cacheHits,
+                                long databaseMillis,
+                                long databaseElapsedMillis,
+                                int peakConcurrency,
+                                long totalMillis,
+                                @Nonnull List<StatementLine> byStatement,
+                                int notRecorded) {
+        var rendered = new StringBuilder("SQL (%s): %s".formatted(name, statements(statementCount)));
+        if (fetchCount > 0) {
+            rendered.append(", ").append(fetches(fetchCount));
+        }
+        if (cacheHits > 0) {
+            rendered.append(", %d from cache".formatted(cacheHits));
+        }
+        // Statements past the recording limit contribute no duration, so the database times cover the recorded
+        // ones only; mark them as lower bounds rather than let a truncated summary understate its own cost.
+        var bound = notRecorded > 0 ? "+" : "";
+        rendered.append(", %d%s ms in database".formatted(databaseMillis, bound));
+        // Concurrency is a count of simultaneous executions, reported only when the work overlapped: summed
+        // database time then exceeds the elapsed time it was compressed into, so both appear.
+        if (peakConcurrency > 1) {
+            rendered.append(" over %d%s ms elapsed (peak %d concurrent)".formatted(
+                    databaseElapsedMillis, bound, peakConcurrency));
+        }
+        rendered.append(", %d ms total".formatted(totalMillis));
+        int width = byStatement.stream()
+                .mapToInt(line -> String.valueOf(NANOSECONDS.toMillis(line.durationNanos())).length())
+                .max()
+                .orElse(1);
+        int executionWidth = byStatement.stream()
+                .mapToInt(line -> String.valueOf(line.executions()).length())
+                .max()
+                .orElse(1);
+        int typeWidth = byStatement.stream()
+                .mapToInt(line -> line.dataType().length())
+                .max()
+                .orElse(1);
+        int rowsWidth = byStatement.stream()
+                .mapToInt(line -> rowsLabel(line).length())
+                .max()
+                .orElse(1);
+        // The identifying columns align and lead; the free-form statement text comes last, where raggedness
+        // does not break the columns after it. The fetch and call-site columns appear only when any row has one.
+        boolean anyFetch = byStatement.stream().anyMatch(StatementLine::fetch);
+        int siteWidth = byStatement.stream()
+                .mapToInt(line -> siteLabel(line).length())
+                .max()
+                .orElse(0);
+        // The row aims for the configured line width: the statement text receives what the fixed columns and
+        // the row's own suffixes leave, down to a floor that keeps it identifiable.
+        int prefixWidth = width + 5 + executionWidth + 3 + rowsWidth + 6 + typeWidth + 2
+                + (anyFetch ? 7 : 0) + (siteWidth > 0 ? siteWidth + 2 : 0);
+        // Ordering is presentation, so the renderer owns it rather than trusting the order it was handed.
+        for (var line : byStatement.stream()
+                .sorted(comparingLong(StatementLine::durationNanos).reversed())
+                .toList()) {
+            rendered.append(String.format(
+                    "%n\t%" + width + "d ms  %" + rowsWidth + "s rows  %" + executionWidth + "dx  %-" + typeWidth + "s",
+                    NANOSECONDS.toMillis(line.durationNanos()),
+                    rowsLabel(line),
+                    line.executions(),
+                    line.dataType()));
+            if (anyFetch) {
+                rendered.append(String.format("  %-5s", line.fetch() ? "fetch" : ""));
+            }
+            if (siteWidth > 0) {
+                rendered.append(String.format("  %-" + siteWidth + "s", siteLabel(line)));
+            }
+            int suffixWidth = (line.variants() > 1 ? 12 + String.valueOf(line.variants()).length() : 0)
+                    + (line.hydration() != null ? 2 + line.hydration().length() : 0);
+            int statementBudget = Math.max(MIN_STATEMENT_WIDTH, lineWidth - prefixWidth - suffixWidth);
+            rendered.append("  ").append(elide(line.statement(), statementBudget));
+            if (line.variants() > 1) {
+                rendered.append(" (%d variants)".formatted(line.variants()));
+            }
+            if (line.hydration() != null) {
+                rendered.append("  ").append(line.hydration());
+            }
+        }
+        if (notRecorded > 0) {
+            rendered.append("%n\t(%s not recorded)".formatted(statements(notRecorded)));
+        }
+        return rendered.toString();
+    }
+
+    /** Returns the row-count column content: the count, marked {@code *} when it is a lower bound. */
+    private static String rowsLabel(@Nonnull StatementLine line) {
+        return line.exactRows() ? String.valueOf(line.rows()) : line.rows() + "*";
+    }
+
+    /** Returns the call-site column content for the line, empty when the scope recorded none. */
+    private static String siteLabel(@Nonnull StatementLine line) {
+        if (line.callSite() == null) {
+            return "";
+        }
+        return line.sites() > 1
+                ? "%s (+%d sites)".formatted(line.callSite(), line.sites() - 1)
+                : line.callSite();
+    }
+
+    /**
+     * Returns the statement on one line, elided from the middle so a summary stays scannable: the head names the
+     * operation and columns, the tail carries the FROM and WHERE clauses that identify what the statement does.
+     */
+    private static String elide(@Nonnull String statement, int width) {
+        // A run of placeholders says nothing its length does not; collapsing it leaves the elision budget to
+        // the clauses that identify the statement. Display only: the detailed rendering keeps the exact text.
+        String flattened = flatten(statement).replaceAll("\\?(?:, \\?){3,}", "?, \u2026, ?");
+        if (flattened.length() <= width) {
+            return flattened;
+        }
+        int head = width / 3;
+        int tail = width - head - 1;
+        return flattened.substring(0, head) + "\u2026" + flattened.substring(flattened.length() - tail);
+    }
+
+    /**
+     * Returns the statement on one line, joining it on the line breaks it was rendered with.
+     *
+     * <p>A nested subquery is rendered on lines of its own, which leaves its closing parenthesis opening a line.
+     * Joining every break with a space reads that back as {@code WHERE id = ? ) ) x}, so a break between characters
+     * that belong together closes up instead.</p>
+     */
+    private static String flatten(@Nonnull String statement) {
+        var flattened = new StringBuilder();
+        statement.lines()
+                .map(String::strip)
+                .filter(line -> !line.isEmpty())
+                .forEach(line -> {
+                    if (!flattened.isEmpty()
+                            && separated(flattened.charAt(flattened.length() - 1), line.charAt(0))) {
+                        flattened.append(' ');
+                    }
+                    flattened.append(line);
+                });
+        return flattened.toString();
+    }
+
+    /** Returns whether a line break between the two characters reads as a space rather than as nothing at all. */
+    private static boolean separated(char before, char after) {
+        return before != '(' && after != ')' && after != ',';
+    }
+
+    private static String statements(int count) {
+        return "%d statement%s".formatted(count, count == 1 ? "" : "s");
+    }
+
+    private static String fetches(int count) {
+        return "%d fetch%s".formatted(count, count == 1 ? "" : "es");
+    }
+
+    /**
+     * Returns the rendered hydration shape of the statement's type in the configured form, or {@code null} when
+     * shapes are off, the statement is not a read, or its type has none.
+     *
+     * @param operation what the statement does.
+     * @param dataType the entity or projection it targets, or {@code null} when it targets none.
+     * @return the rendered shape, or {@code null} when the row carries none.
+     */
+    @Nullable
+    public static String hydrationOf(@Nonnull SqlOperation operation, @Nullable Class<? extends Data> dataType) {
+        var shapes = hydrationShapes;
+        if (shapes == HydrationShapes.OFF) {
+            return null;
+        }
+        if (operation != SqlOperation.SELECT) {
+            // The shape states what reading the type joins and maps. A write touches its own table only, so
+            // the shape would describe a graph its statement never traverses and columns it never sets; a
+            // statement whose operation is undetermined cannot claim to be a read either.
+            return null;
+        }
+        if (dataType == null) {
+            return null;
+        }
+        var shape = HYDRATION.get(dataType);
+        if (shape == NO_HYDRATION) {
+            return null;
+        }
+        if (shapes == HydrationShapes.FULL) {
+            return "joins=%d columns=%d graph=%s".formatted(shape.joins(), shape.columns(), shape.graph());
+        }
+        if (shape.joins() == 0) {
+            // A flat type says nothing its row does not already say; the short token appears when hydration
+            // reaches beyond the statement's own table.
+            return null;
+        }
+        return "j%d c%d d%d".formatted(shape.joins(), shape.columns(), shape.depth());
+    }
+
+    /**
+     * The declared hydration shape of a type: what an eager read of it joins and maps.
+     *
+     * <p>Derived from the type declaration, not from any statement: an entity component is a join edge and
+     * recurses; an inline record is columns on the same table and no subgraph, so a joined entity it carries
+     * splices into its parent's children; a reference is its foreign key column and stops, which is exactly the
+     * width a {@code Ref} declaration saves. Computed once per type, at display time.</p>
+     *
+     * @param joins the join edges an eager read of the type takes.
+     * @param columns the columns it maps.
+     * @param depth the entity levels along the deepest chain: {@code 1} for a flat entity, {@code 3} for
+     *              {@code Pet(Owner(City))}.
+     * @param graph the joined-entity tree, such as {@code Pet(PetType, Owner(City))}.
+     */
+    private record Hydration(int joins, int columns, int depth, @Nonnull String graph) {
+    }
+
+    /** Marks a type without a mapped record structure, for which no shape renders. */
+    private static final Hydration NO_HYDRATION = new Hydration(0, 0, 0, "");
+
+    private static final ClassValue<Hydration> HYDRATION = new ClassValue<>() {
+        @Override
+        protected Hydration computeValue(@Nonnull Class<?> type) {
+            // The reflection provider recognizes the mapped structure of Java records and Kotlin data classes
+            // alike, which is the same bridge the model itself is built over.
+            if (Providers.getORMReflection().findRecordType(type).isEmpty()) {
+                return NO_HYDRATION;
+            }
+            var shape = shape(type, new HashSet<>());
+            String graph = type.getSimpleName()
+                    + (shape.children().isEmpty() ? "" : "(" + shape.children() + ")");
+            return new Hydration(shape.joins(), shape.columns(), 1 + shape.depth(), graph);
+        }
+    };
+
+    /**
+     * The shape of one type level: its joins and columns, the entity levels below it, and its joined children
+     * rendered as a list.
+     */
+    private record Shape(int joins, int columns, int depth, @Nonnull String children) {
+    }
+
+    private static Shape shape(@Nonnull Class<?> type, @Nonnull Set<Class<?>> path) {
+        if (!path.add(type)) {
+            // A cycle recurses no further; the revisited entity contributes its foreign key column.
+            return new Shape(0, 1, 0, "");
+        }
+        try {
+            var reflection = Providers.getORMReflection();
+            var recordType = reflection.findRecordType(type).orElse(null);
+            if (recordType == null) {
+                return new Shape(0, 1, 0, "");
+            }
+            int joins = 0;
+            int columns = 0;
+            int depth = 0;
+            var children = new StringBuilder();
+            for (var field : recordType.fields()) {
+                Class<?> fieldType = field.type();
+                if (Ref.class.isAssignableFrom(fieldType)) {
+                    // The foreign key column; a reference does not widen the read.
+                    columns++;
+                } else if (Entity.class.isAssignableFrom(fieldType)) {
+                    var child = shape(fieldType, path);
+                    joins += 1 + child.joins();
+                    columns += child.columns();
+                    depth = Math.max(depth, 1 + child.depth());
+                    if (!children.isEmpty()) {
+                        children.append(", ");
+                    }
+                    children.append(fieldType.getSimpleName());
+                    if (!child.children().isEmpty()) {
+                        children.append('(').append(child.children()).append(')');
+                    }
+                } else if (reflection.findRecordType(fieldType).isPresent()) {
+                    // Any other mapped record structure is an inline record: columns on this table, not a
+                    // subgraph; entities it joins splice up.
+                    // An inline record is not a level of its own, so an entity it joins counts at this level.
+                    var inline = shape(fieldType, path);
+                    joins += inline.joins();
+                    columns += inline.columns();
+                    depth = Math.max(depth, inline.depth());
+                    if (!inline.children().isEmpty()) {
+                        if (!children.isEmpty()) {
+                            children.append(", ");
+                        }
+                        children.append(inline.children());
+                    }
+                } else {
+                    columns++;
+                }
+            }
+            return new Shape(joins, columns, depth, children.toString());
+        } finally {
+            path.remove(type);
+        }
+    }
+
+    /**
+     * Applies the display settings from configuration ({@link StormConfig#defaults()}, which reads system
+     * properties). How the log renders is a property of the deployment, so it is configured like one; the Spring
+     * and Ktor integrations apply their own configuration through the setters.
+     */
+    // Placed after every field it touches, since static initialization runs in textual order.
+    static {
+        var config = StormConfig.defaults();
+        hydrationShapes(getEnum(config, StormConfig.SQL_LOG_HYDRATION, HydrationShapes.class, HydrationShapes.OFF));
+        lineWidth(getInt(config, StormConfig.SQL_LOG_LINE_WIDTH, 200));
+    }
+}

--- a/storm-core/src/test/java/st/orm/core/SqlLogIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/SqlLogIntegrationTest.java
@@ -33,6 +33,7 @@ import st.orm.core.template.JpaTemplate;
 import st.orm.core.template.ORMTemplate;
 import st.orm.core.template.SqlLog;
 import st.orm.core.template.StatementOrigin;
+import st.orm.core.template.impl.SqlLogRenderer;
 
 /**
  * Verifies that a scope reports what a call cost the database: the statements it took whichever repository issued
@@ -306,14 +307,14 @@ public class SqlLogIntegrationTest {
     @Test
     public void testShortShapesSkipFlatTypes() {
         var orm = ORMTemplate.of(dataSource);
-        SqlLog.hydrationShapes(SqlLog.HydrationShapes.SHORT);
+        SqlLogRenderer.hydrationShapes(SqlLog.HydrationShapes.SHORT);
         try {
             List<SqlLog.Summary> summaries = new ArrayList<>();
             SqlLog.record("short", (Supplier<Object>) () -> orm.entity(City.class).getById(1), summaries::add);
             // A flat type says nothing its row does not already say, so the short form stays off its row.
             assertFalse(summaries.getFirst().toString().contains("j0"), summaries.getFirst().toString());
         } finally {
-            SqlLog.hydrationShapes(SqlLog.HydrationShapes.OFF);
+            SqlLogRenderer.hydrationShapes(SqlLog.HydrationShapes.OFF);
         }
     }
 
@@ -323,19 +324,19 @@ public class SqlLogIntegrationTest {
         // Pet's type is a reference, so it stays a foreign key column; Owner reaches City through an inline
         // Address, which is columns on the owner table rather than a subgraph, so City splices into Owner's
         // children. The short form states the numbers only; the full form names the graph.
-        SqlLog.hydrationShapes(SqlLog.HydrationShapes.SHORT);
+        SqlLogRenderer.hydrationShapes(SqlLog.HydrationShapes.SHORT);
         try {
             List<SqlLog.Summary> summaries = new ArrayList<>();
             SqlLog.record("shape", (Supplier<Object>) () -> orm.entity(Pet.class).getById(1), summaries::add);
             assertTrue(summaries.getFirst().toString().contains("j2 c12 d3"), summaries.getFirst().toString());
             assertFalse(summaries.getFirst().toString().contains("graph="), summaries.getFirst().toString());
-            SqlLog.hydrationShapes(SqlLog.HydrationShapes.FULL);
+            SqlLogRenderer.hydrationShapes(SqlLog.HydrationShapes.FULL);
             summaries.clear();
             SqlLog.record("shape", (Supplier<Object>) () -> orm.entity(Pet.class).getById(1), summaries::add);
             assertTrue(summaries.getFirst().toString().contains("joins=2 columns=12 graph=Pet(Owner(City))"),
                     summaries.getFirst().toString());
         } finally {
-            SqlLog.hydrationShapes(SqlLog.HydrationShapes.OFF);
+            SqlLogRenderer.hydrationShapes(SqlLog.HydrationShapes.OFF);
         }
     }
 
@@ -345,7 +346,7 @@ public class SqlLogIntegrationTest {
         // A shape states what reading a type costs. The delete below targets the same type as the read before it,
         // yet touches its own table only, so its row states no shape in either form.
         for (var shapes : List.of(SqlLog.HydrationShapes.SHORT, SqlLog.HydrationShapes.FULL)) {
-            SqlLog.hydrationShapes(shapes);
+            SqlLogRenderer.hydrationShapes(shapes);
             try {
                 List<SqlLog.Summary> summaries = new ArrayList<>();
                 SqlLog.record("write", (Supplier<Object>) () -> {
@@ -368,7 +369,7 @@ public class SqlLogIntegrationTest {
                 assertNotNull(read.hydration(), shapes.toString());
                 assertNull(write.hydration(), shapes.toString());
             } finally {
-                SqlLog.hydrationShapes(SqlLog.HydrationShapes.OFF);
+                SqlLogRenderer.hydrationShapes(SqlLog.HydrationShapes.OFF);
             }
         }
     }

--- a/storm-core/src/test/java/st/orm/core/template/impl/SqlLogRendererTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/SqlLogRendererTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package st.orm.core.template;
+package st.orm.core.template.impl;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,7 +26,7 @@ import st.orm.core.template.SqlLog.StatementLine;
  * Tests the summary a log reader sees: the heaviest statement leads, repetition reads as a multiplier, and the
  * headline separates database time from the time the call took.
  */
-public class SqlLogRenderTest {
+public class SqlLogRendererTest {
 
     private static final String NL = System.lineSeparator();
 
@@ -36,7 +36,7 @@ public class SqlLogRenderTest {
 
     @Test
     public void theHeaviestStatementLeadsAndRepetitionReadsAsAMultiplier() {
-        String rendered = SqlLog.render("GET /owners/42", 12, 0, 0, 214, 214, 1, 678,
+        String rendered = SqlLogRenderer.render("GET /owners/42", 12, 0, 0, 214, 214, 1, 678,
                 List.of(line("SELECT a FROM city", "City", 1, 18, 1), line("SELECT b FROM owner", "Owner", 7, 96, 700)), 0);
         // The heaviest statement leads, whatever order it arrived in, and each row names its target type.
         assertTrue(rendered.startsWith("SQL (GET /owners/42): 12 statements, 214 ms in database, 678 ms total" + NL),
@@ -48,16 +48,16 @@ public class SqlLogRenderTest {
 
     @Test
     public void concurrencyIsReportedOnlyWhenTheWorkOverlapped() {
-        String serial = SqlLog.render("call", 2, 0, 0, 40, 40, 1, 90, List.of(line("SELECT 1", "-", 2, 40, 2)), 0);
+        String serial = SqlLogRenderer.render("call", 2, 0, 0, 40, 40, 1, 90, List.of(line("SELECT 1", "-", 2, 40, 2)), 0);
         assertFalse(serial.contains("concurrent"), serial);
-        String parallel = SqlLog.render("call", 8, 0, 0, 214, 61, 4, 678, List.of(line("SELECT 1", "-", 8, 214, 8)), 0);
+        String parallel = SqlLogRenderer.render("call", 8, 0, 0, 214, 61, 4, 678, List.of(line("SELECT 1", "-", 8, 214, 8)), 0);
         assertTrue(parallel.contains("214 ms in database over 61 ms elapsed (peak 4 concurrent), 678 ms total"),
                 parallel);
     }
 
     @Test
     public void aFetchIsNamedOnItsOwnLine() {
-        String rendered = SqlLog.render("call", 9, 8, 0, 30, 30, 1, 40,
+        String rendered = SqlLogRenderer.render("call", 9, 8, 0, 30, 30, 1, 40,
                 List.of(new StatementLine("SELECT c FROM city WHERE id = ?", "City", true, 8, 1, 28_000_000L, null, 0, 8, true, null)), 0);
         assertTrue(rendered.contains("8 fetches"), rendered);
         assertTrue(rendered.contains("28 ms  8 rows  8x  City  fetch  SELECT c FROM city WHERE id = ?"), rendered);
@@ -65,7 +65,7 @@ public class SqlLogRenderTest {
 
     @Test
     public void aLongStatementIsElidedOntoOneLine() {
-        String rendered = SqlLog.render("call", 1, 0, 0, 5, 5, 1, 9,
+        String rendered = SqlLogRenderer.render("call", 1, 0, 0, 5, 5, 1, 9,
                 List.of(line("SELECT " + "x".repeat(200) + "\n  FROM city", "City", 1, 5, 1)), 0);
         assertFalse(rendered.contains("\n  FROM"), rendered);
         assertTrue(rendered.contains("\u2026"), rendered);
@@ -76,7 +76,7 @@ public class SqlLogRenderTest {
     @Test
     public void aNestedSubqueryClosesUpRatherThanCarryingItsLineBreaks() {
         // A subquery is rendered on lines of its own, which leaves its parentheses opening and closing lines.
-        String rendered = SqlLog.render("call", 1, 0, 0, 7, 7, 1, 9,
+        String rendered = SqlLogRenderer.render("call", 1, 0, 0, 7, 7, 1, 9,
                 List.of(line("""
                         SELECT SUM(c)
                         FROM ds
@@ -99,14 +99,14 @@ public class SqlLogRenderTest {
     @Test
     public void aGroupCoveringSeveralTextsSaysSo() {
         // A collection parameter that expands per execution yields one group with several texts.
-        String rendered = SqlLog.render("call", 3, 0, 0, 12, 12, 1, 20,
+        String rendered = SqlLogRenderer.render("call", 3, 0, 0, 12, 12, 1, 20,
                 List.of(new StatementLine("SELECT c FROM city WHERE id IN (?, ?)", "City", false, 3, 3, 12_000_000L, null, 0, 6, true, null)), 0);
         assertTrue(rendered.contains("IN (?, ?) (3 variants)"), rendered);
     }
 
     @Test
     public void statementsBeyondTheLimitAreReportedRatherThanDropped() {
-        String rendered = SqlLog.render("call", 500, 0, 0, 90, 90, 1, 120, List.of(line("SELECT 1", "-", 200, 90, 200)), 300);
+        String rendered = SqlLogRenderer.render("call", 500, 0, 0, 90, 90, 1, 120, List.of(line("SELECT 1", "-", 200, 90, 200)), 300);
         assertTrue(rendered.endsWith("(300 statements not recorded)"), rendered);
     }
 
@@ -114,12 +114,12 @@ public class SqlLogRenderTest {
     public void truncatedDatabaseTimesReadAsLowerBounds() {
         // The unrecorded statements contributed no duration, so the summary must not present its own total as
         // the whole cost of the call.
-        String truncated = SqlLog.render("call", 500, 0, 0, 90, 60, 4, 120,
+        String truncated = SqlLogRenderer.render("call", 500, 0, 0, 90, 60, 4, 120,
                 List.of(line("SELECT 1", "-", 200, 90, 200)), 300);
         assertTrue(truncated.contains("500 statements, 90+ ms in database over 60+ ms elapsed (peak 4 concurrent), 120 ms total"),
                 truncated);
         // Nothing was dropped here, so the same numbers are exact and carry no marker.
-        String complete = SqlLog.render("call", 200, 0, 0, 90, 60, 4, 120,
+        String complete = SqlLogRenderer.render("call", 200, 0, 0, 90, 60, 4, 120,
                 List.of(line("SELECT 1", "-", 200, 90, 200)), 0);
         assertTrue(complete.contains("200 statements, 90 ms in database over 60 ms elapsed (peak 4 concurrent), 120 ms total"),
                 complete);
@@ -127,7 +127,7 @@ public class SqlLogRenderTest {
 
     @Test
     public void aCallSiteIsRenderedWhenRecorded() {
-        String rendered = SqlLog.render("call", 9, 0, 0, 30, 30, 1, 40,
+        String rendered = SqlLogRenderer.render("call", 9, 0, 0, 30, 30, 1, 40,
                 List.of(new StatementLine("SELECT s FROM user_session", "UserSession", false, 8, 1, 28_000_000L,
                         "MeController.kt:41", 3, 8, true, null)), 0);
         assertTrue(rendered.contains("MeController.kt:41 (+2 sites)  SELECT s FROM user_session"), rendered);
@@ -135,20 +135,20 @@ public class SqlLogRenderTest {
 
     @Test
     public void aPlaceholderRunCollapsesInTheDisplay() {
-        String rendered = SqlLog.render("call", 1, 0, 0, 5, 5, 1, 9,
+        String rendered = SqlLogRenderer.render("call", 1, 0, 0, 5, 5, 1, 9,
                 List.of(line("INSERT INTO t (a, b) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", "-", 1, 5, 4)), 0);
         assertTrue(rendered.contains("VALUES (?, \u2026, ?)"), rendered);
         // Short runs stay as they are.
-        String untouched = SqlLog.render("call", 1, 0, 0, 5, 5, 1, 9,
+        String untouched = SqlLogRenderer.render("call", 1, 0, 0, 5, 5, 1, 9,
                 List.of(line("SELECT c FROM city WHERE id IN (?, ?)", "-", 1, 5, 2)), 0);
         assertTrue(untouched.contains("IN (?, ?)"), untouched);
     }
 
     @Test
     public void cacheServedReadsAppearInTheHeadlineOnlyWhenAnyWere() {
-        String rendered = SqlLog.render("call", 3, 2, 4, 30, 30, 1, 40, List.of(line("SELECT 1", "-", 3, 30, 3)), 0);
+        String rendered = SqlLogRenderer.render("call", 3, 2, 4, 30, 30, 1, 40, List.of(line("SELECT 1", "-", 3, 30, 3)), 0);
         assertTrue(rendered.contains("3 statements, 2 fetches, 4 from cache, 30 ms in database"), rendered);
-        String without = SqlLog.render("call", 3, 0, 0, 30, 30, 1, 40, List.of(line("SELECT 1", "-", 3, 30, 3)), 0);
+        String without = SqlLogRenderer.render("call", 3, 0, 0, 30, 30, 1, 40, List.of(line("SELECT 1", "-", 3, 30, 3)), 0);
         assertFalse(without.contains("from cache"), without);
     }
 
@@ -156,7 +156,7 @@ public class SqlLogRenderTest {
     public void anInexactRowCountIsMarkedAsALowerBound() {
         // A batch entry whose count the driver declined to report, or a stream closed before its end, leaves the
         // count a known lower bound; the star says so, and the exact count in the other row stays unmarked.
-        String rendered = SqlLog.render("call", 2, 0, 0, 45, 45, 1, 60, List.of(
+        String rendered = SqlLogRenderer.render("call", 2, 0, 0, 45, 45, 1, 60, List.of(
                 new StatementLine("INSERT INTO city (name) VALUES (?)", "City", false, 1, 1, 40_000_000L, null, 0,
                         500, false, null),
                 line("SELECT c FROM city", "City", 1, 5, 3)), 0);
@@ -167,7 +167,7 @@ public class SqlLogRenderTest {
 
     @Test
     public void aHydrationShapeRendersAtTheEndOfItsRow() {
-        String rendered = SqlLog.render("call", 1, 0, 0, 5, 5, 1, 9,
+        String rendered = SqlLogRenderer.render("call", 1, 0, 0, 5, 5, 1, 9,
                 List.of(new StatementLine("SELECT p FROM pet", "Pet", false, 1, 1, 5_000_000L, null, 0, 1, true,
                         "joins=2 columns=10 graph=Pet(Owner(City))")), 0);
         assertTrue(rendered.contains("SELECT p FROM pet  joins=2 columns=10 graph=Pet(Owner(City))"), rendered);

--- a/storm-kotlin/pom.xml
+++ b/storm-kotlin/pom.xml
@@ -37,10 +37,13 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <useModulePath>true</useModulePath>
+                    <!-- The add-exports covers the test-scoped storm-test jar: surefire leaves it on the class
+                         path, where the qualified export to storm.test cannot name it. -->
                     <argLine>
                         @{argLine}
                         --add-reads kotlin.stdlib=kotlinx.coroutines.core
                         --add-reads storm.core=storm.kotlin
+                        --add-exports storm.core/st.orm.core.template.impl=ALL-UNNAMED
                         --add-opens java.base/java.lang=ALL-UNNAMED
                         --add-opens storm.kotlin/st.orm.template=ALL-UNNAMED
                         --add-opens storm.kotlin/st.orm.template.model=ALL-UNNAMED

--- a/storm-kotlin/src/main/kotlin/st/orm/template/SqlLogs.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/SqlLogs.kt
@@ -16,6 +16,7 @@
 package st.orm.template
 
 import kotlinx.coroutines.asContextElement
+import st.orm.core.template.impl.CallSiteCapture
 import st.orm.core.template.impl.SqlInterceptorManager
 import st.orm.template.impl.recordSqlLog
 import kotlin.coroutines.CoroutineContext
@@ -58,8 +59,8 @@ fun sqlLogContext(): CoroutineContext {
     val open = holder.get() ?: return EmptyCoroutineContext
     var context: CoroutineContext = holder.asContextElement(open)
     if (SqlInterceptorManager.hasCallSiteListeners()) {
-        CoreSqlLog.captureCallSite()?.let { launchSite ->
-            context += CoreSqlLog.callSiteHint().asContextElement(launchSite)
+        CallSiteCapture.captureCallSite()?.let { launchSite ->
+            context += CallSiteCapture.callSiteHint().asContextElement(launchSite)
         }
     }
     return context

--- a/storm-kotlin/src/main/kotlin/st/orm/template/impl/SqlLogRecording.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/impl/SqlLogRecording.kt
@@ -18,6 +18,7 @@ package st.orm.template.impl
 import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
+import st.orm.core.template.impl.CallSiteCapture
 import st.orm.core.template.impl.SqlInterceptorManager
 import st.orm.core.template.impl.SqlInterceptorManager.Operator
 import kotlin.coroutines.CoroutineContext
@@ -50,7 +51,7 @@ suspend fun <T> recordSqlLog(
     // The scope opens where the caller still is on the stack, so that frame is the launch-site fallback for
     // children whose own stack loses it.
     val hint: CoroutineContext = if (callSites) {
-        CoreSqlLog.captureCallSite()?.let { CoreSqlLog.callSiteHint().asContextElement(it) }
+        CallSiteCapture.captureCallSite()?.let { CallSiteCapture.callSiteHint().asContextElement(it) }
             ?: EmptyCoroutineContext
     } else {
         EmptyCoroutineContext

--- a/storm-kotlin/src/test/kotlin/com/example/scope/CallSitePlumbingTest.kt
+++ b/storm-kotlin/src/test/kotlin/com/example/scope/CallSitePlumbingTest.kt
@@ -10,12 +10,12 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import st.orm.core.template.SqlLog.Summary
+import st.orm.core.template.impl.CallSiteCapture
 import st.orm.template.DEFAULT_SQL_LOG_LIMIT
 import st.orm.template.IntegrationConfig
 import st.orm.template.ORMTemplate
 import st.orm.template.impl.recordSqlLog
 import st.orm.template.model.PetOwnerRef
-import st.orm.core.template.SqlLog as CoreSqlLog
 
 /**
  * Verifies that a declared plumbing file hides the frames of its inline functions: their lambdas compile into
@@ -38,7 +38,7 @@ open class CallSitePlumbingTest(
 
     @Test
     fun `a plumbing file entry hides the frames of its inline functions`(): Unit = runBlocking {
-        CoreSqlLog.ignoreCallSites("Plumbing.kt")
+        CallSiteCapture.ignoreCallSites("Plumbing.kt")
         val summary = record("plumbed") {
             throughDbLayer { orm.entity(PetOwnerRef::class).select().resultList }
         }
@@ -50,7 +50,7 @@ open class CallSitePlumbingTest(
 
     @Test
     fun `work launched onto another dispatcher names the frame that launched it`(): Unit = runBlocking {
-        CoreSqlLog.ignoreCallSites("Plumbing.kt")
+        CallSiteCapture.ignoreCallSites("Plumbing.kt")
         val summary = record("launched") {
             fetchAllOnDispatcher(orm)
         }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/SqlLogTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/SqlLogTest.kt
@@ -20,6 +20,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import st.orm.Metamodel
 import st.orm.core.template.SqlLog.Summary
 import st.orm.core.template.StatementOrigin.FETCH
+import st.orm.core.template.impl.SqlLogRenderer
 import st.orm.template.impl.recordSqlLog
 import st.orm.template.model.Owner
 import st.orm.template.model.PetOwnerRef
@@ -229,7 +230,7 @@ open class SqlLogTest(
     fun `a hydration shape renders for a data class entity`(): Unit = runBlocking {
         // The shape derives through the reflection provider, which recognizes Kotlin data classes; a JVM-record
         // check would leave these rows bare.
-        CoreSqlLog.hydrationShapes(CoreSqlLog.HydrationShapes.FULL)
+        SqlLogRenderer.hydrationShapes(CoreSqlLog.HydrationShapes.FULL)
         try {
             val (_, summary) = record("shape") {
                 orm.entity(PetOwnerRef::class).select().resultList
@@ -238,7 +239,7 @@ open class SqlLogTest(
             rendered shouldContain "joins="
             rendered shouldContain "graph=PetOwnerRef"
         } finally {
-            CoreSqlLog.hydrationShapes(CoreSqlLog.HydrationShapes.OFF)
+            SqlLogRenderer.hydrationShapes(CoreSqlLog.HydrationShapes.OFF)
         }
     }
 }

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
@@ -33,7 +33,8 @@ import io.micrometer.observation.ObservationRegistry
 import org.slf4j.LoggerFactory
 import st.orm.core.spi.JdbcConnectionProviderImpl
 import st.orm.core.spi.JdbcTransactionTemplateProviderImpl
-import st.orm.core.template.SqlLog
+import st.orm.core.template.impl.CallSiteCapture
+import st.orm.core.template.impl.SqlLogRenderer
 import st.orm.micrometer.MicrometerQueryObserver
 import st.orm.template.ORMTemplate
 import st.orm.template.impl.recordSqlLog
@@ -266,10 +267,10 @@ val Storm = createApplicationPlugin(name = "Storm", createConfiguration = ::Stor
         val limit = pluginConfig.sqlLogLimit
         val callSites = pluginConfig.sqlLogCallSites
         if (pluginConfig.sqlLogCallSiteSkip.isNotEmpty()) {
-            SqlLog.ignoreCallSites(*pluginConfig.sqlLogCallSiteSkip.toTypedArray())
+            CallSiteCapture.ignoreCallSites(*pluginConfig.sqlLogCallSiteSkip.toTypedArray())
         }
-        pluginConfig.sqlLogLineWidth?.let { SqlLog.lineWidth(it) }
-        SqlLog.hydrationShapes(pluginConfig.sqlLogHydration)
+        pluginConfig.sqlLogLineWidth?.let { SqlLogRenderer.lineWidth(it) }
+        SqlLogRenderer.hydrationShapes(pluginConfig.sqlLogHydration)
         val statementThreshold = pluginConfig.sqlLogStatementThreshold
         val durationThreshold = pluginConfig.sqlLogDurationThreshold
         val thresholded = statementThreshold != null || durationThreshold != null

--- a/storm-spring/src/main/java/st/orm/spring/boot/StormSqlLogAutoConfiguration.java
+++ b/storm-spring/src/main/java/st/orm/spring/boot/StormSqlLogAutoConfiguration.java
@@ -35,6 +35,8 @@ import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import st.orm.core.template.impl.CallSiteCapture;
+import st.orm.core.template.impl.SqlLogRenderer;
 
 /**
  * Auto-configuration that reports what each unit of work cost the database.
@@ -81,12 +83,12 @@ public class StormSqlLogAutoConfiguration {
     /** Applies the settings that shape how every summary renders, whichever boundary produced it. */
     private static void applyDisplaySettings(@Nonnull StormProperties.SqlLog sqlLog) {
         if (!sqlLog.getCallSiteSkip().isEmpty()) {
-            st.orm.core.template.SqlLog.ignoreCallSites(sqlLog.getCallSiteSkip().toArray(String[]::new));
+            CallSiteCapture.ignoreCallSites(sqlLog.getCallSiteSkip().toArray(String[]::new));
         }
         if (sqlLog.getLineWidth() != null) {
-            st.orm.core.template.SqlLog.lineWidth(sqlLog.getLineWidth());
+            SqlLogRenderer.lineWidth(sqlLog.getLineWidth());
         }
-        st.orm.core.template.SqlLog.hydrationShapes(switch (sqlLog.getHydration()) {
+        SqlLogRenderer.hydrationShapes(switch (sqlLog.getHydration()) {
             case OFF -> OFF;
             case SHORT -> SHORT;
             case FULL -> FULL;


### PR DESCRIPTION
Fixes #395

## What changed

**Qualified JPMS exports.** `storm-core`'s module descriptor exported `st.orm.core.template.impl` and `st.orm.core.repository.impl` unqualified, which made the 40+ public types in those packages public API by module-path rules. Both packages are now exported to Storm's own modules only:

- `st.orm.core.template.impl` → the modules that use it in main or test sources, including `storm.ktor` (an automatic module: the Ktor plugin applies display settings) and `storm.foundation` (reflective `MetamodelFactory` lookup); `storm.h2` and `storm.oracle` are on the list for their test sources only.
- `st.orm.core.repository.impl` → the eight modules that build on the repository implementations.

On the class path nothing changes; on the module path, application code that reached into the impl packages no longer compiles.

**SqlLog split.** `st.orm.core.template.SqlLog` (1,204 lines) carried its Scope/Recorder diagnostics API together with rendering and analysis machinery. The class keeps the API — `open`/`record`/`recorder`/`summary`, the `Statement`/`Summary`/`StatementLine` records, and the `HydrationShapes` enum, which the Ktor plugin exposes in its public configuration — and the machinery moves to two internal classes:

- `SqlLogRenderer`: the summary/table rendering, line width, and hydration-shape analysis.
- `CallSiteCapture`: the stack walker, launch-site hint, and plumbing skip list.

The display setters (`hydrationShapes`, `lineWidth`, `ignoreCallSites`) and the launch-site hooks (`captureCallSite`, `callSiteHint`) move with them: how summaries render is configured through the `storm.sql_log.*` properties or the Spring and Ktor keys rather than programmed, and the hooks exist for Storm's own integrations. Each internal class applies its configured defaults in its own static initializer, so behavior is unchanged.

## Notes

- Qualified exports are enforced at test compilation in every downstream module, since the compiler patches test sources into the module even where surefire runs tests on the class path — the export lists cover test-source usage for that reason.
- storm-kotlin runs its tests on the module path, and surefire leaves the test-scoped storm-test jar on the class path where the qualified export to `storm.test` cannot name it; its surefire `argLine` gains an `--add-exports ... ALL-UNNAMED` for that jar.

## Testing

- Full reactor compiles (main and test sources of every module).
- Suites green: storm-core, storm-test, storm-spring, storm-java21, storm-kotlin (1,696 tests, module path), storm-ktor (57).
- Dialect module tests compile; their execution needs the docker databases and is covered by CI.