### PR TITLE
fix!: execute count queries for getResultCount, infer page totals, remove QueryBuilder.append

### DIFF
--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -365,7 +365,7 @@ Storm provides two strategies for traversing large result sets: pagination (by p
 
 ### Offset-Based Pagination
 
-Use the `page()` method on any entity or projection repository. Storm executes the data query and count query automatically, returning a `Page` that includes the result list and total count.
+Use the `page()` method on any entity or projection repository. Storm executes the data query, adds a count query only when the total cannot be derived from the fetched page, and returns a `Page` that includes the result list and total count.
 
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>

--- a/docs/pagination-and-scrolling.md
+++ b/docs/pagination-and-scrolling.md
@@ -59,7 +59,7 @@ List<User> results = orm.entity(User.class)
 
 ## Pagination
 
-Pagination navigates by page number and returns a `Page<R>`. Each request typically requires two queries: a `SELECT COUNT(*)` to determine the total number of results, and a data query with `OFFSET`/`LIMIT` for the content.
+Pagination navigates by page number and returns a `Page<R>`. Each request runs a data query with `OFFSET`/`LIMIT` for the content, plus a `SELECT COUNT(*)` when the total cannot be derived from the fetched page. A page that is not full determines the total directly, so the count query only runs for a full page, or for an empty page beyond the first.
 
 Use the `page` terminal method on the query builder. Pass a `Pageable` to specify the page number and page size. The result is a `Page` containing the content, total count, and navigation methods.
 

--- a/storm-core/src/main/java/st/orm/core/repository/EntityRepository.java
+++ b/storm-core/src/main/java/st/orm/core/repository/EntityRepository.java
@@ -658,8 +658,9 @@ public interface EntityRepository<E extends Entity<ID>, ID> extends Repository {
     /**
      * Returns a page of entities using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of entities, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * entities.</p>
      *
      * <p>Page numbers are zero-based: pass {@code 0} for the first page.</p>
      *
@@ -675,8 +676,9 @@ public interface EntityRepository<E extends Entity<ID>, ID> extends Repository {
     /**
      * Returns a page of entities using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of entities, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * entities.</p>
      *
      * <p>Use {@link Pageable#ofSize(int)} for the first page, then navigate with
      * {@link Page#nextPageable()} or {@link Page#previousPageable()}.</p>
@@ -686,7 +688,7 @@ public interface EntityRepository<E extends Entity<ID>, ID> extends Repository {
      * @since 1.10
      */
     default Page<E> page(@Nonnull Pageable pageable) {
-        return select().page(pageable, count());
+        return select().page(pageable);
     }
 
     /**
@@ -706,15 +708,16 @@ public interface EntityRepository<E extends Entity<ID>, ID> extends Repository {
     /**
      * Returns a page of entity refs using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of entities, and
-     * a query with OFFSET and LIMIT to fetch the refs for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the refs for the requested page and, when the
+     * total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * entities.</p>
      *
      * @param pageable the pagination request specifying page number and page size.
      * @return a page containing the ref results and pagination metadata.
      * @since 1.10
      */
     default Page<Ref<E>> pageRef(@Nonnull Pageable pageable) {
-        return selectRef().page(pageable, count());
+        return selectRef().page(pageable);
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/repository/ProjectionRepository.java
+++ b/storm-core/src/main/java/st/orm/core/repository/ProjectionRepository.java
@@ -299,8 +299,9 @@ public interface ProjectionRepository<P extends Projection<ID>, ID> extends Repo
     /**
      * Returns a page of projections using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of projections, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * projections.</p>
      *
      * <p>Page numbers are zero-based: pass {@code 0} for the first page.</p>
      *
@@ -316,8 +317,9 @@ public interface ProjectionRepository<P extends Projection<ID>, ID> extends Repo
     /**
      * Returns a page of projections using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of projections, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * projections.</p>
      *
      * <p>Use {@link Pageable#ofSize(int)} for the first page, then navigate with
      * {@link Page#nextPageable()} or {@link Page#previousPageable()}.</p>
@@ -327,7 +329,7 @@ public interface ProjectionRepository<P extends Projection<ID>, ID> extends Repo
      * @since 1.10
      */
     default Page<P> page(@Nonnull Pageable pageable) {
-        return select().page(pageable, count());
+        return select().page(pageable);
     }
 
     /**
@@ -347,15 +349,16 @@ public interface ProjectionRepository<P extends Projection<ID>, ID> extends Repo
     /**
      * Returns a page of projection refs using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of projections, and
-     * a query with OFFSET and LIMIT to fetch the refs for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the refs for the requested page and, when the
+     * total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * projections.</p>
      *
      * @param pageable the pagination request specifying page number and page size.
      * @return a page containing the ref results and pagination metadata.
      * @since 1.10
      */
     default Page<Ref<P>> pageRef(@Nonnull Pageable pageable) {
-        return selectRef().page(pageable, count());
+        return selectRef().page(pageable);
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
+++ b/storm-core/src/main/java/st/orm/core/template/QueryBuilder.java
@@ -701,24 +701,6 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      */
     public abstract QueryBuilder<T, R, ID> offset(int offset);
 
-    /**
-     * Append the query with a string template.
-     *
-     * @param template the string template to append.
-     * @return the query builder.
-     */
-    public abstract QueryBuilder<T, R, ID> append(@Nonnull TemplateString template);
-
-    /**
-     * Append the query with a string template.
-     *
-     * @param template the string template to append.
-     * @return the query builder.
-     */
-    public final QueryBuilder<T, R, ID> append(@Nonnull String template) {
-        return append(TemplateString.of(template));
-    }
-
     //
     // Locking.
     //
@@ -800,9 +782,10 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     /**
      * Executes the query and returns a {@link Page} of results using offset-based pagination.
      *
-     * <p>This method executes two queries: one to count the total number of matching results (without offset or
-     * limit), and one to fetch the content for the requested page. The caller is responsible for adding ORDER BY
-     * clauses to ensure deterministic ordering across pages.</p>
+     * <p>This method executes the query for the requested page and, when the total cannot be derived from the
+     * fetched page, a count query (without offset or limit). A page that is not full determines the total directly,
+     * so the count query only runs for a full page, or for an empty page beyond the first. The caller is responsible
+     * for adding ORDER BY clauses to ensure deterministic ordering across pages.</p>
      *
      * <p>Page numbers are zero-based: pass {@code 0} for the first page.</p>
      *
@@ -819,10 +802,11 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     /**
      * Executes the query and returns a {@link Page} of results using offset-based pagination.
      *
-     * <p>This method executes two queries: one to count the total number of matching results (without offset or
-     * limit), and one to fetch the content for the requested page. Sort orders can be specified either through the
-     * pageable or through explicit {@code orderBy} calls on the query builder, but not both. If both are present,
-     * a {@link PersistenceException} is thrown.</p>
+     * <p>This method executes the query for the requested page and, when the total cannot be derived from the
+     * fetched page, a count query (without offset or limit). A page that is not full determines the total directly,
+     * so the count query only runs for a full page, or for an empty page beyond the first. Sort orders can be
+     * specified either through the pageable or through explicit {@code orderBy} calls on the query builder, but not
+     * both. If both are present, a {@link PersistenceException} is thrown.</p>
      *
      * <p>Use {@link Pageable#ofSize(int)} for the first page, then navigate with
      * {@link Page#nextPageable()} or {@link Page#previousPageable()}.</p>
@@ -833,7 +817,16 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.10
      */
     public final Page<R> page(@Nonnull Pageable pageable) {
-        return page(pageable, getResultCount());
+        List<R> content = pageContent(pageable);
+        long totalCount;
+        if (content.size() < pageable.pageSize() && (pageable.offset() == 0 || !content.isEmpty())) {
+            // A page that is not full is the last page, so the total follows from the page itself. An empty page
+            // beyond the first proves nothing: the offset may lie anywhere past the end.
+            totalCount = pageable.offset() + content.size();
+        } else {
+            totalCount = getResultCount();
+        }
+        return new Page<>(content, totalCount, pageable);
     }
 
     /**
@@ -855,6 +848,13 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.10
      */
     public final Page<R> page(@Nonnull Pageable pageable, long totalCount) {
+        return new Page<>(pageContent(pageable), totalCount, pageable);
+    }
+
+    /**
+     * Fetches the content for the requested page, applying the pageable's sort orders and offset/limit window.
+     */
+    private List<R> pageContent(@Nonnull Pageable pageable) {
         // Forbid combining explicit orderBy with Pageable sort orders for consistency with scroll, which also
         // manages ORDER BY internally and forbids explicit orderBy calls.
         if (hasOrderBy() && !pageable.orders().isEmpty()) {
@@ -865,8 +865,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
             // The Pageable's sort field may be rooted anywhere in the query, so the column is named directly.
             sorted = sorted.orderBy(wrap(new Columns(order.field(), CASCADE, order.descending())));
         }
-        List<R> content = sorted.offset((int) pageable.offset()).limit(pageable.pageSize()).getResultList();
-        return new Page<>(content, totalCount, pageable);
+        return sorted.offset((int) pageable.offset()).limit(pageable.pageSize()).getResultList();
     }
 
     /**
@@ -1058,11 +1057,16 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     /**
      * Returns the number of results of this query.
      *
+     * <p>Select queries execute a dedicated count query derived from this builder: the select clause is replaced by
+     * {@code COUNT(*)}, or the query is counted as a derived table when its shape requires it (DISTINCT, GROUP BY,
+     * HAVING, limit, offset or a custom select clause). Queries that lock rows fetch and count
+     * the results instead, so the requested locks are acquired.</p>
+     *
      * @return the total number of results of this query as a long value.
      * @throws PersistenceException if the query operation fails due to underlying database issues, such as
      *                              connectivity.
      */
-    public final long getResultCount() {
+    public long getResultCount() {
         try (var stream = getResultStream()) {
             return stream.count();
         }

--- a/storm-core/src/main/java/st/orm/core/template/impl/DeleteBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/DeleteBuilderImpl.java
@@ -45,20 +45,19 @@ public class DeleteBuilderImpl<T extends Data, ID> extends QueryBuilderImpl<T, O
     private final boolean unsafe;
 
     public DeleteBuilderImpl(@Nonnull QueryTemplate queryTemplate, @Nonnull Class<T> fromType, @Nonnull Supplier<Model<T, ID>> modelSupplier) {
-        this(queryTemplate, fromType, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), modelSupplier, false);
+        this(queryTemplate, fromType, List.of(), List.of(), List.of(), List.of(), List.of(), modelSupplier, false);
     }
 
     private DeleteBuilderImpl(@Nonnull QueryTemplate queryTemplate,
                               @Nonnull Class<T> fromType,
                               @Nonnull List<Join> join,
                               @Nonnull List<Where> where,
-                              @Nonnull List<TemplateString> templates,
                               @Nonnull List<TemplateString> groupBy,
                               @Nonnull List<TemplateString> having,
                               @Nonnull List<TemplateString> orderBy,
                               @Nonnull Supplier<Model<T, ID>> modelSupplier,
                               boolean unsafe) {
-        super(queryTemplate, fromType, join, where, templates, groupBy, having, orderBy, modelSupplier);
+        super(queryTemplate, fromType, join, where, groupBy, having, orderBy, modelSupplier);
         this.unsafe = unsafe;
     }
 
@@ -73,7 +72,7 @@ public class DeleteBuilderImpl<T extends Data, ID> extends QueryBuilderImpl<T, O
      */
     @Override
     public QueryBuilder<T, Object, ID> unsafe() {
-        return new DeleteBuilderImpl<>(queryTemplate, fromType, join, where, templates, groupBy, having, orderBy, modelSupplier, true);
+        return new DeleteBuilderImpl<>(queryTemplate, fromType, join, where, groupBy, having, orderBy, modelSupplier, true);
     }
 
     /**
@@ -83,7 +82,6 @@ public class DeleteBuilderImpl<T extends Data, ID> extends QueryBuilderImpl<T, O
      * @param fromType the type of the table being queried.
      * @param join the list of joins.
      * @param where the list of where clauses.
-     * @param templates the list of string templates.
      * @return a new query builder.
      */
     @Override
@@ -91,11 +89,10 @@ public class DeleteBuilderImpl<T extends Data, ID> extends QueryBuilderImpl<T, O
                                          @Nonnull Class<T> fromType,
                                          @Nonnull List<Join> join,
                                          @Nonnull List<Where> where,
-                                         @Nonnull List<TemplateString> templates,
                                          @Nonnull List<TemplateString> groupBy,
                                          @Nonnull List<TemplateString> having,
                                          @Nonnull List<TemplateString> orderBy) {
-        return new DeleteBuilderImpl<>(queryTemplate, fromType, join, where, templates, groupBy, having, orderBy, modelSupplier, unsafe);
+        return new DeleteBuilderImpl<>(queryTemplate, fromType, join, where, groupBy, having, orderBy, modelSupplier, unsafe);
     }
 
     /**
@@ -216,9 +213,6 @@ public class DeleteBuilderImpl<T extends Data, ID> extends QueryBuilderImpl<T, O
                         .orElseThrow();
                 template = TemplateString.combine(template, TemplateString.of("\nWHERE "), whereClause);
             }
-        }
-        if (!templates.isEmpty()) {
-            template = TemplateString.combine(template, TemplateString.combine(templates));
         }
         if (!supportsJoin()) {
             template = TemplateString.combine(TemplateString.raw("DELETE\nFROM \0\nWHERE (", from(fromType, false)),

--- a/storm-core/src/main/java/st/orm/core/template/impl/QueryBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/QueryBuilderImpl.java
@@ -70,7 +70,6 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
     protected final Class<T> fromType;
     protected final List<Join> join;
     protected final List<Where> where;
-    protected final List<TemplateString> templates;
     protected final List<TemplateString> groupBy;
     protected final List<TemplateString> having;
     protected final List<TemplateString> orderBy;
@@ -80,7 +79,6 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
                                @Nonnull Class<T> fromType,
                                @Nonnull List<Join> join,
                                @Nonnull List<Where> where,
-                               @Nonnull List<TemplateString> templates,
                                @Nonnull List<TemplateString> groupBy,
                                @Nonnull List<TemplateString> having,
                                @Nonnull List<TemplateString> orderBy,
@@ -89,7 +87,6 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
         this.fromType = fromType;
         this.join = List.copyOf(join);
         this.where = List.copyOf(where);
-        this.templates = List.copyOf(templates);
         this.groupBy = List.copyOf(groupBy);
         this.having = List.copyOf(having);
         this.orderBy = List.copyOf(orderBy);
@@ -163,14 +160,12 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
      * @param fromType the type of the table being queried.
      * @param join the list of joins.
      * @param where the list of where clauses.
-     * @param templates the list of string templates.
      * @return a new query builder.
      */
     abstract QueryBuilder<T, R, ID> copyWith(@Nonnull QueryTemplate queryTemplate,
                                              @Nonnull Class<T> fromType,
                                              @Nonnull List<Join> join,
                                              @Nonnull List<Where> where,
-                                             @Nonnull List<TemplateString> templates,
                                              @Nonnull List<TemplateString> groupBy,
                                              @Nonnull List<TemplateString> having,
                                              @Nonnull List<TemplateString> orderBy);
@@ -201,7 +196,7 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
     private QueryBuilder<Data, R, ID> addJoin(@Nonnull Join join) {
         List<Join> copy = new ArrayList<>(this.join);
         copy.add(join);
-        return (QueryBuilder<Data, R, ID>) copyWith(queryTemplate, fromType, copy, where, templates, groupBy, having, orderBy);
+        return (QueryBuilder<Data, R, ID>) copyWith(queryTemplate, fromType, copy, where, groupBy, having, orderBy);
     }
 
     /**
@@ -224,23 +219,7 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
     private QueryBuilder<T, R, ID> addWhere(@Nonnull Where where) {
         List<Where> copy = new ArrayList<>(this.where);
         copy.add(where);
-        return copyWith(queryTemplate, fromType, join, copy, templates, groupBy, having, orderBy);
-    }
-
-    /**
-     * Append the query with a string template.
-     *
-     * @param template the string template to append.
-     * @return the query builder.
-     */
-    @Override
-    public QueryBuilder<T, R, ID> append(@Nonnull TemplateString template) {
-        List<TemplateString> copy = new ArrayList<>(templates);
-        if (!template.fragments().isEmpty()) {
-            template = combine(TemplateString.of("\n"), template);
-        }
-        copy.add(template);
-        return copyWith(queryTemplate, fromType, join, where, copy, groupBy, having, orderBy);
+        return copyWith(queryTemplate, fromType, join, copy, groupBy, having, orderBy);
     }
 
     /**
@@ -254,7 +233,7 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
     public QueryBuilder<T, R, ID> orderBy(@Nonnull TemplateString template) {
         List<TemplateString> copy = new ArrayList<>(orderBy);
         copy.add(template);
-        return copyWith(queryTemplate, fromType, join, where, templates, groupBy, having, copy);
+        return copyWith(queryTemplate, fromType, join, where, groupBy, having, copy);
     }
 
     /**
@@ -268,7 +247,7 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
     public QueryBuilder<T, R, ID> groupBy(@Nonnull TemplateString template) {
         List<TemplateString> copy = new ArrayList<>(groupBy);
         copy.add(template);
-        return copyWith(queryTemplate, fromType, join, where, templates, copy, having, orderBy);
+        return copyWith(queryTemplate, fromType, join, where, copy, having, orderBy);
     }
 
     /**
@@ -282,7 +261,7 @@ abstract class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<T, R
     public QueryBuilder<T, R, ID> having(@Nonnull TemplateString template) {
         List<TemplateString> copy = new ArrayList<>(having);
         copy.add(template);
-        return copyWith(queryTemplate, fromType, join, where, templates, groupBy, copy, orderBy);
+        return copyWith(queryTemplate, fromType, join, where, groupBy, copy, orderBy);
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/SelectBuilderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SelectBuilderImpl.java
@@ -39,6 +39,8 @@ import st.orm.core.template.QueryBuilder;
 import st.orm.core.template.QueryPlan;
 import st.orm.core.template.QueryTemplate;
 import st.orm.core.template.TemplateString;
+import st.orm.core.template.impl.Elements.Fetch;
+import st.orm.core.template.impl.Elements.Select;
 import st.orm.core.template.impl.Elements.Where;
 
 /**
@@ -66,7 +68,7 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
                              @Nonnull TemplateString selectTemplate,
                              boolean subquery,
                              @Nonnull Supplier<Model<T, ID>> modelSupplier) {
-        this(queryTemplate, fromType, selectType, false, List.of(), List.of(), null, null, TemplateString.EMPTY, selectTemplate, List.of(), List.of(), List.of(), List.of(), subquery, null, null, List.of(), modelSupplier);
+        this(queryTemplate, fromType, selectType, false, List.of(), List.of(), null, null, TemplateString.EMPTY, selectTemplate, List.of(), List.of(), List.of(), subquery, null, null, List.of(), modelSupplier);
     }
 
     public SelectBuilderImpl(@Nonnull QueryTemplate queryTemplate,
@@ -75,7 +77,7 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
                              @Nonnull Class<?> pkType,
                              @Nonnull Supplier<Model<T, ID>> modelSupplier) {
         //noinspection unchecked
-        this(queryTemplate, fromType, (Class<R>) Ref.class, false, List.of(), List.of(), null, null, TemplateString.EMPTY, wrap(select(refType, PK)), List.of(), List.of(), List.of(), List.of(), false, requireNonNull(refType), requireNonNull(pkType), List.of(), modelSupplier);
+        this(queryTemplate, fromType, (Class<R>) Ref.class, false, List.of(), List.of(), null, null, TemplateString.EMPTY, wrap(select(refType, PK)), List.of(), List.of(), List.of(), false, requireNonNull(refType), requireNonNull(pkType), List.of(), modelSupplier);
     }
 
     private SelectBuilderImpl(@Nonnull QueryTemplate ormTemplate,
@@ -88,7 +90,6 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
                               @Nullable Integer offset,
                               @Nonnull TemplateString forLock,
                               @Nonnull TemplateString selectTemplate,
-                              @Nonnull List<TemplateString> templates,
                               @Nonnull List<TemplateString> groupBy,
                               @Nonnull List<TemplateString> having,
                               @Nonnull List<TemplateString> orderBy,
@@ -97,7 +98,7 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
                               @Nullable Class<?> pkType,
                               @Nonnull List<String> fetchPaths,
                               @Nonnull Supplier<Model<T, ID>> modelSupplier) {
-        super(ormTemplate, fromType, join, where, templates, groupBy, having, orderBy, modelSupplier);
+        super(ormTemplate, fromType, join, where, groupBy, having, orderBy, modelSupplier);
         this.forLock = forLock;
         this.selectType = selectType;
         this.distinct = distinct;
@@ -130,7 +131,6 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
      * @param fromType the type of the table being queried.
      * @param join the list of joins.
      * @param where the list of where clauses.
-     * @param templates the list of string templates.
      * @return a new query builder.
      */
     @Override
@@ -138,12 +138,11 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
                                     @Nonnull Class<T> fromType,
                                     @Nonnull List<Join> join,
                                     @Nonnull List<Where> where,
-                                    @Nonnull List<TemplateString> templates,
                                     @Nonnull List<TemplateString> groupBy,
                                     @Nonnull List<TemplateString> having,
                                     @Nonnull List<TemplateString> orderBy) {
         return new SelectBuilderImpl<>(queryTemplate, fromType, selectType, distinct, join, where, limit, offset, forLock,
-                selectTemplate, templates, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
+                selectTemplate, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
     }
 
     /**
@@ -164,7 +163,7 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
     @Override
     public QueryBuilder<T, R, ID> distinct() {
         return new SelectBuilderImpl<>(queryTemplate, fromType, selectType, true, join, where, limit, offset, forLock,
-                selectTemplate, templates, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
+                selectTemplate, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
     }
 
     /**
@@ -208,7 +207,7 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
             }
         }
         return new SelectBuilderImpl<>(queryTemplate, fromType, selectType, distinct, join, where, limit, offset, forLock,
-                selectTemplate, templates, groupBy, having, orderBy, subquery, refType, pkType, combined, modelSupplier);
+                selectTemplate, groupBy, having, orderBy, subquery, refType, pkType, combined, modelSupplier);
     }
 
     /**
@@ -225,12 +224,23 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
         }
         return switch (selectTemplate.values().getFirst()) {
             case Class<?> selected -> selected == type;
-            case Elements.Select(var table, var mode) -> table == type && mode == NESTED;
+            case Select(var table, var mode) -> table == type && mode == NESTED;
             case null, default -> false;
         };
     }
 
     private TemplateString toTemplateString() {
+        // A resolved reference is carried by the fetch element; the compiler collects it from the template before
+        // any element renders, so the element's position does not matter and the referenced table's columns take
+        // the place its foreign key column would have occupied.
+        //noinspection unchecked
+        TemplateString selectClause = fetchPaths.isEmpty()
+                ? selectTemplate
+                : TemplateString.combine(wrap(select((Class<? extends Data>) selectType, NESTED)), wrap(new Fetch(fetchPaths)));
+        return toTemplateString(selectClause, true);
+    }
+
+    private TemplateString toTemplateString(@Nonnull TemplateString selectClause, boolean withOrderBy) {
         TemplateString template = TemplateString.combine(TemplateString.of("SELECT %s".formatted(distinct ? "DISTINCT " : "")));
         if (queryTemplate.dialect().applyLimitAfterSelect()) {
             if (limit != null && offset == null) {
@@ -240,15 +250,8 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
                         TemplateString.of(" "));
             }
         }
-        // A resolved reference is carried by the fetch element; the compiler collects it from the template before
-        // any element renders, so the element's position does not matter and the referenced table's columns take
-        // the place its foreign key column would have occupied.
-        //noinspection unchecked
-        TemplateString selectClause = fetchPaths.isEmpty()
-                ? selectTemplate
-                : TemplateString.combine(wrap(select((Class<? extends Data>) selectType, NESTED)), wrap(new Elements.Fetch(fetchPaths)));
         template = TemplateString.combine(template, selectClause, TemplateString.raw("\nFROM \0", from(fromType, true)));
-        boolean hasLock = forLock.fragments().size() == 1 && !forLock.fragments().getFirst().isEmpty();
+        boolean hasLock = hasLockHint();
         if (hasLock && queryTemplate.dialect().applyLockHintAfterFrom()) {
             template = TemplateString.combine(template, TemplateString.of("\n"), forLock);
         }
@@ -287,10 +290,7 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
                 template = TemplateString.combine(template, TemplateString.of("\nHAVING "), havingClause);
             }
         }
-        if (!templates.isEmpty()) {
-            template = TemplateString.combine(template, TemplateString.combine(templates));
-        }
-        if (!orderBy.isEmpty()) {
+        if (withOrderBy && !orderBy.isEmpty()) {
             TemplateString orderByClause = orderBy.stream()
                     .reduce((a, b) -> TemplateString.combine(a, TemplateString.of(", "), b))
                     .orElseThrow();
@@ -327,7 +327,7 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
     @Override
     public QueryBuilder<T, R, ID> offset(int offset) {
         return new SelectBuilderImpl<>(queryTemplate, fromType, selectType, distinct, join, where, limit, offset, forLock,
-                selectTemplate, templates, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
+                selectTemplate, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
     }
 
     /**
@@ -340,7 +340,7 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
     @Override
     public QueryBuilder<T, R, ID> limit(int limit) {
         return new SelectBuilderImpl<>(queryTemplate, fromType, selectType, distinct, join, where, limit, offset, forLock,
-                selectTemplate, templates, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
+                selectTemplate, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
     }
 
     /**
@@ -382,7 +382,7 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
     @Override
     public QueryBuilder<T, R, ID> forLock(@Nonnull TemplateString template) {
         return new SelectBuilderImpl<>(queryTemplate, fromType, selectType, distinct, join, where, limit, offset,
-                template, selectTemplate, templates, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
+                template, selectTemplate, groupBy, having, orderBy, subquery, refType, pkType, fetchPaths, modelSupplier);
     }
 
     /**
@@ -409,6 +409,101 @@ public class SelectBuilderImpl<T extends Data, R, ID> extends QueryBuilderImpl<T
             throw new PersistenceException("Cannot compile a plan from a subquery.");
         }
         return queryTemplate.plan(toTemplateString());
+    }
+
+    /**
+     * Returns whether a lock hint has been set via {@code forShare()}, {@code forUpdate()} or {@code forLock()}.
+     */
+    private boolean hasLockHint() {
+        return forLock.fragments().size() == 1 && !forLock.fragments().getFirst().isEmpty();
+    }
+
+    /**
+     * Returns the record type whose column set forms the select clause, or {@code null} when the select clause is a
+     * custom template. A custom template is opaque: it may aggregate, so the number of rows it produces cannot be
+     * derived from the FROM clause alone.
+     */
+    @Nullable
+    private Class<? extends Data> selectedRecordType() {
+        if (refType != null) {
+            return refType;
+        }
+        if (selectTemplate.values().size() != 1
+                || !selectTemplate.fragments().stream().allMatch(String::isEmpty)) {
+            return null;
+        }
+        return switch (selectTemplate.values().getFirst()) {
+            case Class<?> selected when Data.class.isAssignableFrom(selected) -> selected.asSubclass(Data.class);
+            case Select(var table, var ignore) -> table;
+            case null, default -> null;
+        };
+    }
+
+    /**
+     * Returns the count query for this builder, or {@code null} when no count query can express this query's result
+     * count and the results must be fetched and counted instead.
+     *
+     * <p>A select of a record's column set without row-shaping clauses counts the rows of its own FROM/JOIN/WHERE
+     * shape, so the select clause is replaced by {@code COUNT(*)}. Row-shaping clauses (DISTINCT, GROUP BY, HAVING,
+     * limit and offset) and custom select clauses determine what a row is, so those queries are counted as a derived
+     * table instead. Inside the derived table, a record column set is replaced: every select
+     * mode includes the record's primary key and the primary key determines the remaining columns, so a DISTINCT
+     * select counts distinct primary keys, and any other select counts a constant. Both replacements keep the derived
+     * table free of duplicate column names, which not every database accepts. ORDER BY does not affect a count and is
+     * omitted, except inside a derived table with a limit or offset, where dialects rendering OFFSET/FETCH require
+     * it.</p>
+     */
+    @Nullable
+    private TemplateString toCountTemplateString() {
+        Class<? extends Data> recordType = selectedRecordType();
+        boolean rowShape = distinct || limit != null || offset != null
+                || !groupBy.isEmpty() || !having.isEmpty();
+        if (recordType != null && !rowShape) {
+            return toTemplateString(TemplateString.of("COUNT(*)"), false);
+        }
+        TemplateString innerSelect;
+        if (recordType == null) {
+            innerSelect = selectTemplate;
+        } else if (distinct) {
+            Class<?> primaryKeyType = queryTemplate.model(recordType, false).primaryKeyType();
+            if (primaryKeyType == Void.class) {
+                // Without a primary key there is no reduced column set that preserves the distinct row identity.
+                return null;
+            }
+            innerSelect = wrap(select(recordType, PK));
+        } else {
+            innerSelect = TemplateString.of("1");
+        }
+        boolean withOrderBy = limit != null || offset != null;
+        return TemplateString.combine(
+                TemplateString.of("SELECT COUNT(*)\nFROM (\n"),
+                toTemplateString(innerSelect, withOrderBy),
+                TemplateString.of("\n) c"));
+    }
+
+    /**
+     * Returns the number of results of this query by executing a dedicated count query derived from this builder.
+     *
+     * <p>Queries that lock rows fetch and count the results instead, so the requested locks are acquired, as does the
+     * rare shape no count query can express (a DISTINCT select of a record without a primary key).</p>
+     *
+     * @return the total number of results of this query as a long value.
+     * @throws PersistenceException if the query operation fails due to underlying database issues, such as
+     * connectivity.
+     */
+    @Override
+    public long getResultCount() {
+        if (subquery) {
+            throw new PersistenceException("Cannot build a query from a subquery.");
+        }
+        if (hasLockHint()) {
+            return super.getResultCount();
+        }
+        TemplateString countTemplate = toCountTemplateString();
+        if (countTemplate == null) {
+            return super.getResultCount();
+        }
+        return queryTemplate.query(countTemplate).withoutFetchSize().getSingleResult(Long.class);
     }
 
     /**

--- a/storm-core/src/test/java/st/orm/core/BuilderIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/BuilderIntegrationTest.java
@@ -380,25 +380,23 @@ public class BuilderIntegrationTest {
         assertEquals(5, list.size());
     }
 
-    // 13. append
+    // 13. template-based orderBy and where
 
     @Test
-    public void testAppendRawSql() {
+    public void testOrderByOrdinalTemplate() {
         var orm = ORMTemplate.of(dataSource);
-        // Append a LIMIT clause manually.
         var list = orm.selectFrom(City.class)
-                .append("ORDER BY 1")
+                .orderBy(raw("1"))
                 .limit(3)
                 .getResultList();
         assertEquals(3, list.size());
     }
 
     @Test
-    public void testAppendTemplateString() {
+    public void testWhereTemplateString() {
         var orm = ORMTemplate.of(dataSource);
-        // Append a WHERE clause via template.
         var list = orm.selectFrom(City.class)
-                .append(raw("WHERE \0.name = \0", City.class, "Madison"))
+                .where(raw("\0.name = \0", City.class, "Madison"))
                 .getResultList();
         assertEquals(1, list.size());
         assertEquals("Madison", list.getFirst().name());
@@ -856,5 +854,141 @@ public class BuilderIntegrationTest {
         var row = query.getSingleResult();
         assertEquals(1, row.length);
         assertEquals(6L, ((Number) row[0]).longValue());
+    }
+
+    // Additional: ref single/optional results.
+
+    @Test
+    public void testRefSingleResult() {
+        var orm = ORMTemplate.of(dataSource);
+        var ref = orm.entity(Pet.class).selectRef().where(it -> it.whereId(1)).getSingleResult();
+        assertEquals(1, ref.id());
+    }
+
+    @Test
+    public void testRefOptionalResultEmpty() {
+        var orm = ORMTemplate.of(dataSource);
+        assertTrue(orm.entity(Pet.class).selectRef().where(it -> it.whereId(-1)).getOptionalResult().isEmpty());
+    }
+
+    // Additional: multi-path orderBy and template-based descending order.
+
+    @Test
+    public void testOrderByMultiplePaths() {
+        var list = ORMTemplate.of(dataSource).selectFrom(Pet.class).orderBy(Pet_.name, Pet_.id).getResultList();
+        assertFalse(list.isEmpty());
+    }
+
+    @Test
+    public void testOrderByDescendingTemplate() {
+        var list = ORMTemplate.of(dataSource).selectFrom(City.class)
+                .orderByDescending(raw("\0.id", City.class))
+                .getResultList();
+        assertEquals(6, list.getFirst().id());
+    }
+
+    // Additional: exists/notExists conveniences on the builder.
+
+    @Test
+    public void testWhereExistsConvenience() {
+        var orm = ORMTemplate.of(dataSource);
+        var list = orm.selectFrom(Owner.class)
+                .whereExists(orm.subquery(Visit.class).where(raw("\0.id = \0.id", alias(Owner.class, OUTER), alias(Owner.class, INNER))))
+                .getResultList();
+        assertEquals(6, list.size());
+    }
+
+    @Test
+    public void testWhereNotExistsConvenience() {
+        var orm = ORMTemplate.of(dataSource);
+        var list = orm.selectFrom(Owner.class)
+                .whereNotExists(orm.subquery(Visit.class).where(raw("\0.id = \0.id", alias(Owner.class, OUTER), alias(Owner.class, INNER))))
+                .getResultList();
+        assertEquals(4, list.size());
+    }
+
+    @Test
+    public void testHavingExistsConvenience() {
+        var orm = ORMTemplate.of(dataSource);
+        var count = orm.entity(Owner.class).selectCount()
+                .havingExists(orm.subquery(Visit.class))
+                .getSingleResult();
+        assertEquals(10, count);
+    }
+
+    @Test
+    public void testHavingNotExistsConvenience() {
+        var orm = ORMTemplate.of(dataSource);
+        var result = orm.entity(Owner.class).selectCount()
+                .havingNotExists(orm.subquery(Visit.class))
+                .getOptionalResult();
+        assertTrue(result.isEmpty());
+    }
+
+    // Additional: subquery builders cannot be executed directly.
+
+    @Test
+    public void testSubqueryCannotExecute() {
+        var orm = ORMTemplate.of(dataSource);
+        var subquery = orm.subquery(City.class);
+        assertThrows(PersistenceException.class, subquery::getResultList);
+        assertThrows(PersistenceException.class, subquery::plan);
+        assertThrows(PersistenceException.class, subquery::getResultCount);
+    }
+
+    // Additional: unsafe() is a no-op for select queries.
+
+    @Test
+    public void testUnsafeSelect() {
+        assertEquals(6, ORMTemplate.of(dataSource).selectFrom(City.class).unsafe().getResultList().size());
+    }
+
+    // Additional: fetch() rejects queries that do not select the root record graph.
+
+    @Test
+    public void testFetchOnRefSelectThrows() {
+        var orm = ORMTemplate.of(dataSource);
+        assertThrows(PersistenceException.class, () -> orm.entity(Pet.class).selectRef().fetch(Pet_.owner));
+    }
+
+    @Test
+    public void testFetchOnCustomSelectTypeThrows() {
+        var orm = ORMTemplate.of(dataSource);
+        assertThrows(PersistenceException.class, () -> orm.entity(Pet.class).select(City.class).fetch(Pet_.owner));
+    }
+
+    @Test
+    public void testFetchOnCustomColumnListThrows() {
+        var orm = ORMTemplate.of(dataSource);
+        assertThrows(PersistenceException.class, () -> orm.entity(Pet.class)
+                .select(Pet.class, raw("\0.id, \0.name", Pet.class, Pet.class))
+                .fetch(Pet_.owner));
+    }
+
+    @Test
+    public void testFetchWithoutPathsThrows() {
+        var orm = ORMTemplate.of(dataSource);
+        assertThrows(PersistenceException.class, () -> orm.selectFrom(Pet.class).fetch());
+    }
+
+    // Additional: DELETE builder plans and subquery restrictions.
+
+    @Test
+    public void testDeletePlan() {
+        var orm = ORMTemplate.of(dataSource);
+        // A plan without the unsafe marker defers the missing-WHERE check to execution.
+        assertNotNull(orm.deleteFrom(Visit.class).plan());
+        // The unsafe marker carries over to every query the plan produces; the delete rolls back with the test
+        // transaction.
+        var plan = orm.deleteFrom(Visit.class).unsafe().plan();
+        assertEquals(14, plan.query().executeUpdate());
+    }
+
+    @Test
+    public void testDeleteAsSubqueryThrows() {
+        var orm = ORMTemplate.of(dataSource);
+        assertThrows(PersistenceException.class, () -> orm.selectFrom(Owner.class)
+                .whereExists(orm.deleteFrom(Visit.class))
+                .getResultList());
     }
 }

--- a/storm-core/src/test/java/st/orm/core/PageCountInferenceIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/PageCountInferenceIntegrationTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static st.orm.Operator.EQUALS;
+import static st.orm.core.template.SqlInterceptor.observe;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.Page;
+import st.orm.Pageable;
+import st.orm.PersistenceException;
+import st.orm.core.model.City;
+import st.orm.core.model.City_;
+import st.orm.core.model.Visit;
+import st.orm.core.template.ORMTemplate;
+
+/**
+ * Integration tests for the count inference of {@code page(Pageable)}: a page that is not full determines the total
+ * directly, so the count query only runs for a full page, or for an empty page beyond the first.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IntegrationConfig.class)
+@DataJpaTest(showSql = false)
+public class PageCountInferenceIntegrationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    private List<String> observeStatements(Runnable runnable) {
+        List<String> statements = new ArrayList<>();
+        observe(sql -> statements.add(sql.statement()), runnable);
+        return statements;
+    }
+
+    @Test
+    public void testPartialFirstPageSkipsCount() {
+        var orm = ORMTemplate.of(dataSource);
+        long total = orm.selectFrom(City.class).getResultCount();
+        AtomicReference<Page<City>> page = new AtomicReference<>();
+        var statements = observeStatements(() ->
+                page.setPlain(orm.selectFrom(City.class).page(Pageable.ofSize((int) total + 10))));
+        assertEquals(1, statements.size());
+        assertEquals(total, page.getPlain().totalCount());
+        assertEquals(total, page.getPlain().content().size());
+    }
+
+    @Test
+    public void testFullPageRunsCount() {
+        var orm = ORMTemplate.of(dataSource);
+        long total = orm.selectFrom(Visit.class).getResultCount();
+        AtomicReference<Page<Visit>> page = new AtomicReference<>();
+        var statements = observeStatements(() ->
+                page.setPlain(orm.selectFrom(Visit.class).page(Pageable.ofSize(5))));
+        assertEquals(2, statements.size());
+        assertTrue(statements.stream().anyMatch(statement -> statement.startsWith("SELECT COUNT(*)")));
+        assertEquals(total, page.getPlain().totalCount());
+        assertEquals(5, page.getPlain().content().size());
+    }
+
+    @Test
+    public void testPartialLastPageSkipsCount() {
+        var orm = ORMTemplate.of(dataSource);
+        long total = orm.selectFrom(Visit.class).getResultCount();
+        int pageSize = 5;
+        int lastPageNumber = (int) (total / pageSize);
+        int lastPageContentSize = (int) (total % pageSize);
+        assertTrue(lastPageContentSize > 0, "test data must not fill the last page exactly");
+        AtomicReference<Page<Visit>> page = new AtomicReference<>();
+        var statements = observeStatements(() ->
+                page.setPlain(orm.selectFrom(Visit.class).page(Pageable.of(lastPageNumber, pageSize))));
+        assertEquals(1, statements.size());
+        assertEquals(total, page.getPlain().totalCount());
+        assertEquals(lastPageContentSize, page.getPlain().content().size());
+    }
+
+    @Test
+    public void testEmptyPageBeyondEndRunsCount() {
+        var orm = ORMTemplate.of(dataSource);
+        long total = orm.selectFrom(Visit.class).getResultCount();
+        AtomicReference<Page<Visit>> page = new AtomicReference<>();
+        var statements = observeStatements(() ->
+                page.setPlain(orm.selectFrom(Visit.class).page(Pageable.of(100, 5))));
+        assertEquals(2, statements.size());
+        assertEquals(total, page.getPlain().totalCount());
+        assertTrue(page.getPlain().content().isEmpty());
+    }
+
+    @Test
+    public void testEmptyFirstPageSkipsCount() {
+        var orm = ORMTemplate.of(dataSource);
+        AtomicReference<Page<City>> page = new AtomicReference<>();
+        var statements = observeStatements(() ->
+                page.setPlain(orm.selectFrom(City.class)
+                        .where(City_.name, EQUALS, "No Such City")
+                        .page(Pageable.ofSize(5))));
+        assertEquals(1, statements.size());
+        assertEquals(0, page.getPlain().totalCount());
+        assertTrue(page.getPlain().content().isEmpty());
+    }
+
+    @Test
+    public void testPrecomputedTotalSkipsCount() {
+        var orm = ORMTemplate.of(dataSource);
+        AtomicReference<Page<Visit>> page = new AtomicReference<>();
+        var statements = observeStatements(() ->
+                page.setPlain(orm.selectFrom(Visit.class).page(Pageable.ofSize(5), 42)));
+        assertEquals(1, statements.size());
+        assertEquals(42, page.getPlain().totalCount());
+        assertEquals(5, page.getPlain().content().size());
+    }
+
+    @Test
+    public void testInferenceWithPageableSortOrders() {
+        var orm = ORMTemplate.of(dataSource);
+        long total = orm.selectFrom(City.class).getResultCount();
+        AtomicReference<Page<City>> page = new AtomicReference<>();
+        var statements = observeStatements(() ->
+                page.setPlain(orm.selectFrom(City.class)
+                        .page(Pageable.ofSize((int) total + 10).sortBy(City_.name))));
+        assertEquals(1, statements.size());
+        assertEquals(total, page.getPlain().totalCount());
+        var names = page.getPlain().content().stream().map(City::name).toList();
+        assertEquals(names.stream().sorted().toList(), names);
+    }
+
+    @Test
+    public void testRepositoryPageSkipsCountOnPartialPage() {
+        var orm = ORMTemplate.of(dataSource);
+        long total = orm.entity(City.class).count();
+        AtomicReference<Page<City>> page = new AtomicReference<>();
+        var statements = observeStatements(() ->
+                page.setPlain(orm.entity(City.class).page(0, (int) total + 10)));
+        assertEquals(1, statements.size());
+        assertEquals(total, page.getPlain().totalCount());
+    }
+
+    @Test
+    public void testPageableSortsWithExplicitOrderByThrows() {
+        var orm = ORMTemplate.of(dataSource);
+        assertThrows(PersistenceException.class, () ->
+                orm.selectFrom(City.class).orderBy(City_.name).page(Pageable.ofSize(5).sortBy(City_.id)));
+    }
+
+    @Test
+    public void testNavigationAcrossPagesKeepsTotalConsistent() {
+        var orm = ORMTemplate.of(dataSource);
+        long total = orm.selectFrom(Visit.class).getResultCount();
+        var pageable = Pageable.ofSize(5);
+        long seen = 0;
+        Page<Visit> page;
+        do {
+            page = orm.selectFrom(Visit.class).page(pageable);
+            assertEquals(total, page.totalCount());
+            seen += page.content().size();
+            pageable = page.nextPageable();
+        } while (page.hasNext());
+        assertEquals(total, seen);
+    }
+}

--- a/storm-core/src/test/java/st/orm/core/RepositoryPreparedStatementIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/RepositoryPreparedStatementIntegrationTest.java
@@ -808,14 +808,18 @@ public class RepositoryPreparedStatementIntegrationTest {
 
     @Test
     public void testSelectWithTwoPetsWithPathRaw() {
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
-        var list = ORMTemplate.of(dataSource).entity(VisitWithTwoPets.class).select().append(raw("WHERE \0", where(VisitWithTwoPets_.pet1.owner, EQUALS, owner))).getResultList();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
+        var list = ORMTemplate.of(dataSource).query(raw("""
+                SELECT \0
+                FROM \0
+                WHERE \0""", VisitWithTwoPets.class, VisitWithTwoPets.class, where(VisitWithTwoPets_.pet1.owner, EQUALS, owner)))
+                .getResultList(VisitWithTwoPets.class);
         assertEquals(2, list.size());
     }
 
     @Test
     public void testSelectWithTwoPetsWithPathTemplate() {
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
         var visits = ORMTemplate.of(dataSource).entity(VisitWithTwoPets.class)
                 .select()
                 .where(it -> it.where(raw("\0 = \0", VisitWithTwoPets_.pet1.owner, owner.id()))).getResultList();
@@ -825,7 +829,7 @@ public class RepositoryPreparedStatementIntegrationTest {
     @Test
     public void testSelectWithTwoPetsWithMultipleParameters() {
         var orm = ORMTemplate.of(dataSource);
-        var owner = orm.entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = orm.entity(Owner.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var visits = orm.entity(VisitWithTwoPets.class)
@@ -839,7 +843,7 @@ public class RepositoryPreparedStatementIntegrationTest {
 
     @Test
     public void testSelectWithTwoPetsWithMultipleParametersTemplate() {
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var visits = ORMTemplate.of(dataSource).entity(VisitWithTwoPets.class)
@@ -886,7 +890,7 @@ public class RepositoryPreparedStatementIntegrationTest {
 
     @Test
     public void testSelectWithTwoPetsOneRefWithoutPath() throws Exception {
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var visits = relaxed(ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class).select()).where(it -> it.where(owner)).getResultList();
@@ -897,7 +901,7 @@ public class RepositoryPreparedStatementIntegrationTest {
 
     @Test
     public void testSelectWithTwoPetsOneRefWithoutPathTemplate() {
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var visits = ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class)
@@ -910,7 +914,7 @@ public class RepositoryPreparedStatementIntegrationTest {
 
     @Test
     public void testSelectWithTwoPetsOneRefWithRootPathTemplateMetamodel() {
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var list = ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class)
@@ -927,7 +931,7 @@ public class RepositoryPreparedStatementIntegrationTest {
     @Test
     public void testSelectWithTwoPetsOneRefWithInvalidPathTemplateMetamodel() {
         var e = assertThrows(PersistenceException.class, () -> {
-            var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+            var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
             AtomicReference<Sql> sql = new AtomicReference<>();
             observe(sql::setPlain, () -> {
                 ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class)
@@ -946,7 +950,7 @@ public class RepositoryPreparedStatementIntegrationTest {
             LEFT JOIN pet por ON vwtpor.pet_id = por.id
             LEFT JOIN pet_type pt ON por.type_id = pt.id
             WHERE por.owner_id = ?""";
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             relaxed(ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class).select())
@@ -957,7 +961,7 @@ public class RepositoryPreparedStatementIntegrationTest {
 
     @Test
     public void testSelectWithTwoPetsOneRefWithRootPathMetamodelTemplate() {
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var list = ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class)
@@ -974,7 +978,7 @@ public class RepositoryPreparedStatementIntegrationTest {
     @Test
     public void testSelectWithTwoPetsOneRefWithInvalidPathMetamodelTemplate() {
         var e = assertThrows(PersistenceException.class, () -> {
-            var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+            var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
             AtomicReference<Sql> sql = new AtomicReference<>();
             observe(sql::setPlain, () -> {
                 ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class)
@@ -987,7 +991,7 @@ public class RepositoryPreparedStatementIntegrationTest {
 
     @Test
     public void testSelectWithTwoPetsOneRefWithPath() {
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var visits = ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class).select().where(VisitWithTwoPetsOneRef_.pet1.owner, EQUALS, owner).getResultList();
@@ -998,7 +1002,7 @@ public class RepositoryPreparedStatementIntegrationTest {
 
     @Test
     public void testSelectWithTwoPetsOneRefWithPathTemplate() {
-        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+        var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var visits = ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class)
@@ -1012,7 +1016,7 @@ public class RepositoryPreparedStatementIntegrationTest {
     @Test
     public void testSelectWithTwoPetsOneRefPetWithoutPath() {
         var e = assertThrows(PersistenceException.class, () -> {
-            var pet = ORMTemplate.of(dataSource).entity(PetOwnerRef.class).select().append("LIMIT 1").getSingleResult();
+            var pet = ORMTemplate.of(dataSource).entity(PetOwnerRef.class).select().limit(1).getSingleResult();
             relaxed(ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class).select()).where(it -> it.where(pet)).getResultList();
         });
         assertInstanceOf(SqlTemplateException.class, e.getCause());
@@ -1021,7 +1025,7 @@ public class RepositoryPreparedStatementIntegrationTest {
     @Test
     public void testSelectWithTwoPetsOneRefPetWithoutPathTemplate() {
         // Note that this test is not comparable to the previous test because of the re-use of pet_id.
-        var pet = ORMTemplate.of(dataSource).entity(PetOwnerRef.class).select().append("LIMIT 1").getSingleResult();
+        var pet = ORMTemplate.of(dataSource).entity(PetOwnerRef.class).select().limit(1).getSingleResult();
         var visits = ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class)
                 .select()
                 .where(it -> it.where(raw("\0.id = \0", PetOwnerRef.class, pet.id()))).getResultList();
@@ -1030,7 +1034,7 @@ public class RepositoryPreparedStatementIntegrationTest {
 
     @Test
     public void testSelectWithTwoPetsOneRefPetWithPath() {
-        var pet = ORMTemplate.of(dataSource).entity(PetOwnerRef.class).select().append("LIMIT 1").getSingleResult();
+        var pet = ORMTemplate.of(dataSource).entity(PetOwnerRef.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var visits = ORMTemplate.of(dataSource).entity(VisitWithTwoPetsOneRef.class).select().where(VisitWithTwoPetsOneRef_.pet1, EQUALS, pet).getResultList();
@@ -1042,7 +1046,7 @@ public class RepositoryPreparedStatementIntegrationTest {
     @Test
     public void testSelectWithTwoPetsOneRefPetWithPathTemplateMetamodel() throws Exception {
         var ORM = ORMTemplate.of(dataSource);
-        var pet = ORM.entity(PetOwnerRef.class).select().append("LIMIT 1").getSingleResult();
+        var pet = ORM.entity(PetOwnerRef.class).select().limit(1).getSingleResult();
         AtomicReference<Sql> sql = new AtomicReference<>();
         observe(sql::setPlain, () -> {
             var visits = ORM.entity(VisitWithTwoPetsOneRef.class)
@@ -1079,7 +1083,7 @@ public class RepositoryPreparedStatementIntegrationTest {
     @Test
     public void testSelectWithTwoPetRefsWithoutPath() {
         PersistenceException e = assertThrows(PersistenceException.class, () -> {
-            var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+            var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
             relaxed(ORMTemplate.of(dataSource).entity(VisitWithTwoPetRefs.class).select()).where(it -> it.where(owner)).getResultList();
         });
         assertInstanceOf(SqlTemplateException.class, e.getCause());
@@ -1088,7 +1092,7 @@ public class RepositoryPreparedStatementIntegrationTest {
     @Test
     public void testSelectWithTwoPetRefsWithoutPathTemplate() {
         PersistenceException e = assertThrows(PersistenceException.class, () -> {
-            var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().append("LIMIT 1").getSingleResult();
+            var owner = ORMTemplate.of(dataSource).entity(Owner.class).select().limit(1).getSingleResult();
             ORMTemplate.of(dataSource).entity(VisitWithTwoPetRefs.class)
                     .select()
                     .where(it -> it.where(raw("\0.id = \0", PetOwnerRef.class, owner.id()))) // Cannot find PetOwnerRef alias as ref fields are not joined.
@@ -1531,22 +1535,22 @@ public class RepositoryPreparedStatementIntegrationTest {
     }
 
     @Test
-    public void testWhereExistsAppendSubquery() {
+    public void testWhereExistsSubqueryWithOuterAlias() {
         var orm = ORMTemplate.of(dataSource);
         var list = ORMTemplate.of(dataSource).entity(Owner.class)
                 .select()
-                .append(raw("WHERE EXISTS (\0)", orm.subquery(Visit.class).where(raw("\0.id = \0.id", alias(Owner.class, OUTER), alias(Owner.class, INNER)))))
+                .where(raw("EXISTS (\0)", orm.subquery(Visit.class).where(raw("\0.id = \0.id", alias(Owner.class, OUTER), alias(Owner.class, INNER)))))
                 .getResultList();
         assertEquals(6, list.size());
     }
 
     @Test
-    public void testWhereAppendQuery() {
-        // We cannot append a query, we need to use a query builder instead.
+    public void testWhereQuery() {
+        // A query cannot be embedded in a WHERE clause; a query builder must be used instead.
         var e = assertThrows(PersistenceException.class, () -> {
             ORMTemplate.of(dataSource).entity(Owner.class)
                     .select()
-                    .append(raw("WHERE (\0)", ORMTemplate.of(dataSource).query("SELECT 1")))
+                    .where(raw("(\0)", ORMTemplate.of(dataSource).query("SELECT 1")))
                     .getResultList();
         });
         assertInstanceOf(SqlTemplateException.class, e.getCause());
@@ -1583,18 +1587,16 @@ public class RepositoryPreparedStatementIntegrationTest {
     }
 
     @Test
-    public void testWhereAppendQueryBuilderParameters() {
+    public void testWhereQueryBuilderParameters() {
         String expectedSql = """
             SELECT o.id, o.first_name, o.last_name, o.address, o.city_id, c.name, o.telephone, o.version
             FROM owner o
             LEFT JOIN city c ON o.city_id = c.id
-            WHERE o.id = ?
-            AND EXISTS (
+            WHERE (o.id = ?) AND EXISTS (
               SELECT o1.id, o1.first_name, o1.last_name, o1.address, o1.city_id, o1.telephone, o1.version
               FROM owner o1
               WHERE o1.id = ?
-            )
-            AND 3 = ?""";
+            ) AND (3 = ?)""";
         observe(sql -> {
             assertEquals(expectedSql, sql.statement());
             assertTrue(sql.parameters().get(0) instanceof PositionalParameter(int position, Object dbValue)
@@ -1607,9 +1609,9 @@ public class RepositoryPreparedStatementIntegrationTest {
             var orm = ORMTemplate.of(dataSource);
             orm.entity(Owner.class)
                     .select()
-                    .append(raw("WHERE \0.id = \0", alias(Owner.class, INNER), 1))
-                    .append(raw("AND EXISTS (\0)", orm.subquery(Owner.class).where(raw("\0.id = \0", alias(Owner.class, INNER), 2))))
-                    .append(raw("AND 3 = \0", 3))
+                    .where(it -> it.where(raw("\0.id = \0", alias(Owner.class, INNER), 1))
+                            .and(it.exists(orm.subquery(Owner.class).where(raw("\0.id = \0", alias(Owner.class, INNER), 2))))
+                            .and(it.where(raw("3 = \0", 3))))
                     .getResultList();
         });
     }

--- a/storm-core/src/test/java/st/orm/core/ResultCountIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/ResultCountIntegrationTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static st.orm.core.template.SqlInterceptor.observe;
+import static st.orm.core.template.TemplateString.raw;
+import static st.orm.core.template.Templates.select;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.Pageable;
+import st.orm.core.model.City;
+import st.orm.core.model.Owner;
+import st.orm.core.model.Pet;
+import st.orm.core.model.Pet_;
+import st.orm.core.model.Visit;
+import st.orm.core.model.VisitView;
+import st.orm.core.template.ORMTemplate;
+import st.orm.core.template.TemplateString;
+
+/**
+ * Integration tests for {@code getResultCount()}, which executes a dedicated count query derived from the builder's
+ * shape rather than fetching and counting the results.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IntegrationConfig.class)
+@DataJpaTest(showSql = false)
+public class ResultCountIntegrationTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    private List<String> observeStatements(Runnable runnable) {
+        List<String> statements = new ArrayList<>();
+        observe(sql -> statements.add(sql.statement()), runnable);
+        return statements;
+    }
+
+    @Test
+    public void testPlainCountReplacesSelectClause() {
+        var orm = ORMTemplate.of(dataSource);
+        long expected = orm.selectFrom(Pet.class).getResultList().size();
+        var statements = observeStatements(() ->
+                assertEquals(expected, orm.selectFrom(Pet.class).getResultCount()));
+        assertEquals(1, statements.size());
+        assertTrue(statements.getFirst().startsWith("SELECT COUNT(*)"));
+        assertFalse(statements.getFirst().contains("FROM ("));
+    }
+
+    @Test
+    public void testCountWithWhere() {
+        var orm = ORMTemplate.of(dataSource);
+        var filtered = orm.selectFrom(Pet.class)
+                .where(Pet_.owner, Owner.builder().id(1).build());
+        assertEquals(filtered.getResultList().size(), filtered.getResultCount());
+    }
+
+    @Test
+    public void testCountWithRowExpandingJoin() {
+        var orm = ORMTemplate.of(dataSource);
+        var joined = orm.selectFrom(Pet.class)
+                .innerJoin(Visit.class).on(Pet.class);
+        assertEquals(joined.getResultList().size(), joined.getResultCount());
+    }
+
+    @Test
+    public void testDistinctCountCountsDistinctPrimaryKeys() {
+        var orm = ORMTemplate.of(dataSource);
+        var distinct = orm.selectFrom(Pet.class)
+                .distinct()
+                .innerJoin(Visit.class).on(Pet.class);
+        long expected = distinct.getResultList().size();
+        var statements = observeStatements(() ->
+                assertEquals(expected, distinct.getResultCount()));
+        assertEquals(1, statements.size());
+        assertTrue(statements.getFirst().startsWith("SELECT COUNT(*)"));
+        assertTrue(statements.getFirst().contains("DISTINCT"));
+    }
+
+    @Test
+    public void testDistinctCountWithCustomSelect() {
+        var orm = ORMTemplate.of(dataSource);
+        var distinctOwners = orm.entity(Pet.class)
+                .select(Integer.class, raw("\0.id", Owner.class))
+                .distinct();
+        assertEquals(distinctOwners.getResultList().size(), distinctOwners.getResultCount());
+    }
+
+    @Test
+    public void testCountRespectsLimitAndOffset() {
+        var orm = ORMTemplate.of(dataSource);
+        long total = orm.selectFrom(Visit.class).getResultCount();
+        assertEquals(5, orm.selectFrom(Visit.class).limit(5).getResultCount());
+        assertEquals(total - 10, orm.selectFrom(Visit.class).offset(10).getResultCount());
+        assertEquals(2, orm.selectFrom(Visit.class).offset((int) total - 2).limit(5).getResultCount());
+    }
+
+    @Test
+    public void testCountWithOrderByOmitsOrderBy() {
+        var orm = ORMTemplate.of(dataSource);
+        var ordered = orm.selectFrom(Pet.class).orderBy(Pet_.name);
+        long expected = ordered.getResultList().size();
+        var statements = observeStatements(() ->
+                assertEquals(expected, ordered.getResultCount()));
+        assertEquals(1, statements.size());
+        assertFalse(statements.getFirst().contains("ORDER BY"));
+    }
+
+    @Test
+    public void testCountWithCustomSelect() {
+        var orm = ORMTemplate.of(dataSource);
+        var names = orm.entity(City.class).select(String.class, raw("\0.name", City.class));
+        long expected = names.getResultList().size();
+        var statements = observeStatements(() ->
+                assertEquals(expected, names.getResultCount()));
+        assertEquals(1, statements.size());
+        assertTrue(statements.getFirst().contains("FROM ("));
+    }
+
+    @Test
+    public void testCountWithAggregateSelect() {
+        var orm = ORMTemplate.of(dataSource);
+        // The query returns a single aggregate row, so its result count is 1, not the number of rows counted.
+        assertEquals(1, orm.entity(Pet.class)
+                .select(Long.class, TemplateString.of("COUNT(*)"))
+                .getResultCount());
+    }
+
+    @Test
+    public void testCountWithGroupBy() {
+        var orm = ORMTemplate.of(dataSource);
+        var grouped = orm.entity(Pet.class)
+                .select(Long.class, TemplateString.of("COUNT(*)"))
+                .groupBy(Pet_.owner);
+        assertEquals(grouped.getResultList().size(), grouped.getResultCount());
+    }
+
+    @Test
+    public void testLockedCountFetchesResults() {
+        var orm = ORMTemplate.of(dataSource);
+        var locked = orm.selectFrom(Pet.class).forUpdate();
+        long expected = orm.selectFrom(Pet.class).getResultList().size();
+        var statements = observeStatements(() ->
+                assertEquals(expected, locked.getResultCount()));
+        assertEquals(1, statements.size());
+        assertTrue(statements.getFirst().contains("FOR UPDATE"));
+        assertFalse(statements.getFirst().contains("COUNT"));
+    }
+
+    @Test
+    public void testRefCount() {
+        var orm = ORMTemplate.of(dataSource);
+        var refs = orm.entity(Pet.class).selectRef();
+        assertEquals(refs.getResultList().size(), refs.getResultCount());
+    }
+
+    @Test
+    public void testDistinctCountWithoutPrimaryKeyFetchesResults() {
+        var orm = ORMTemplate.of(dataSource);
+        // VisitView is a projection without a primary key, so no reduced column set preserves the distinct row
+        // identity and the results are fetched and counted.
+        var distinct = orm.projection(VisitView.class).select().distinct();
+        long expected = distinct.getResultList().size();
+        var statements = observeStatements(() ->
+                assertEquals(expected, distinct.getResultCount()));
+        assertEquals(1, statements.size());
+        assertFalse(statements.getFirst().contains("COUNT"));
+    }
+
+    @Test
+    public void testCountWithSelectElementTemplate() {
+        var orm = ORMTemplate.of(dataSource);
+        var cities = orm.entity(City.class).select(City.class, TemplateString.wrap(select(City.class)));
+        long expected = cities.getResultList().size();
+        var statements = observeStatements(() ->
+                assertEquals(expected, cities.getResultCount()));
+        assertEquals(1, statements.size());
+        assertTrue(statements.getFirst().startsWith("SELECT COUNT(*)"));
+    }
+
+    @Test
+    public void testPageUsesCountQuery() {
+        var orm = ORMTemplate.of(dataSource);
+        long total = orm.selectFrom(Visit.class).getResultList().size();
+        var statements = observeStatements(() -> {
+            var page = orm.selectFrom(Visit.class).page(Pageable.ofSize(5));
+            assertEquals(total, page.totalCount());
+            assertEquals(5, page.content().size());
+        });
+        assertEquals(2, statements.size());
+        assertTrue(statements.stream().anyMatch(statement -> statement.startsWith("SELECT COUNT(*)")));
+    }
+}

--- a/storm-core/src/test/java/st/orm/core/TemplatePreparedStatementIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/TemplatePreparedStatementIntegrationTest.java
@@ -1054,7 +1054,7 @@ public class TemplatePreparedStatementIntegrationTest {
     @Test
     public void testSelect() {
         // Append a raw WHERE clause to a builder query. Visit id=1 exists; exactly 1 result.
-        var count = ORMTemplate.of(dataSource).selectFrom(Visit.class).append(raw("WHERE \0.id = \0", alias(Visit.class), 1)).getResultCount();
+        var count = ORMTemplate.of(dataSource).selectFrom(Visit.class).where(raw("\0.id = \0", alias(Visit.class), 1)).getResultCount();
         assertEquals(1, count);
     }
 

--- a/storm-core/src/test/java/st/orm/core/repository/PetRepository.java
+++ b/storm-core/src/test/java/st/orm/core/repository/PetRepository.java
@@ -37,20 +37,20 @@ public interface PetRepository extends EntityRepository<Pet, Integer> {
     }
 
     default Pet getById3(int id) {
-        return orm().selectFrom(Pet.class).append(raw("WHERE \0", where(id))).getSingleResult();
+        return select().where(it -> it.whereId(id)).getSingleResult();
     }
 
     default List<Pet> findByOwnerFirstName(String firstName) {
-        return orm().selectFrom(Pet.class).append(raw("WHERE \0.first_name = \0",
+        return orm().selectFrom(Pet.class).where(raw("\0.first_name = \0",
                 alias(Owner.class), firstName)).getResultList();
     }
 
     default List<Pet> findByOwnerCity(String city) {
-        return select().append(raw("WHERE \0.name = \0", City.class, city)).getResultList();
+        return select().where(raw("\0.name = \0", City.class, city)).getResultList();
     }
 
     default List<Pet> findByOwnerCityQuery(String city) {
-        return orm().selectFrom(Pet.class).append(raw("WHERE \0.city = \0", alias(Owner.class), city)).getResultList();
+        return orm().selectFrom(Pet.class).where(raw("\0.city = \0", alias(Owner.class), city)).getResultList();
     }
 
     record PetVisitCount(Pet pet, int visitCount) {}

--- a/storm-java21/src/main/java/st/orm/repository/EntityRepository.java
+++ b/storm-java21/src/main/java/st/orm/repository/EntityRepository.java
@@ -989,8 +989,9 @@ public interface EntityRepository<E extends Entity<ID>, ID> extends Repository {
     /**
      * Returns a page of entities using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of entities, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * entities.</p>
      *
      * <p>Page numbers are zero-based: pass {@code 0} for the first page.</p>
      *
@@ -1004,8 +1005,9 @@ public interface EntityRepository<E extends Entity<ID>, ID> extends Repository {
     /**
      * Returns a page of entities using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of entities, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * entities.</p>
      *
      * <p>Use {@link Pageable#ofSize(int)} for the first page, then navigate with
      * {@link Page#nextPageable()} or {@link Page#previousPageable()}.</p>
@@ -1031,8 +1033,9 @@ public interface EntityRepository<E extends Entity<ID>, ID> extends Repository {
     /**
      * Returns a page of entity refs using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of entities, and
-     * a query with OFFSET and LIMIT to fetch the refs for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the refs for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * entities.</p>
      *
      * @param pageable the pagination request specifying page number and page size.
      * @return a page containing the ref results and pagination metadata.

--- a/storm-java21/src/main/java/st/orm/repository/ProjectionRepository.java
+++ b/storm-java21/src/main/java/st/orm/repository/ProjectionRepository.java
@@ -586,8 +586,9 @@ public interface ProjectionRepository<P extends Projection<ID>, ID> extends Repo
     /**
      * Returns a page of projections using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of projections, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * projections.</p>
      *
      * <p>Page numbers are zero-based: pass {@code 0} for the first page.</p>
      *
@@ -601,8 +602,9 @@ public interface ProjectionRepository<P extends Projection<ID>, ID> extends Repo
     /**
      * Returns a page of projections using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of projections, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * projections.</p>
      *
      * <p>Use {@link Pageable#ofSize(int)} for the first page, then navigate with
      * {@link Page#nextPageable()} or {@link Page#previousPageable()}.</p>
@@ -628,8 +630,9 @@ public interface ProjectionRepository<P extends Projection<ID>, ID> extends Repo
     /**
      * Returns a page of projection refs using offset-based pagination.
      *
-     * <p>This method executes two queries: a {@code SELECT COUNT(*)} to determine the total number of projections, and
-     * a query with OFFSET and LIMIT to fetch the refs for the requested page.</p>
+     * <p>This method executes a query with OFFSET and LIMIT to fetch the refs for the requested page and, when
+     * the total cannot be derived from the fetched page, a {@code SELECT COUNT(*)} to determine the total number of
+     * projections.</p>
      *
      * @param pageable the pagination request specifying page number and page size.
      * @return a page containing the ref results and pagination metadata.

--- a/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
+++ b/storm-java21/src/main/java/st/orm/template/QueryBuilder.java
@@ -699,14 +699,6 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      */
     public abstract QueryBuilder<T, R, ID> offset(int offset);
 
-    /**
-     * Append the query with a string template.
-     *
-     * @param template the string template to append.
-     * @return the query builder.
-     */
-    public abstract QueryBuilder<T, R, ID> append(@Nonnull StringTemplate template);
-
     //
     // Locking.
     //
@@ -774,9 +766,10 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     /**
      * Executes the query and returns a {@link Page} of results using offset-based pagination.
      *
-     * <p>This method executes two queries: one to count the total number of matching results (without offset or
-     * limit), and one to fetch the content for the requested page. The caller is responsible for adding ORDER BY
-     * clauses to ensure deterministic ordering across pages.</p>
+     * <p>This method executes the query for the requested page and, when the total cannot be derived from the
+     * fetched page, a count query (without offset or limit). A page that is not full determines the total directly,
+     * so the count query only runs for a full page, or for an empty page beyond the first. The caller is responsible
+     * for adding ORDER BY clauses to ensure deterministic ordering across pages.</p>
      *
      * <p>Page numbers are zero-based: pass {@code 0} for the first page.</p>
      *
@@ -793,10 +786,11 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     /**
      * Executes the query and returns a {@link Page} of results using offset-based pagination.
      *
-     * <p>This method executes two queries: one to count the total number of matching results (without offset or
-     * limit), and one to fetch the content for the requested page. Sort orders can be specified either through the
-     * pageable or through explicit {@code orderBy} calls on the query builder, but not both. If both are present,
-     * a {@link PersistenceException} is thrown.</p>
+     * <p>This method executes the query for the requested page and, when the total cannot be derived from the
+     * fetched page, a count query (without offset or limit). A page that is not full determines the total directly,
+     * so the count query only runs for a full page, or for an empty page beyond the first. Sort orders can be
+     * specified either through the pageable or through explicit {@code orderBy} calls on the query builder, but not
+     * both. If both are present, a {@link PersistenceException} is thrown.</p>
      *
      * <p>Use {@link Pageable#ofSize(int)} for the first page, then navigate with
      * {@link Page#nextPageable()} or {@link Page#previousPageable()}.</p>
@@ -807,7 +801,16 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.10
      */
     public final Page<R> page(@Nonnull Pageable pageable) {
-        return page(pageable, getResultCount());
+        List<R> content = pageContent(pageable);
+        long totalCount;
+        if (content.size() < pageable.pageSize() && (pageable.offset() == 0 || !content.isEmpty())) {
+            // A page that is not full is the last page, so the total follows from the page itself. An empty page
+            // beyond the first proves nothing: the offset may lie anywhere past the end.
+            totalCount = pageable.offset() + content.size();
+        } else {
+            totalCount = getResultCount();
+        }
+        return new Page<>(content, totalCount, pageable);
     }
 
     /**
@@ -829,6 +832,13 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
      * @since 1.10
      */
     public final Page<R> page(@Nonnull Pageable pageable, long totalCount) {
+        return new Page<>(pageContent(pageable), totalCount, pageable);
+    }
+
+    /**
+     * Fetches the content for the requested page, applying the pageable's sort orders and offset/limit window.
+     */
+    private List<R> pageContent(@Nonnull Pageable pageable) {
         // Forbid combining explicit orderBy with Pageable sort orders for consistency with scroll, which also
         // manages ORDER BY internally and forbids explicit orderBy calls.
         if (hasOrderBy() && !pageable.orders().isEmpty()) {
@@ -839,8 +849,7 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
             // The Pageable's sort field may be rooted anywhere in the query, so the column is named directly.
             sorted = sorted.orderBy(RAW."\{new Columns(order.field(), CASCADE, order.descending())}");
         }
-        List<R> content = sorted.offset((int) pageable.offset()).limit(pageable.pageSize()).getResultList();
-        return new Page<>(content, totalCount, pageable);
+        return sorted.offset((int) pageable.offset()).limit(pageable.pageSize()).getResultList();
     }
 
     /**
@@ -895,11 +904,16 @@ public abstract class QueryBuilder<T extends Data, R, ID> {
     /**
      * Returns the number of results of this query.
      *
+     * <p>Select queries execute a dedicated count query derived from this builder: the select clause is replaced by
+     * {@code COUNT(*)}, or the query is counted as a derived table when its shape requires it (DISTINCT, GROUP BY,
+     * HAVING, limit, offset or a custom select clause). Queries that lock rows fetch and count
+     * the results instead, so the requested locks are acquired.</p>
+     *
      * @return the total number of results of this query as a long value.
      * @throws PersistenceException if the query operation fails due to underlying database issues, such as
      *                              connectivity.
      */
-    public final long getResultCount() {
+    public long getResultCount() {
         try (var stream = getResultStream()) {
             return stream.count();
         }

--- a/storm-java21/src/main/java/st/orm/template/impl/QueryBuilderImpl.java
+++ b/storm-java21/src/main/java/st/orm/template/impl/QueryBuilderImpl.java
@@ -130,17 +130,6 @@ public final class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<
     }
 
     /**
-     * Returns a processor that can be used to append the query with a string template.
-     *
-     * @param template the string template to append.
-     * @return a processor that can be used to append the query with a string template.
-     */
-    @Override
-    public QueryBuilder<T, R, ID> append(@Nonnull StringTemplate template) {
-        return new QueryBuilderImpl<>(core.append(convert(template)));
-    }
-
-    /**
      * Adds an ORDER BY clause to the query using a string template. Multiple calls to this method append additional
      * columns to the ORDER BY clause.
      *
@@ -282,6 +271,14 @@ public final class QueryBuilderImpl<T extends Data, R, ID> extends QueryBuilder<
     @Override
     public Stream<R> getResultStream() {
         return core.getResultStream();
+    }
+
+    /**
+     * Delegates to the core builder, which executes a dedicated count query derived from the builder's shape.
+     */
+    @Override
+    public long getResultCount() {
+        return core.getResultCount();
     }
 
     /**

--- a/storm-java21/src/test/java/st/orm/template/QueryBuilderTest.java
+++ b/storm-java21/src/test/java/st/orm/template/QueryBuilderTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import st.orm.NoResultException;
 import st.orm.NonUniqueResultException;
+import st.orm.Pageable;
 import st.orm.PersistenceException;
 import st.orm.Ref;
 import st.orm.Scrollable;
@@ -400,14 +401,71 @@ public class QueryBuilderTest {
         assertFalse(cities.isEmpty());
     }
 
-    // QueryBuilder - append
+    // QueryBuilder - orderBy template
 
     @Test
-    public void testAppend() {
+    public void testOrderByTemplate() {
         List<City> cities = orm.selectFrom(City.class)
-                .append(RAW." ORDER BY \{City.class}.name")
+                .orderBy(RAW."\{City.class}.name")
                 .getResultList();
         assertEquals(6, cities.size());
+    }
+
+    // QueryBuilder - page
+
+    @Test
+    public void testPagePartialFirstPageInfersTotal() {
+        var page = orm.selectFrom(City.class).page(Pageable.ofSize(20));
+        assertEquals(6, page.totalCount());
+        assertEquals(6, page.content().size());
+    }
+
+    @Test
+    public void testPageFullPageCountsTotal() {
+        var page = orm.selectFrom(City.class).page(0, 3);
+        assertEquals(6, page.totalCount());
+        assertEquals(3, page.content().size());
+    }
+
+    @Test
+    public void testPagePartialLastPageInfersTotal() {
+        var page = orm.selectFrom(City.class).page(1, 4);
+        assertEquals(6, page.totalCount());
+        assertEquals(2, page.content().size());
+    }
+
+    @Test
+    public void testPageBeyondEndCountsTotal() {
+        var page = orm.selectFrom(City.class).page(5, 4);
+        assertEquals(6, page.totalCount());
+        assertTrue(page.content().isEmpty());
+    }
+
+    @Test
+    public void testPageWithPrecomputedTotal() {
+        var page = orm.selectFrom(City.class).page(Pageable.ofSize(3), 42);
+        assertEquals(42, page.totalCount());
+        assertEquals(3, page.content().size());
+    }
+
+    @Test
+    public void testPageAppliesPageableSortOrders() {
+        var page = orm.selectFrom(City.class).page(Pageable.ofSize(10).sortByDescending(City_.id));
+        assertEquals(6, page.content().getFirst().id());
+    }
+
+    @Test
+    public void testPageableSortsWithExplicitOrderByThrows() {
+        assertThrows(PersistenceException.class, () ->
+                orm.selectFrom(City.class).orderBy(City_.name).page(Pageable.ofSize(3).sortBy(City_.id)));
+    }
+
+    // QueryBuilder - whereNotExists convenience
+
+    @Test
+    public void testWhereNotExistsConvenience() {
+        var list = orm.selectFrom(City.class).whereNotExists(orm.selectFrom(City.class)).getResultList();
+        assertTrue(list.isEmpty());
     }
 
     // QueryBuilder - forUpdate / forShare / forLock

--- a/storm-java21/src/test/java/st/orm/template/TemplatesTest.java
+++ b/storm-java21/src/test/java/st/orm/template/TemplatesTest.java
@@ -267,13 +267,13 @@ public class TemplatesTest {
         assertEquals(5, cities.size());
     }
 
-    // QueryBuilderImpl.append
+    // QueryBuilderImpl.orderBy template
 
     @Test
-    public void testQueryBuilderAppend() {
+    public void testQueryBuilderOrderByTemplate() {
         List<City> cities = orm.entity(City.class).select()
                 .where(wb -> wb.where(RAW."1 = 1"))
-                .append(RAW." ORDER BY \{City.class}.name ASC")
+                .orderBy(RAW."\{City.class}.name")
                 .getResultList();
         assertFalse(cities.isEmpty());
         // Verify ordering

--- a/storm-kotlin/src/main/kotlin/st/orm/repository/EntityRepository.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/repository/EntityRepository.kt
@@ -1716,8 +1716,9 @@ public interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID>
     /**
      * Returns a page of entities using offset-based pagination.
      *
-     * This method executes two queries: a `SELECT COUNT(*)` to determine the total number of entities, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.
+     * This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a `SELECT COUNT(*)` to determine the total number of
+     * entities.
      *
      * Page numbers are zero-based: pass `0` for the first page.
      *
@@ -1731,8 +1732,9 @@ public interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID>
     /**
      * Returns a page of entities using offset-based pagination.
      *
-     * This method executes two queries: a `SELECT COUNT(*)` to determine the total number of entities, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.
+     * This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a `SELECT COUNT(*)` to determine the total number of
+     * entities.
      *
      * Use [Pageable.ofSize] for the first page, then navigate with
      * [Page.nextPageable] or [Page.previousPageable].
@@ -1758,8 +1760,9 @@ public interface EntityRepository<E, ID : Any> : Repository where E : Entity<ID>
     /**
      * Returns a page of entity refs using offset-based pagination.
      *
-     * This method executes two queries: a `SELECT COUNT(*)` to determine the total number of entities, and
-     * a query with OFFSET and LIMIT to fetch the refs for the requested page.
+     * This method executes a query with OFFSET and LIMIT to fetch the refs for the requested page and, when
+     * the total cannot be derived from the fetched page, a `SELECT COUNT(*)` to determine the total number of
+     * entities.
      *
      * @param pageable the pagination request specifying page number and page size.
      * @return a page containing the ref results and pagination metadata.

--- a/storm-kotlin/src/main/kotlin/st/orm/repository/ProjectionRepository.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/repository/ProjectionRepository.kt
@@ -765,8 +765,9 @@ public interface ProjectionRepository<P, ID : Any> : Repository where P : Projec
     /**
      * Returns a page of projections using offset-based pagination.
      *
-     * This method executes two queries: a `SELECT COUNT(*)` to determine the total number of projections, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.
+     * This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a `SELECT COUNT(*)` to determine the total number of
+     * projections.
      *
      * Page numbers are zero-based: pass `0` for the first page.
      *
@@ -780,8 +781,9 @@ public interface ProjectionRepository<P, ID : Any> : Repository where P : Projec
     /**
      * Returns a page of projections using offset-based pagination.
      *
-     * This method executes two queries: a `SELECT COUNT(*)` to determine the total number of projections, and
-     * a query with OFFSET and LIMIT to fetch the content for the requested page.
+     * This method executes a query with OFFSET and LIMIT to fetch the content for the requested page and, when
+     * the total cannot be derived from the fetched page, a `SELECT COUNT(*)` to determine the total number of
+     * projections.
      *
      * Use [Pageable.ofSize] for the first page, then navigate with
      * [Page.nextPageable] or [Page.previousPageable].
@@ -807,8 +809,9 @@ public interface ProjectionRepository<P, ID : Any> : Repository where P : Projec
     /**
      * Returns a page of projection refs using offset-based pagination.
      *
-     * This method executes two queries: a `SELECT COUNT(*)` to determine the total number of projections, and
-     * a query with OFFSET and LIMIT to fetch the refs for the requested page.
+     * This method executes a query with OFFSET and LIMIT to fetch the refs for the requested page and, when
+     * the total cannot be derived from the fetched page, a `SELECT COUNT(*)` to determine the total number of
+     * projections.
      *
      * @param pageable the pagination request specifying page number and page size.
      * @return a page containing the ref results and pagination metadata.

--- a/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/QueryBuilder.kt
@@ -892,22 +892,6 @@ public abstract class QueryBuilder<T : Data, R, ID> {
      */
     public abstract fun offset(offset: Int): QueryBuilder<T, R, ID>
 
-    /**
-     * Append the query with a string template.
-     *
-     * @param builder the string template to append.
-     * @return the query builder.
-     */
-    public fun append(builder: TemplateBuilder): QueryBuilder<T, R, ID> = append(builder.build())
-
-    /**
-     * Append the query with a string template.
-     *
-     * @param template the string template to append.
-     * @return the query builder.
-     */
-    public abstract fun append(template: TemplateString): QueryBuilder<T, R, ID>
-
     //
     // Locking.
     //
@@ -984,9 +968,10 @@ public abstract class QueryBuilder<T : Data, R, ID> {
     /**
      * Executes the query and returns a [Page] of results using offset-based pagination.
      *
-     * This method executes two queries: one to count the total number of matching results (without offset or
-     * limit), and one to fetch the content for the requested page. The caller is responsible for adding ORDER BY
-     * clauses to ensure deterministic ordering across pages.
+     * This method executes the query for the requested page and, when the total cannot be derived from the
+     * fetched page, a count query (without offset or limit). A page that is not full determines the total directly,
+     * so the count query only runs for a full page, or for an empty page beyond the first. The caller is responsible
+     * for adding ORDER BY clauses to ensure deterministic ordering across pages.
      *
      * Page numbers are zero-based: pass `0` for the first page.
      *
@@ -1001,10 +986,11 @@ public abstract class QueryBuilder<T : Data, R, ID> {
     /**
      * Executes the query and returns a [Page] of results using offset-based pagination.
      *
-     * This method executes two queries: one to count the total number of matching results (without offset or
-     * limit), and one to fetch the content for the requested page. Sort orders can be specified either through the
-     * pageable or through explicit `orderBy` calls on the query builder, but not both. If both are present,
-     * a [PersistenceException] is thrown.
+     * This method executes the query for the requested page and, when the total cannot be derived from the
+     * fetched page, a count query (without offset or limit). A page that is not full determines the total directly,
+     * so the count query only runs for a full page, or for an empty page beyond the first. Sort orders can be
+     * specified either through the pageable or through explicit `orderBy` calls on the query builder, but not both.
+     * If both are present, a [PersistenceException] is thrown.
      *
      * Use [Pageable.ofSize] for the first page, then navigate with
      * [Page.nextPageable] or [Page.previousPageable].
@@ -1014,7 +1000,17 @@ public abstract class QueryBuilder<T : Data, R, ID> {
      * @throws PersistenceException if the pageable has sort orders and the query builder has explicit orderBy calls.
      * @since 1.10
      */
-    public fun page(pageable: Pageable): Page<R> = page(pageable, resultCount)
+    public fun page(pageable: Pageable): Page<R> {
+        val content = pageContent(pageable)
+        val totalCount = if (content.size < pageable.pageSize() && (pageable.offset() == 0L || content.isNotEmpty())) {
+            // A page that is not full is the last page, so the total follows from the page itself. An empty page
+            // beyond the first proves nothing: the offset may lie anywhere past the end.
+            pageable.offset() + content.size
+        } else {
+            resultCount
+        }
+        return Page(content, totalCount, pageable)
+    }
 
     /**
      * Executes the query and returns a [Page] of results using offset-based pagination with a pre-computed
@@ -1034,7 +1030,12 @@ public abstract class QueryBuilder<T : Data, R, ID> {
      * @throws PersistenceException if the pageable has sort orders and the query builder has explicit orderBy calls.
      * @since 1.10
      */
-    public fun page(pageable: Pageable, totalCount: Long): Page<R> {
+    public fun page(pageable: Pageable, totalCount: Long): Page<R> = Page(pageContent(pageable), totalCount, pageable)
+
+    /**
+     * Fetches the content for the requested page, applying the pageable's sort orders and offset/limit window.
+     */
+    private fun pageContent(pageable: Pageable): List<R> {
         // Forbid combining explicit orderBy with Pageable sort orders for consistency with scroll, which also
         // manages ORDER BY internally and forbids explicit orderBy calls.
         if (hasOrderBy() && pageable.orders().isNotEmpty()) {
@@ -1045,8 +1046,7 @@ public abstract class QueryBuilder<T : Data, R, ID> {
             // The Pageable's sort field may be rooted anywhere in the query, so the column is named directly.
             sorted = sorted.orderBy(wrap(Columns(order.field(), CASCADE, order.descending())))
         }
-        val content = sorted.offset(pageable.offset().toInt()).limit(pageable.pageSize()).resultList
-        return Page(content, totalCount, pageable)
+        return sorted.offset(pageable.offset().toInt()).limit(pageable.pageSize()).resultList
     }
 
     /**
@@ -1103,9 +1103,14 @@ public abstract class QueryBuilder<T : Data, R, ID> {
     public val resultFlow: Flow<R>
         get() = resultStream.consumeAsFlow()
 
-    public val resultCount: Long
+    public open val resultCount: Long
         /**
          * Returns the number of results of this query.
+         *
+         * Select queries execute a dedicated count query derived from this builder: the select clause is replaced by
+         * `COUNT(*)`, or the query is counted as a derived table when its shape requires it (DISTINCT, GROUP BY,
+         * HAVING, limit, offset or a custom select clause). Queries that lock rows fetch and
+         * count the results instead, so the requested locks are acquired.
          *
          * @return the total number of results of this query as a long value.
          * @throws PersistenceException if the query operation fails due to underlying database issues, such as
@@ -1589,11 +1594,6 @@ public class SqlScope<T : Data, R, ID : Any> @PublishedApi internal constructor(
     /** Locks the selected rows for writing (SELECT ... FOR UPDATE). */
     public fun forUpdate() {
         builder = builder.forUpdate()
-    }
-
-    /** Appends raw SQL to the query using a template expression. */
-    public fun append(template: TemplateBuilder) {
-        builder = builder.append(template)
     }
 
     /**

--- a/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/impl/QueryBuilderImpl.kt
@@ -62,14 +62,6 @@ internal class QueryBuilderImpl<T : Data, R, ID>(
     override fun fetch(paths: List<Navigable<T, out Data>>): QueryBuilder<T, R, ID> = QueryBuilderImpl<T, R, ID>(core.fetch(paths))
 
     /**
-     * Returns a processor that can be used to append the query with a string template.
-     *
-     * @param template the string template to append.
-     * @return a processor that can be used to append the query with a string template.
-     */
-    override fun append(template: TemplateString): QueryBuilder<T, R, ID> = QueryBuilderImpl<T, R, ID>(core.append(template.unwrap))
-
-    /**
      * Adds an ORDER BY clause to the query using a string template. Multiple calls to this method append additional
      * columns to the ORDER BY clause.
      *
@@ -165,6 +157,12 @@ internal class QueryBuilderImpl<T : Data, R, ID>(
          * connectivity.
          */
         get() = core.getResultStream()
+
+    override val resultCount: Long
+        /**
+         * Delegates to the core builder, which executes a dedicated count query derived from the builder's shape.
+         */
+        get() = core.resultCount
 
     override val resultList: List<R>
         /**

--- a/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
@@ -16,15 +16,20 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import st.orm.Data
 import st.orm.JoinType
 import st.orm.Metamodel
+import st.orm.Navigable
 import st.orm.NoResultException
 import st.orm.NonUniqueResultException
 import st.orm.Operator.*
+import st.orm.Pageable
 import st.orm.PersistenceException
 import st.orm.Ref
 import st.orm.Scrollable
 import st.orm.TypedMetamodel
+import st.orm.Window
 import st.orm.repository.entity
 import st.orm.template.model.*
+import java.util.stream.Stream
+import kotlin.reflect.KClass
 
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
@@ -923,10 +928,10 @@ open class QueryBuilderTest(
         results shouldHaveSize 4
     }
 
-    // QueryBuilder: append
+    // QueryBuilder: orderBy with limit
 
     @Test
-    fun `append with template should add raw SQL to query`() {
+    fun `orderBy with limit should window ordered results`() {
         val repo = orm.entity(City::class)
         val idPath = metamodel<City, Int>(repo.model, "id")
         // Use orderBy + limit to get first 3 cities by id.
@@ -1088,7 +1093,7 @@ open class QueryBuilderTest(
     fun `orderBy with TemplateBuilder should sort results`() {
         val repo = orm.entity(City::class)
         val idPath = metamodel<City, Int>(repo.model, "id")
-        val cities = repo.select().orderBy { "${t(Templates.column(idPath))} ASC" }.resultList
+        val cities = repo.select().orderBy { "${t(Templates.column(idPath))}" }.resultList
         cities[0].id shouldBe 1
         cities[5].id shouldBe 6
     }
@@ -1222,24 +1227,6 @@ open class QueryBuilderTest(
         val templateString = TemplateString.raw { "COUNT(*) > ${t(1)}" }
         val counts = repo.selectCount().groupBy(cityPath).having(templateString).resultList
         counts shouldHaveSize 2
-    }
-
-    @Test
-    fun `append with TemplateBuilder should add clause`() {
-        val repo = orm.entity(City::class)
-        val idPath = metamodel<City, Int>(repo.model, "id")
-        val cities = repo.select().orderBy(idPath).append { "" }.resultList
-        cities shouldHaveSize 6
-        cities[0].id shouldBe 1
-    }
-
-    @Test
-    fun `append with TemplateString should add clause`() {
-        val repo = orm.entity(City::class)
-        val idPath = metamodel<City, Int>(repo.model, "id")
-        val cities = repo.select().orderBy(idPath).append(TemplateString.raw("")).resultList
-        cities shouldHaveSize 6
-        cities[0].id shouldBe 1
     }
 
     @Test
@@ -1729,29 +1716,17 @@ open class QueryBuilderTest(
         }
     }
 
-    // append() tests
+    // orderBy() template tests
 
     @Test
-    fun `append with raw SQL template should modify query`() {
-        // Use append to add a raw ORDER BY clause. The first 3 cities by id should be 1, 2, 3.
+    fun `orderBy with raw SQL template should order query`() {
+        // Order by a raw column template. The first 3 cities by id should be 1, 2, 3.
         val repo = orm.entity(City::class)
-        val cities = repo.select().append { "ORDER BY ${t(Templates.column(metamodel<City, Int>(repo.model, "id")))}" }.limit(3).resultList
+        val cities = repo.select().orderBy { "${t(Templates.column(metamodel<City, Int>(repo.model, "id")))}" }.limit(3).resultList
         cities shouldHaveSize 3
         cities[0].id shouldBe 1
         cities[1].id shouldBe 2
         cities[2].id shouldBe 3
-    }
-
-    @Test
-    fun `append with TemplateString should add clause to query`() {
-        // Use append with a TemplateString (raw) to add a comment-like clause.
-        val repo = orm.entity(City::class)
-        val idPath = metamodel<City, Int>(repo.model, "id")
-        // Append an ORDER BY and verify ordering is applied.
-        val cities = repo.select().orderBy(idPath).append(TemplateString.raw("")).resultList
-        cities shouldHaveSize 6
-        cities[0].id shouldBe 1
-        cities[5].id shouldBe 6
     }
 
     // typed() tests
@@ -2507,5 +2482,138 @@ open class QueryBuilderTest(
                 (pet.owner === ownerRef.getOrNull()) shouldBe true
             }
         }
+    }
+
+    // page() tests
+
+    @Test
+    fun `page with partial first page should infer total`() {
+        val page = orm.entity(City::class).select().page(Pageable.ofSize(20))
+        page.totalCount() shouldBe 6L
+        page.content() shouldHaveSize 6
+    }
+
+    @Test
+    fun `page with full page should count total`() {
+        val page = orm.entity(City::class).select().page(0, 3)
+        page.totalCount() shouldBe 6L
+        page.content() shouldHaveSize 3
+    }
+
+    @Test
+    fun `page with partial last page should infer total`() {
+        val page = orm.entity(City::class).select().page(1, 4)
+        page.totalCount() shouldBe 6L
+        page.content() shouldHaveSize 2
+    }
+
+    @Test
+    fun `page beyond the end should count total`() {
+        val page = orm.entity(City::class).select().page(5, 4)
+        page.totalCount() shouldBe 6L
+        page.content() shouldHaveSize 0
+    }
+
+    @Test
+    fun `page with precomputed total should skip count`() {
+        val page = orm.entity(City::class).select().page(Pageable.ofSize(3), 42)
+        page.totalCount() shouldBe 42L
+        page.content() shouldHaveSize 3
+    }
+
+    @Test
+    fun `page with pageable sorts and explicit orderBy should throw`() {
+        val repo = orm.entity(City::class)
+        val idPath = metamodel<City, Int>(repo.model, "id")
+        assertThrows<PersistenceException> {
+            repo.select().orderBy(idPath).page(Pageable.ofSize(3).sortBy(idPath))
+        }
+    }
+
+    // where/having convenience overload tests
+
+    @Test
+    fun `where with operator and iterable should filter results`() {
+        val repo = orm.entity(City::class)
+        val idPath = metamodel<City, Int>(repo.model, "id")
+        repo.select().where(idPath, IN, listOf(1, 2)).resultList shouldHaveSize 2
+    }
+
+    @Test
+    fun `where with operator and vararg should filter results`() {
+        val repo = orm.entity(City::class)
+        val idPath = metamodel<City, Int>(repo.model, "id")
+        repo.select().where(idPath, EQUALS, 1).resultList shouldHaveSize 1
+    }
+
+    @Test
+    fun `whereExists with subquery should filter results`() {
+        val repo = orm.entity(City::class)
+        repo.select().whereExists(orm.entity(City::class).select()).resultList shouldHaveSize 6
+    }
+
+    @Test
+    fun `having with operator should filter grouped results`() {
+        val repo = orm.entity(City::class)
+        val idPath = metamodel<City, Int>(repo.model, "id")
+        repo.selectCount().groupBy(idPath).having(idPath, EQUALS, 1).resultList shouldHaveSize 1
+    }
+
+    // Base result terminals: a minimal subclass inherits the streaming defaults, so they are exercised directly.
+
+    private class ForwardingQueryBuilder(private val delegate: QueryBuilder<City, City, Int>) : QueryBuilder<City, City, Int>() {
+        override fun <X : Any> typedId(pkType: KClass<X>): QueryBuilder<City, City, X> = delegate.typedId(pkType)
+        override fun <X : Data> narrow(rootType: KClass<X>): QueryBuilder<X, City, Int> = delegate.narrow(rootType)
+        override fun widen(): QueryBuilder<Data, City, Int> = delegate.widen()
+        override fun unsafe(): QueryBuilder<City, City, Int> = delegate.unsafe()
+        override fun distinct(): QueryBuilder<City, City, Int> = delegate.distinct()
+        override fun fetch(paths: List<Navigable<City, out Data>>): QueryBuilder<City, City, Int> = delegate.fetch(paths)
+        override fun crossJoin(relation: KClass<out Data>): QueryBuilder<Data, City, Int> = delegate.crossJoin(relation)
+        override fun innerJoin(relation: KClass<out Data>): TypedJoinBuilder<City, City, Int> = delegate.innerJoin(relation)
+        override fun leftJoin(relation: KClass<out Data>): TypedJoinBuilder<City, City, Int> = delegate.leftJoin(relation)
+        override fun rightJoin(relation: KClass<out Data>): TypedJoinBuilder<City, City, Int> = delegate.rightJoin(relation)
+        override fun join(type: JoinType, relation: KClass<out Data>, alias: String): TypedJoinBuilder<City, City, Int> = delegate.join(type, relation, alias)
+        override fun crossJoin(template: TemplateString): QueryBuilder<Data, City, Int> = delegate.crossJoin(template)
+        override fun innerJoin(template: TemplateString, alias: String): JoinBuilder<City, City, Int> = delegate.innerJoin(template, alias)
+        override fun leftJoin(template: TemplateString, alias: String): JoinBuilder<City, City, Int> = delegate.leftJoin(template, alias)
+        override fun rightJoin(template: TemplateString, alias: String): JoinBuilder<City, City, Int> = delegate.rightJoin(template, alias)
+        override fun join(type: JoinType, template: TemplateString, alias: String): JoinBuilder<City, City, Int> = delegate.join(type, template, alias)
+        override fun join(type: JoinType, subquery: QueryBuilder<*, *, *>, alias: String): JoinBuilder<City, City, Int> = delegate.join(type, subquery, alias)
+        override fun whereBuilder(predicate: WhereBuilder<City, City, Int>.() -> PredicateBuilder<out City, *, *>): QueryBuilder<City, City, Int> = delegate.whereBuilder(predicate)
+        override fun groupBy(template: TemplateString): QueryBuilder<City, City, Int> = delegate.groupBy(template)
+        override fun having(template: TemplateString): QueryBuilder<City, City, Int> = delegate.having(template)
+        override fun having(predicate: PredicateBuilder<out City, *, *>): QueryBuilder<City, City, Int> = delegate.having(predicate)
+        override fun havingExists(subquery: QueryBuilder<*, *, *>): QueryBuilder<City, City, Int> = delegate.havingExists(subquery)
+        override fun havingNotExists(subquery: QueryBuilder<*, *, *>): QueryBuilder<City, City, Int> = delegate.havingNotExists(subquery)
+        override fun subqueryTemplate(): SubqueryTemplate = delegate.subqueryTemplate()
+        override fun orderBy(template: TemplateString): QueryBuilder<City, City, Int> = delegate.orderBy(template)
+        override fun hasOrderBy(): Boolean = delegate.hasOrderBy()
+        override fun limit(limit: Int): QueryBuilder<City, City, Int> = delegate.limit(limit)
+        override fun offset(offset: Int): QueryBuilder<City, City, Int> = delegate.offset(offset)
+        override fun forShare(): QueryBuilder<City, City, Int> = delegate.forShare()
+        override fun forUpdate(): QueryBuilder<City, City, Int> = delegate.forUpdate()
+        override fun forLock(template: TemplateString): QueryBuilder<City, City, Int> = delegate.forLock(template)
+        override fun build(): Query = delegate.build()
+        override fun scroll(size: Int): Window<City> = delegate.scroll(size)
+        override fun scroll(scrollable: Scrollable<City>): Window<City> = delegate.scroll(scrollable)
+        override val resultStream: Stream<City> get() = delegate.resultStream
+        override fun <V : Data> resultGroupedBy(path: TypedMetamodel<City, V, out V?>): Map<V, List<City>> = delegate.resultGroupedBy(path)
+        override fun <V : Data> resultGroupedByRef(path: Metamodel<City, V>): Map<Ref<V>, List<City>> = delegate.resultGroupedByRef(path)
+    }
+
+    @Test
+    fun `base result terminals stream and count`() {
+        val repo = orm.entity(City::class)
+        val all = ForwardingQueryBuilder(repo.select())
+        all.resultCount shouldBe 6L
+        all.resultList shouldHaveSize 6
+        assertThrows<NonUniqueResultException> { all.singleResult }
+        assertThrows<NonUniqueResultException> { all.optionalResult }
+        val single = ForwardingQueryBuilder(repo.select().where(1))
+        single.singleResult.id shouldBe 1
+        single.optionalResult?.id shouldBe 1
+        val none = ForwardingQueryBuilder(repo.select().where(999))
+        assertThrows<NoResultException> { none.singleResult }
+        none.optionalResult shouldBe null
     }
 }


### PR DESCRIPTION
`getResultCount()` streamed and counted the full result set, so `page(Pageable.ofSize(20))` on a large table transferred every row to produce a total. It now executes a dedicated count query derived from the builder's shape:

- A select of a record's column set without row-shaping clauses replaces the select clause with `COUNT(*)` over the same FROM/JOIN/WHERE.
- DISTINCT, GROUP BY, HAVING, limit and offset are counted as a derived table. Inside it, a record column set is replaced: primary key columns for DISTINCT (every select mode includes the primary key and the key determines the remaining columns), a constant otherwise. Both keep the derived table free of duplicate column names, which H2 and SQL Server reject. Custom select clauses stay intact, so aggregate selects still count their own result rows.
- Queries that lock rows fetch and count the results, so the requested locks are acquired; the same fallback covers a DISTINCT select of a projection without a primary key.
- ORDER BY is omitted from count queries, except inside a derived table with limit or offset, where OFFSET/FETCH dialects require it.

`page(Pageable)` now fetches the page first and runs the count query only when the total cannot be derived from the fetched page: a page that is not full determines the total directly, so result sets that fit in one page and the common last-page request skip the count entirely. The repository `page`/`pageRef` methods delegate to the builder and inherit the inference. The `page(pageable, totalCount)` overload keeps its single-query behavior.

`QueryBuilder.append` is removed (breaking). It was undocumented, had no internal callers, and duplicated first-class API for every observed use (`orderBy`, `limit`, `where`), while its opacity worked against the builder: an appended ORDER BY bypassed the `hasOrderBy()` guards, and every appended fragment had to be treated as if it could carry a LIMIT. Raw SQL remains fully supported through the template API. The internal `templates` plumbing goes with it.

The Java 21 and Kotlin builders delegate their counts to core, and the javadoc, KDoc and pagination docs describe the conditional count. The docs changes live in `docs/` only, so they show at `/docs/next` until the next release snapshot. New suites `ResultCountIntegrationTest` and `PageCountInferenceIntegrationTest` pin counts and SQL shapes via `SqlInterceptor.observe`, and line coverage of the touched builder classes is 81-97%. Full reactor green including the Testcontainers dialect suites (MySQL, MariaDB, PostgreSQL, SQL Server, Oracle, SQLite).

Fixes #379
Fixes #428
Fixes #429