### PR TITLE
fix: keep the PostgreSQL, MariaDB and MSSQL JDBC drivers at test scope

### DIFF
--- a/storm-mariadb/pom.xml
+++ b/storm-mariadb/pom.xml
@@ -151,6 +151,7 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>3.3.3</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/storm-mssqlserver/pom.xml
+++ b/storm-mssqlserver/pom.xml
@@ -145,6 +145,7 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>12.2.0.jre11</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/storm-postgresql/pom.xml
+++ b/storm-postgresql/pom.xml
@@ -141,6 +141,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.4</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>st.orm</groupId>


### PR DESCRIPTION
The `postgresql` (42.7.4), `mariadb-java-client` (3.3.3) and `mssql-jdbc` (12.2.0.jre11) drivers shipped at compile scope in the published poms, dragging an unmanaged driver version into applications that add one of these dialects and overriding the application's own dependency management. The other four dialect modules already keep their drivers at test scope.

This moves the three drivers to test scope. No main source in these modules references driver classes and no `module-info.java` requires a driver module, so the drivers were test-only all along. The flattened poms now list all three at test scope, which consumers ignore.

Verified with the full test suites of all three modules against real databases via Testcontainers: PostgreSQL 181, MariaDB 161, MSSQL Server 180 tests, zero failures.

Fixes #402