### PR TITLE
fix: move @GenerateMetamodel to st.orm so the processors find it

### DIFF
--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -798,29 +798,17 @@ path1.canonical().equals(path2.canonical());  // true
 
 ## `@GenerateMetamodel` Annotation
 
-By default, the metamodel processor generates metamodel classes for all records that implement `Entity` or `Projection`. If you have a plain record (or data class) that does not implement either interface but you still want a metamodel generated for it, annotate it with `@GenerateMetamodel`.
-
-This is useful for:
-- Inline records (embedded components) that you want to reference in queries via the metamodel
-- `Data` implementations used in custom SQL templates
-- Any non-entity record where you want compile-time type-safe field references
+The metamodel processor generates metamodel classes for every record that implements `Data`, which includes all entities and projections, and for every record such a type references, so the entity graph is covered automatically. A record that stays outside the entity graph, such as a plain result row for a custom query, is skipped. Annotate it with `@GenerateMetamodel` to process it anyway: its metamodel class is generated next to it, and it receives an instantiator so the runtime constructs instances without reflection. On GraalVM native images this keeps custom query rows working without reflection configuration.
 
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
 
 ```kotlin
 @GenerateMetamodel
-data class Address(
-    val street: String,
-    @FK val city: City
+data class CityStats(
+    val name: String,
+    val inhabitants: Int
 )
-
-// Now Address_ is available for type-safe references
-val addresses = orm.query { """
-    SELECT ${Address::class}
-    FROM ${Address::class}
-    WHERE ${Address_.street} LIKE ${"%Main%"}
-""" }
 ```
 
 </TabItem>
