### PR TITLE
fix: point published POM metadata at the storm-orm org and unify contact addresses

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-storm@zantvoort.biz. All complaints will be reviewed and investigated promptly
+zantvoort@orm.st. All complaints will be reviewed and investigated promptly
 and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-zantvoort@orm.st. All complaints will be reviewed and investigated promptly
+dev@orm.st. All complaints will be reviewed and investigated promptly
 and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thank you for your interest in contributing to Storm! This document provides gui
 
 ```bash
 # Clone the repository
-git clone https://github.com/storm-repo/storm-framework.git
+git clone https://github.com/storm-orm/storm-framework.git
 cd storm-framework
 
 # Build all modules

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ The Storm team takes security vulnerabilities seriously. We appreciate your effo
 
 **Please do NOT report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them via email to **zantvoort@orm.st**.
+Instead, please report them via email to **dev@orm.st**.
 
 Include as much of the following information as possible to help us understand and resolve the issue quickly:
 
@@ -59,4 +59,4 @@ When a security vulnerability is confirmed and resolved, we will:
 
 ## Contact
 
-For any questions about this security policy, please contact **zantvoort@orm.st**.
+For any questions about this security policy, please contact **dev@orm.st**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ The Storm team takes security vulnerabilities seriously. We appreciate your effo
 
 **Please do NOT report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them via email to **security@zantvoort.biz**.
+Instead, please report them via email to **zantvoort@orm.st**.
 
 Include as much of the following information as possible to help us understand and resolve the issue quickly:
 
@@ -59,4 +59,4 @@ When a security vulnerability is confirmed and resolved, we will:
 
 ## Contact
 
-For any questions about this security policy, please contact **storm@zantvoort.biz**.
+For any questions about this security policy, please contact **zantvoort@orm.st**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -244,4 +244,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <packaging>pom</packaging>
     <name>Storm Framework</name>
     <description>A SQL Template and ORM framework, focusing on modernizing and simplifying database programming.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -45,9 +45,9 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <modules>
         <module>storm-bom</module>

--- a/storm-bom/pom.xml
+++ b/storm-bom/pom.xml
@@ -13,7 +13,7 @@
     <packaging>pom</packaging>
     <name>Storm BOM</name>
     <description>Bill of Materials (BOM) for the Storm framework, providing centralized dependency management for all Storm modules.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -23,13 +23,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-bom/pom.xml
+++ b/storm-bom/pom.xml
@@ -23,7 +23,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-core</artifactId>
     <name>Storm Core</name>
     <description>Storm core package.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-core/pom.xml
+++ b/storm-core/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-foundation/pom.xml
+++ b/storm-foundation/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-foundation</artifactId>
     <name>Storm Foundation</name>
     <description>Foundational Storm interfaces, shared by the Java and Kotlin packages.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-foundation/pom.xml
+++ b/storm-foundation/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-h2/pom.xml
+++ b/storm-h2/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-h2</artifactId>
     <name>Storm H2</name>
     <description>H2 extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-h2/pom.xml
+++ b/storm-h2/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-jackson2/pom.xml
+++ b/storm-jackson2/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-jackson2</artifactId>
     <name>Storm Jackson 2</name>
     <description>Jackson 2 JSON extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-jackson2/pom.xml
+++ b/storm-jackson2/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-jackson3/pom.xml
+++ b/storm-jackson3/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-jackson3</artifactId>
     <name>Storm Jackson 3</name>
     <description>Jackson 3 JSON extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-jackson3/pom.xml
+++ b/storm-jackson3/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-java21/pom.xml
+++ b/storm-java21/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-java21</artifactId>
     <name>Storm for Java 21</name>
     <description>Main Storm package.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-java21/pom.xml
+++ b/storm-java21/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-kotlin-spring-boot-starter/pom.xml
+++ b/storm-kotlin-spring-boot-starter/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-kotlin-spring-boot-starter</artifactId>
     <name>Storm Spring Boot Starter for Kotlin</name>
     <description>Spring Boot Starter for Storm with Kotlin support, providing auto-configuration for the Storm ORM framework.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-kotlin-spring-boot-starter/pom.xml
+++ b/storm-kotlin-spring-boot-starter/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-kotlin-spring/pom.xml
+++ b/storm-kotlin-spring/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-kotlin-spring</artifactId>
     <name>Storm Spring for Kotlin</name>
     <description>Spring extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-kotlin-spring/pom.xml
+++ b/storm-kotlin-spring/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-kotlin/pom.xml
+++ b/storm-kotlin/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-kotlin</artifactId>
     <name>Storm for Kotlin</name>
     <description>Storm for Kotlin.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-kotlin/pom.xml
+++ b/storm-kotlin/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-kotlinx-serialization/pom.xml
+++ b/storm-kotlinx-serialization/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-kotlinx-serialization</artifactId>
     <name>Storm Kotlinx Serialization</name>
     <description>Kotlinx Serialization Json extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>

--- a/storm-kotlinx-serialization/pom.xml
+++ b/storm-kotlinx-serialization/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-ktor-test/pom.xml
+++ b/storm-ktor-test/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-ktor-test</artifactId>
     <name>Storm Ktor Test</name>
     <description>Testing support for Storm with Ktor.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <!-- Matches storm-ktor's toolchain (Ktor 3.4 / Kotlin 2.3 / coroutines 1.10); see storm-ktor/pom.xml. -->
     <properties>

--- a/storm-ktor-test/pom.xml
+++ b/storm-ktor-test/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-ktor/pom.xml
+++ b/storm-ktor/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-ktor</artifactId>
     <name>Storm Ktor</name>
     <description>Ktor integration for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <!-- Ktor 3.4 requires Kotlin 2.3 and kotlinx-coroutines 1.10; this module tracks Ktor's toolchain while
          the rest of the framework stays on Kotlin 2.0. As a leaf module (only storm-ktor-test consumes it, and

--- a/storm-ktor/pom.xml
+++ b/storm-ktor/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-mariadb/pom.xml
+++ b/storm-mariadb/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-mariadb</artifactId>
     <name>Storm MariaDB</name>
     <description>MariaDB extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-mariadb/pom.xml
+++ b/storm-mariadb/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-metamodel-ksp/pom.xml
+++ b/storm-metamodel-ksp/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>storm-metamodel-ksp</artifactId>
     <name>Storm Metamodel KSP</name>
     <description>Metamodel extensions for Kotlin.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -21,13 +21,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>

--- a/storm-metamodel-ksp/pom.xml
+++ b/storm-metamodel-ksp/pom.xml
@@ -21,7 +21,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-metamodel-processor/pom.xml
+++ b/storm-metamodel-processor/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>storm-metamodel-processor</artifactId>
     <name>Storm Metamodel Processor</name>
     <description>Metamodel extensions for Java.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -21,13 +21,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-metamodel-processor/pom.xml
+++ b/storm-metamodel-processor/pom.xml
@@ -21,7 +21,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-micrometer/pom.xml
+++ b/storm-micrometer/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>storm-micrometer</artifactId>
     <name>Storm Micrometer</name>
     <description>Micrometer Observation binding for Storm's query observer, providing metrics and tracing for query execution.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -25,9 +25,9 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-micrometer/pom.xml
+++ b/storm-micrometer/pom.xml
@@ -21,7 +21,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-mssqlserver/pom.xml
+++ b/storm-mssqlserver/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-mssqlserver</artifactId>
     <name>Storm MS SQL Server</name>
     <description>MS SQL Server extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-mssqlserver/pom.xml
+++ b/storm-mssqlserver/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-mysql/pom.xml
+++ b/storm-mysql/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-mysql</artifactId>
     <name>Storm MySQL</name>
     <description>MySQL extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-mysql/pom.xml
+++ b/storm-mysql/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-oracle/pom.xml
+++ b/storm-oracle/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-oracle/pom.xml
+++ b/storm-oracle/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-oracle</artifactId>
     <name>Storm Oracle</name>
     <description>Oracle extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-postgresql/pom.xml
+++ b/storm-postgresql/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-postgresql</artifactId>
     <name>Storm PostgreSQL</name>
     <description>PostgreSQL extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-postgresql/pom.xml
+++ b/storm-postgresql/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-spring-boot-starter/pom.xml
+++ b/storm-spring-boot-starter/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-spring-boot-starter</artifactId>
     <name>Storm Spring Boot Starter</name>
     <description>Spring Boot Starter for Storm, providing auto-configuration for the Storm ORM framework.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-spring-boot-starter/pom.xml
+++ b/storm-spring-boot-starter/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-spring-boot-test-autoconfigure/pom.xml
+++ b/storm-spring-boot-test-autoconfigure/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-spring-boot-test-autoconfigure</artifactId>
     <name>Storm Spring Boot Test AutoConfigure</name>
     <description>Test slice support for Storm in Spring Boot applications, providing the @DataStormTest annotation.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-spring-boot-test-autoconfigure/pom.xml
+++ b/storm-spring-boot-test-autoconfigure/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-spring/pom.xml
+++ b/storm-spring/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-spring</artifactId>
     <name>Storm Spring</name>
     <description>Spring extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-spring/pom.xml
+++ b/storm-spring/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-sqlite/pom.xml
+++ b/storm-sqlite/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-sqlite</artifactId>
     <name>Storm SQLite</name>
     <description>SQLite extensions for Storm.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-sqlite/pom.xml
+++ b/storm-sqlite/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>

--- a/storm-test/pom.xml
+++ b/storm-test/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>storm-test</artifactId>
     <name>Storm Test</name>
     <description>Test support for Storm, providing JUnit 5 integration and SQL statement capture utilities.</description>
-    <url>https://github.com/storm-repo/storm-framework</url>
+    <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
@@ -22,13 +22,13 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>storm@zantvoort.biz</email>
+            <email>zantvoort@orm.st</email>
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/storm-repo/storm-framework.git</connection>
-        <developerConnection>scm:git:ssh://github.com/storm-repo/storm-framework.git</developerConnection>
-        <url>https://github.com/storm-repo/storm-framework/</url>
+        <connection>scm:git:git://github.com/storm-orm/storm-framework.git</connection>
+        <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
+        <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
     <build>
         <plugins>

--- a/storm-test/pom.xml
+++ b/storm-test/pom.xml
@@ -22,7 +22,7 @@
     <developers>
         <developer>
             <name>Leon van Zantvoort</name>
-            <email>zantvoort@orm.st</email>
+            <email>dev@orm.st</email>
         </developer>
     </developers>
     <scm>


### PR DESCRIPTION
The parent pom and all 26 module poms carried the old `storm-repo` org in their `<url>`/`<scm>` blocks. The old URL redirects today, but Central metadata is immutable per release, so every release bakes the stale coordinates in permanently. This points them all at `storm-orm`, along with the `CONTRIBUTING.md` clone command and the `docs/index.md` LICENSE link. The `versioned_docs/` snapshots are left frozen, so the docs change appears at `/docs/next` and reaches the live docs with the next release snapshot.

Contact addresses are unified on the role-based `dev@orm.st`: the parent pom and storm-micrometer used `zantvoort@orm.st`, the other 25 module poms still had `storm@zantvoort.biz`, and `SECURITY.md` used `security@zantvoort.biz` for reports and `storm@zantvoort.biz` for policy questions. `CODE_OF_CONDUCT.md` carried the same stale address and is updated as well.

Verified with `mvn validate` and a full repo sweep: no `storm-repo/`, `zantvoort.biz`, or personal-address references remain outside the frozen `versioned_docs/` snapshots.

Fixes #416