@@ -828,20 +816,15 @@ val addresses = orm.query { """
 
 ```java
 @GenerateMetamodel
-record Address(String street,
-               @FK City city) {}
-
-// Now Address_ is available for type-safe references
-var addresses = orm.query(RAW."""
-        SELECT \{Address.class}
-        FROM \{Address.class}
-        WHERE \{Address_.street} LIKE \{"%Main%"}""");
+record CityStats(String name, int inhabitants) {}
 ```
 
 </TabItem>
 </Tabs>
 
-The `@GenerateMetamodel` annotation is located in `st.orm.core.template` and requires the `storm-core` dependency at compile time (provided scope is sufficient).
+The root metamodel interface (`CityStats_` in this example) is only generated for `Data` types: every metamodel is rooted in a `Data` type, so a plain record participates in queries through the entity graph that references it rather than as a root of its own.
+
+The `@GenerateMetamodel` annotation is located in the `st.orm` package alongside Storm's other annotations.
 
 ## Benefits
 

--- a/storm-foundation/src/main/java/st/orm/GenerateMetamodel.java
+++ b/storm-foundation/src/main/java/st/orm/GenerateMetamodel.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package st.orm.core.template;
+package st.orm;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -22,9 +22,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that a metamodel class should be generated for the annotated record.
+ * Indicates that a metamodel class should be generated for the annotated record or data class.
  *
- * <p><strong>Note:</strong> This annotation is not required for records implementing {@code Entity} or
+ * <p><strong>Note:</strong> This annotation is not required for types implementing {@code Entity} or
  * {@code Projection}, as they are automatically included when the annotation processor is enabled.</p>
  *
  * @since 1.2

--- a/storm-metamodel-ksp/pom.xml
+++ b/storm-metamodel-ksp/pom.xml
@@ -171,8 +171,50 @@
         <dependency>
             <groupId>com.google.devtools.ksp</groupId>
             <artifactId>symbol-processing-api</artifactId>
-            <version>2.0.21-1.0.25</version>
+            <version>${kotlin.ksp.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>st.orm</groupId>
+            <artifactId>storm-foundation</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.zacsweers.kctfork</groupId>
+            <artifactId>ksp</artifactId>
+            <version>0.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Align kctfork's transitive compiler and KSP artifacts with this module's toolchain. -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-compiler-embeddable</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.devtools.ksp</groupId>
+            <artifactId>symbol-processing</artifactId>
+            <version>${kotlin.ksp.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.devtools.ksp</groupId>
+            <artifactId>symbol-processing-common-deps</artifactId>
+            <version>${kotlin.ksp.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.devtools.ksp</groupId>
+            <artifactId>symbol-processing-aa-embeddable</artifactId>
+            <version>${kotlin.ksp.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/storm-metamodel-ksp/src/test/kotlin/st/orm/metamodel/MetamodelProcessorTest.kt
+++ b/storm-metamodel-ksp/src/test/kotlin/st/orm/metamodel/MetamodelProcessorTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.metamodel
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspSourcesDir
+import com.tschuchort.compiletesting.symbolProcessorProviders
+import com.tschuchort.compiletesting.useKsp2
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Compiles fixture sources with the processor attached and asserts on the generated files. The fixtures compile
+ * against the actual storm-foundation classes, so the `st.orm.GenerateMetamodel` annotation the processor matches
+ * by name is the real one and the generated code compiles against the real metamodel base classes.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+class MetamodelProcessorTest {
+
+    private fun compile(source: String): KotlinCompilation {
+        val compilation = KotlinCompilation().apply {
+            sources = listOf(SourceFile.kotlin("CityStats.kt", source))
+            useKsp2()
+            symbolProcessorProviders = mutableListOf(MetamodelProcessorProvider())
+            inheritClassPath = true
+            verbose = false
+        }
+        val result = compilation.compile()
+        assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode, result.messages)
+        return compilation
+    }
+
+    private fun KotlinCompilation.generatedFileNames(): Set<String> = kspSourcesDir.walkTopDown().filter { it.isFile }.map { it.name }.toSet()
+
+    @Test
+    fun `generates metamodel for annotated plain data class`() {
+        val compilation = compile(
+            """
+            package com.example
+
+            import st.orm.GenerateMetamodel
+
+            @GenerateMetamodel
+            data class CityStats(val name: String, val inhabitants: Int)
+            """.trimIndent(),
+        )
+        val generated = compilation.generatedFileNames()
+        assertTrue("CityStatsMetamodel.kt" in generated) {
+            "expected a metamodel for the @GenerateMetamodel data class, generated: $generated"
+        }
+        assertTrue("CityStatsNullableMetamodel.kt" in generated) {
+            "expected a nullable-chain metamodel for the @GenerateMetamodel data class, generated: $generated"
+        }
+        assertTrue("CityStatsInstantiator.kt" in generated) {
+            "expected an instantiator for the @GenerateMetamodel data class, generated: $generated"
+        }
+        assertFalse("CityStats_.kt" in generated) {
+            "the root metamodel interface is reserved for Data types, generated: $generated"
+        }
+        val services = compilation.workingDir.walkTopDown().filter { it.isFile }
+        assertTrue(services.any { it.name == "st.orm.mapping.Instantiator" && "CityStatsInstantiator" in it.readText() }) {
+            "expected an instantiator service registration"
+        }
+    }
+
+    @Test
+    fun `ignores plain data class without annotation`() {
+        val compilation = compile(
+            """
+            package com.example
+
+            data class CityStats(val name: String, val inhabitants: Int)
+            """.trimIndent(),
+        )
+        val generated = compilation.generatedFileNames()
+        assertTrue(generated.isEmpty()) {
+            "a plain data class without @GenerateMetamodel should not get generated files, generated: $generated"
+        }
+    }
+}

--- a/storm-metamodel-processor/pom.xml
+++ b/storm-metamodel-processor/pom.xml
@@ -41,12 +41,26 @@
                     <release>${java.version}</release>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <storm.foundation.sources>${project.basedir}/../storm-foundation/src/main/java</storm.foundation.sources>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/storm-metamodel-processor/src/test/java/st/orm/metamodel/MetamodelProcessorTest.java
+++ b/storm-metamodel-processor/src/test/java/st/orm/metamodel/MetamodelProcessorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.metamodel;
+
+import static java.util.stream.Collectors.joining;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Compiles fixture sources with the processor attached and asserts on the generated files.
+ *
+ * <p>The fixtures compile against the actual storm-foundation sources via {@code -sourcepath}, so the
+ * {@code st.orm.GenerateMetamodel} annotation the processor matches by name is the real one and the generated
+ * code compiles against the real metamodel base classes. A jar dependency on storm-foundation is not an option
+ * here: storm-foundation's own build runs this processor through {@code annotationProcessorPaths}, an edge the
+ * reactor sorter cannot see, so a visible dependency in the other direction would order storm-foundation first
+ * and break builds that start from an empty repository.</p>
+ */
+class MetamodelProcessorTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private record Compilation(boolean success, String errors, Path generatedSources, Path classes) {
+
+        boolean generated(String relativePath) {
+            return Files.exists(generatedSources.resolve(relativePath));
+        }
+    }
+
+    @Test
+    void generatesMetamodelForAnnotatedPlainRecord() throws Exception {
+        Compilation compilation = compile("CityStats.java", """
+                import st.orm.GenerateMetamodel;
+
+                @GenerateMetamodel
+                public record CityStats(String name, int inhabitants) {}
+                """);
+        assertTrue(compilation.success(), compilation.errors());
+        assertTrue(compilation.generated("CityStatsMetamodel.java"),
+                "expected a metamodel for the @GenerateMetamodel record");
+        assertTrue(compilation.generated("CityStatsInstantiator.java"),
+                "expected an instantiator for the @GenerateMetamodel record");
+        assertTrue(Files.exists(compilation.classes().resolve("CityStatsMetamodel.class")),
+                "expected the generated metamodel to compile");
+        assertFalse(compilation.generated("CityStats_.java"),
+                "the root metamodel interface is reserved for Data records");
+        Path services = compilation.classes().resolve("META-INF/services/st.orm.mapping.Instantiator");
+        assertTrue(Files.exists(services), "expected an instantiator service registration");
+        assertTrue(Files.readString(services).contains("CityStatsInstantiator"));
+    }
+
+    @Test
+    void ignoresPlainRecordWithoutAnnotation() throws Exception {
+        Compilation compilation = compile("CityStats.java", """
+                public record CityStats(String name, int inhabitants) {}
+                """);
+        assertTrue(compilation.success(), compilation.errors());
+        assertFalse(compilation.generated("CityStatsMetamodel.java"),
+                "a plain record without @GenerateMetamodel should not get a metamodel");
+        assertFalse(compilation.generated("CityStatsInstantiator.java"),
+                "a plain record without @GenerateMetamodel should not get an instantiator");
+    }
+
+    private Compilation compile(String fileName, String source) throws IOException, URISyntaxException {
+        Path fixtureDir = Files.createDirectories(tempDir.resolve("fixtures"));
+        Path sourcePath = Files.createDirectories(tempDir.resolve("sourcepath"));
+        Path generatedSources = Files.createDirectories(tempDir.resolve("generated"));
+        Path classes = Files.createDirectories(tempDir.resolve("classes"));
+        copyFoundationSources(sourcePath);
+        Path fixture = fixtureDir.resolve(fileName);
+        Files.writeString(fixture, source);
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
+            List<String> options = List.of(
+                    "-d", classes.toString(),
+                    "-s", generatedSources.toString(),
+                    "-sourcepath", sourcePath.toString(),
+                    "-implicit:class",
+                    "-classpath", jarOf(jakarta.annotation.Nonnull.class));
+            JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, options, null,
+                    fileManager.getJavaFileObjectsFromPaths(List.of(fixture)));
+            task.setProcessors(List.of(new MetamodelProcessor()));
+            boolean success = task.call();
+            String errors = diagnostics.getDiagnostics().stream()
+                    .filter(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR)
+                    .map(Object::toString)
+                    .collect(joining("\n"));
+            return new Compilation(success, errors, generatedSources, classes);
+        }
+    }
+
+    /**
+     * Copies the storm-foundation package tree onto the fixture sourcepath, leaving the module declaration
+     * behind so the fixture compilation stays on the classpath instead of turning modular.
+     */
+    private static void copyFoundationSources(Path sourcePath) throws IOException {
+        Path foundation = foundationSources().resolve("st");
+        try (Stream<Path> sources = Files.walk(foundation)) {
+            for (Path source : sources.toList()) {
+                Path target = sourcePath.resolve("st").resolve(foundation.relativize(source).toString());
+                if (Files.isDirectory(source)) {
+                    Files.createDirectories(target);
+                } else {
+                    Files.copy(source, target);
+                }
+            }
+        }
+    }
+
+    private static Path foundationSources() {
+        String configured = System.getProperty("storm.foundation.sources");
+        Path path = configured != null
+                ? Path.of(configured)
+                : Path.of("..", "storm-foundation", "src", "main", "java");
+        assertTrue(Files.isDirectory(path.resolve("st").resolve("orm")),
+                "storm-foundation sources not found at " + path.toAbsolutePath());
+        return path;
+    }
+
+    private static String jarOf(Class<?> type) throws URISyntaxException {
+        return Path.of(type.getProtectionDomain().getCodeSource().getLocation().toURI()).toString();
+    }
+}


### PR DESCRIPTION
## Problem

Both metamodel processors look the annotation up as `st.orm.GenerateMetamodel` (`MetamodelProcessor.java:70`, `MetamodelProcessor.kt:88`), but the annotation lived in `st.orm.core.template`. Annotating a plain record or data class therefore generated nothing, with no diagnostic and no test. It was also the only user-facing annotation outside the `st.orm` package.

## Changes

- Move `GenerateMetamodel` to `st.orm` in storm-foundation, which already exports the package. This fixes the lookup and the package convention in one change.
- Add the first tests to both processor modules:
  - **storm-metamodel-processor** compiles fixtures through the JavaCompiler API with the processor attached, resolving storm-foundation via `-sourcepath` instead of a jar dependency. Foundation's `annotationProcessorPaths` references this processor through an edge the reactor sorter cannot see, so a visible dependency in the other direction would order foundation first and break builds that start from an empty repository.
  - **storm-metamodel-ksp** compiles fixtures with kctfork in KSP2 mode; the KSP1 hook is a K1-only `AnalysisHandlerExtension` that the K2 compiler skips silently. The compiler and KSP transitives are pinned to the module's toolchain versions.
  - Both assert that an annotated plain type gets its metamodel class (plus the nullable-chain variant on the KSP side) and an instantiator with its service registration, that no root metamodel interface is generated, and that an unannotated plain type generates nothing.
- Correct the `@GenerateMetamodel` docs section. The old example promised `Address_` for a plain record, which the type system rules out: `Metamodel<T extends Data, E>` roots every metamodel in a `Data` type, so the root interface exists only for `Data` types. The section now describes what the annotation actually produces: the metamodel class and a reflection-free instantiator for records outside the entity graph. The docs change shows at `/docs/next` until the next release snapshot.

## Verification

`mvn verify` (including spotless) is green on storm-metamodel-processor (2 tests), storm-foundation (320), storm-metamodel-ksp (2), and storm-core (2523). The full-reactor build order still places the processor before foundation.

Fixes #378