### PR TITLE
fix: dispatch template keywords on word boundaries and detect only top-level WHERE

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlParser.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlParser.java
@@ -36,9 +36,6 @@ import st.orm.core.template.impl.Elements.Unsafe;
 final class SqlParser {
 
     private static final Pattern WITH_PATTERN = Pattern.compile("^(?i:WITH)\\b.*", DOTALL);
-    private static final Pattern WHERE_PATTERN = Pattern.compile(
-            "(?i:\\bWHERE\\b)", DOTALL
-    );
 
     private SqlParser() {
     }
@@ -83,16 +80,33 @@ final class SqlParser {
      * Returns whether {@code sql} begins with {@code keyword} (case-insensitive) followed by a word boundary, matching
      * the semantics of the {@code ^(?i:keyword)\b} anchored pattern.
      */
-    private static boolean startsWithKeyword(@Nonnull String sql, @Nonnull String keyword) {
+    static boolean startsWithKeyword(@Nonnull String sql, @Nonnull String keyword) {
         int length = keyword.length();
         if (sql.length() < length || !sql.regionMatches(true, 0, keyword, 0, length)) {
             return false;
         }
-        if (sql.length() == length) {
-            return true;
+        return sql.length() == length || !isIdentifierChar(sql.charAt(length));
+    }
+
+    /**
+     * Returns whether {@code sql} ends with {@code keyword} (case-insensitive) preceded by a word boundary, matching
+     * the semantics of the {@code \b(?i:keyword)$} anchored pattern. A bare {@code endsWith} would also match an
+     * identifier that merely carries the keyword as a suffix, such as {@code nowhere} or {@code dataset}.
+     */
+    static boolean endsWithKeyword(@Nonnull String sql, @Nonnull String keyword) {
+        int offset = sql.length() - keyword.length();
+        if (offset < 0 || !sql.regionMatches(true, offset, keyword, 0, keyword.length())) {
+            return false;
         }
-        char next = sql.charAt(length);
-        return !(Character.isLetterOrDigit(next) || next == '_');
+        return offset == 0 || !isIdentifierChar(sql.charAt(offset - 1));
+    }
+
+    /**
+     * Returns whether {@code ch} can be part of an SQL identifier, the character class that separates a keyword from
+     * an identifier that carries it as a prefix or suffix.
+     */
+    private static boolean isIdentifierChar(char ch) {
+        return Character.isLetterOrDigit(ch) || ch == '_';
     }
 
     /**
@@ -120,8 +134,29 @@ final class SqlParser {
         return operation;
     }
 
+    /**
+     * Returns whether {@code sql} has a WHERE clause at the top level of the statement. A WHERE inside parentheses
+     * belongs to a subquery and says nothing about the statement itself: an unqualified UPDATE or DELETE whose only
+     * WHERE sits in a subquery still touches every row, which is exactly what the safety check exists to flag.
+     */
     static boolean hasWhereClause(@Nonnull String sql, @Nonnull SqlDialect dialect) {
-        return WHERE_PATTERN.matcher(clearStringLiterals(clearQuotedIdentifiers(removeComments(sql, dialect), dialect), dialect)).find();
+        String cleared = clearStringLiterals(clearQuotedIdentifiers(removeComments(sql, dialect), dialect), dialect);
+        int depth = 0;
+        for (int i = 0; i < cleared.length(); i++) {
+            char ch = cleared.charAt(i);
+            if (ch == '(') {
+                depth++;
+            } else if (ch == ')') {
+                depth--;
+            } else if (depth == 0
+                    && (ch == 'W' || ch == 'w')
+                    && cleared.regionMatches(true, i, "WHERE", 0, 5)
+                    && (i == 0 || !isIdentifierChar(cleared.charAt(i - 1)))
+                    && (i + 5 == cleared.length() || !isIdentifierChar(cleared.charAt(i + 5)))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String removeWithClause(@Nonnull String sql, @Nonnull SqlDialect dialect) {

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplatePreparation.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplatePreparation.java
@@ -45,8 +45,10 @@ import static st.orm.core.template.impl.RecordReflection.isSealedEntity;
 import static st.orm.core.template.impl.RecordReflection.isTypePresent;
 import static st.orm.core.template.impl.RecordReflection.mapForeignKeys;
 import static st.orm.core.template.impl.RecordValidation.validateDataType;
+import static st.orm.core.template.impl.SqlParser.endsWithKeyword;
 import static st.orm.core.template.impl.SqlParser.getSqlOperation;
 import static st.orm.core.template.impl.SqlParser.removeComments;
+import static st.orm.core.template.impl.SqlParser.startsWithKeyword;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -280,25 +282,25 @@ class TemplatePreparation {
         String previous = removeComments(previousFragment, template.dialect()).stripTrailing().toUpperCase();
         return switch (operation) {
             case SELECT, DELETE, UNDEFINED -> {
-                if (previous.endsWith("WHERE")) {
+                if (endsWithKeyword(previous, "WHERE")) {
                     yield where(bindVars);
                 }
                 throw new SqlTemplateException("BindVars element expected after WHERE.");
             }
             case INSERT -> {
-                if (previous.endsWith("WHERE")) {
+                if (endsWithKeyword(previous, "WHERE")) {
                     yield where(bindVars);
                 }
-                if (previous.endsWith("VALUES")) {
+                if (endsWithKeyword(previous, "VALUES")) {
                     yield values(bindVars);
                 }
                 throw new SqlTemplateException("BindVars element expected after VALUES or WHERE.");
             }
             case UPDATE -> {
-                if (previous.endsWith("SET")) {
+                if (endsWithKeyword(previous, "SET")) {
                     yield set(bindVars);
                 }
-                if (previous.endsWith("WHERE")) {
+                if (endsWithKeyword(previous, "WHERE")) {
                     yield where(bindVars);
                 }
                 throw new SqlTemplateException("BindVars element expected after SET or WHERE.");
@@ -326,7 +328,7 @@ class TemplatePreparation {
         String previous = removeComments(previousFragment, template.dialect()).stripTrailing().toUpperCase();
         return switch (operation) {
             case SELECT, DELETE, UNDEFINED -> {
-                if (previous.endsWith("WHERE")) {
+                if (endsWithKeyword(previous, "WHERE")) {
                     if (o != null) {
                         yield where(o);
                     }
@@ -335,13 +337,13 @@ class TemplatePreparation {
                 yield param(o);
             }
             case INSERT -> {
-                if (previous.endsWith("VALUES")) {
+                if (endsWithKeyword(previous, "VALUES")) {
                     if (o instanceof Data r) {
                         yield values(r);
                     }
                     throw new SqlTemplateException("Record expected after VALUES.");
                 }
-                if (previous.endsWith("WHERE")) {
+                if (endsWithKeyword(previous, "WHERE")) {
                     if (o != null) {
                         yield where(o);
                     }
@@ -350,13 +352,13 @@ class TemplatePreparation {
                 yield param(o);
             }
             case UPDATE -> {
-                if (previous.endsWith("SET")) {
+                if (endsWithKeyword(previous, "SET")) {
                     if (o instanceof Data r) {
                         yield set(r);
                     }
                     throw new SqlTemplateException("Record expected after SET.");
                 }
-                if (previous.endsWith("WHERE")) {
+                if (endsWithKeyword(previous, "WHERE")) {
                     if (o != null) {
                         yield where(o);
                     }
@@ -408,19 +410,19 @@ class TemplatePreparation {
         String previous = removeComments(previousFragment, template.dialect()).stripTrailing().toUpperCase();
         return switch (operation) {
             case SELECT, UPDATE, DELETE, UNDEFINED -> {
-                if (previous.endsWith("WHERE")) {
+                if (endsWithKeyword(previous, "WHERE")) {
                     yield where(iterable);
                 }
                 yield param(iterable);
             }
             case INSERT -> {
-                if (previous.endsWith("VALUES")) {
+                if (endsWithKeyword(previous, "VALUES")) {
                     if (StreamSupport.stream(iterable.spliterator(), false).allMatch(it -> it instanceof Data)) {
                         yield values((Iterable<? extends Data>) iterable);
                     }
                     throw new SqlTemplateException("Records expected after VALUES.");
                 }
-                if (previous.endsWith("WHERE")) {
+                if (endsWithKeyword(previous, "WHERE")) {
                     yield where(iterable);
                 }
                 yield param(iterable);
@@ -456,32 +458,32 @@ class TemplatePreparation {
         String previous = removeComments(previousFragment, template.dialect()).stripTrailing().toUpperCase();
         return switch (operation) {
             case SELECT -> {
-                if (previous.endsWith("FROM")) {
+                if (endsWithKeyword(previous, "FROM")) {
                     boolean autoJoin = first instanceof Select select && isTypePresent(recordType, select.table());
                     yield from(recordType, autoJoin);
                 }
-                if (previous.endsWith("JOIN")) {
+                if (endsWithKeyword(previous, "JOIN")) {
                     yield table(recordType);
                 }
                 yield select(recordType);
             }
             case INSERT -> {
-                if (previous.endsWith("INTO")) {
+                if (endsWithKeyword(previous, "INTO")) {
                     yield insert(recordType);
                 }
                 yield table(recordType);
             }
             case UPDATE -> {
-                if (previous.endsWith("UPDATE")) {
+                if (endsWithKeyword(previous, "UPDATE")) {
                     yield update(recordType);
                 }
                 yield table(recordType);
             }
             case DELETE -> {
-                if (next.startsWith("FROM")) {
+                if (startsWithKeyword(next, "FROM")) {
                     yield delete(recordType);
                 }
-                if (previous.endsWith("FROM")) {
+                if (endsWithKeyword(previous, "FROM")) {
                     yield from(recordType, false);
                 }
                 yield table(recordType);

--- a/storm-core/src/test/java/st/orm/core/BuilderIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/BuilderIntegrationTest.java
@@ -655,6 +655,16 @@ public class BuilderIntegrationTest {
     }
 
     @Test
+    public void testUpdateWithSubqueryWhereOnlyRequiresUnsafe() {
+        var orm = ORMTemplate.of(dataSource);
+        // The only WHERE sits in a subquery; the update itself is unqualified and touches every row.
+        var query = orm.query(raw("UPDATE visit SET description = (SELECT name FROM city WHERE city.id = 1)"));
+        var e = assertThrows(PersistenceException.class, query::executeUpdate);
+        assertTrue(e.getMessage().contains("unsafe"));
+        assertEquals(14, query.unsafe().executeUpdate());
+    }
+
+    @Test
     public void testQueryManaged() {
         var orm = ORMTemplate.of(dataSource);
         var query = orm.selectFrom(City.class).build();

--- a/storm-core/src/test/java/st/orm/core/template/impl/SqlParserTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/SqlParserTest.java
@@ -1,9 +1,14 @@
 package st.orm.core.template.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static st.orm.core.spi.Providers.getSqlDialect;
 import static st.orm.core.template.impl.SqlParser.clearQuotedIdentifiers;
 import static st.orm.core.template.impl.SqlParser.clearStringLiterals;
+import static st.orm.core.template.impl.SqlParser.endsWithKeyword;
+import static st.orm.core.template.impl.SqlParser.hasWhereClause;
+import static st.orm.core.template.impl.SqlParser.startsWithKeyword;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,5 +28,83 @@ public class SqlParserTest {
         // double-quoted identifiers untouched (including escaped identifiers like """table""").
         assertEquals("SELECT * FROM \"table\" WHERE column = ''", clearStringLiterals("SELECT * FROM \"table\" WHERE column = 'value'", getSqlDialect()));
         assertEquals("SELECT * FROM \"\"\"table\"\"\" WHERE column = ''", clearStringLiterals("SELECT * FROM \"\"\"table\"\"\" WHERE column = '''value'''", getSqlDialect()));
+    }
+
+    // endsWithKeyword
+
+    @Test
+    public void testEndsWithKeywordMatchesKeywordAfterBoundary() {
+        assertTrue(endsWithKeyword("SELECT * FROM T WHERE", "WHERE"));
+        assertTrue(endsWithKeyword("SELECT * FROM T\nWHERE", "WHERE"));
+        assertTrue(endsWithKeyword("(WHERE", "WHERE"));
+        assertTrue(endsWithKeyword("A SET", "SET"));
+        assertTrue(endsWithKeyword("WHERE", "WHERE"));
+    }
+
+    @Test
+    public void testEndsWithKeywordIsCaseInsensitive() {
+        assertTrue(endsWithKeyword("select * from t where", "WHERE"));
+    }
+
+    @Test
+    public void testEndsWithKeywordRejectsIdentifierSuffix() {
+        assertFalse(endsWithKeyword("SELECT * FROM nowhere", "WHERE"));
+        assertFalse(endsWithKeyword("SELECT dataset", "SET"));
+        assertFalse(endsWithKeyword("LIMIT 1 OFFSET", "SET"));
+        assertFalse(endsWithKeyword("INSERT INTO key_values", "VALUES"));
+        assertFalse(endsWithKeyword("SELECT copied_from", "FROM"));
+        assertFalse(endsWithKeyword("SELECT 7SET", "SET"));
+    }
+
+    @Test
+    public void testEndsWithKeywordRejectsShorterString() {
+        assertFalse(endsWithKeyword("SET", "WHERE"));
+    }
+
+    // startsWithKeyword
+
+    @Test
+    public void testStartsWithKeywordMatchesKeywordBeforeBoundary() {
+        assertTrue(startsWithKeyword("FROM t", "FROM"));
+        assertTrue(startsWithKeyword("FROM", "FROM"));
+        assertTrue(startsWithKeyword("from t", "FROM"));
+        assertTrue(startsWithKeyword("FROM(", "FROM"));
+    }
+
+    @Test
+    public void testStartsWithKeywordRejectsIdentifierPrefix() {
+        assertFalse(startsWithKeyword("FROMAGE", "FROM"));
+        assertFalse(startsWithKeyword("FROM_TABLE t", "FROM"));
+        assertFalse(startsWithKeyword("FROM2 t", "FROM"));
+    }
+
+    // hasWhereClause
+
+    @Test
+    public void testHasWhereClauseDetectsTopLevelWhere() {
+        assertTrue(hasWhereClause("DELETE FROM t WHERE id = 1", getSqlDialect()));
+        assertTrue(hasWhereClause("update t set x = 1 where id = 1", getSqlDialect()));
+        assertTrue(hasWhereClause("DELETE FROM t WHERE EXISTS (SELECT 1 FROM b WHERE b.id = t.id)", getSqlDialect()));
+        assertTrue(hasWhereClause("UPDATE t SET x = (SELECT a FROM b WHERE c = 1) WHERE t.id = 1", getSqlDialect()));
+    }
+
+    @Test
+    public void testHasWhereClauseIgnoresSubqueryWhere() {
+        assertFalse(hasWhereClause("UPDATE t SET x = (SELECT a FROM b WHERE c = 1)", getSqlDialect()));
+        assertFalse(hasWhereClause("DELETE FROM t USING (SELECT id FROM b WHERE b.x = 1) s", getSqlDialect()));
+    }
+
+    @Test
+    public void testHasWhereClauseIgnoresMissingWhere() {
+        assertFalse(hasWhereClause("DELETE FROM t", getSqlDialect()));
+        assertFalse(hasWhereClause("UPDATE t SET x = 1", getSqlDialect()));
+    }
+
+    @Test
+    public void testHasWhereClauseIgnoresIdentifiersAndLiterals() {
+        assertFalse(hasWhereClause("UPDATE nowhere SET x = 1", getSqlDialect()));
+        assertFalse(hasWhereClause("UPDATE t SET x = 'WHERE'", getSqlDialect()));
+        assertFalse(hasWhereClause("UPDATE t SET \"where\" = 1", getSqlDialect()));
+        assertFalse(hasWhereClause("UPDATE t SET x = 1 -- WHERE id = 1", getSqlDialect()));
     }
 }

--- a/storm-core/src/test/java/st/orm/core/template/impl/TemplatePreparationTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/TemplatePreparationTest.java
@@ -594,4 +594,45 @@ public class TemplatePreparationTest {
             assertNotNull(owner.address().city());
         }
     }
+
+    // ==================== keyword boundaries in value dispatch ====================
+
+    @Test
+    public void testIdentifierWithWhereSuffixDoesNotDispatchWhere() throws Exception {
+        // An identifier that merely ends in WHERE must not reclassify the next value as a where-object.
+        Sql sql = TEMPLATE.process(raw("SELECT * FROM city AS nowhere \0", 42));
+        assertEquals("SELECT * FROM city AS nowhere ?", sql.statement());
+        assertEquals(1, sql.parameters().size());
+    }
+
+    @Test
+    public void testIdentifierWithValuesSuffixDoesNotDispatchValues() throws Exception {
+        // An identifier that merely ends in VALUES must not reclassify the next value as an insert row.
+        Sql sql = TEMPLATE.process(raw("INSERT INTO key_values \0", "text"));
+        assertEquals("INSERT INTO key_values ?", sql.statement());
+        assertEquals(1, sql.parameters().size());
+    }
+
+    @Test
+    public void testIdentifierWithSetSuffixDoesNotDispatchSet() throws Exception {
+        // An identifier that merely ends in SET must not reclassify the next value as an update row.
+        Sql sql = TEMPLATE.process(raw("UPDATE test_entity SET name = dataset\0", 1));
+        assertEquals("UPDATE test_entity SET name = dataset?", sql.statement());
+        assertEquals(1, sql.parameters().size());
+    }
+
+    // ==================== top-level WHERE detection for the unsafe-statement check ====================
+
+    @Test
+    public void testUpdateWithSubqueryWhereOnlyIsFlaggedUnsafe() throws Exception {
+        // The only WHERE sits in a subquery; the update itself is unqualified and must be flagged.
+        Sql sql = TEMPLATE.process(raw("UPDATE test_entity SET name = (SELECT name FROM other WHERE other.id = 1)"));
+        assertTrue(sql.unsafeWarning().isPresent());
+    }
+
+    @Test
+    public void testUpdateWithTopLevelWhereIsNotFlagged() throws Exception {
+        Sql sql = TEMPLATE.process(raw("UPDATE test_entity SET name = (SELECT name FROM other WHERE other.id = 1) WHERE id = 1"));
+        assertTrue(sql.unsafeWarning().isEmpty());
+    }
 }


### PR DESCRIPTION
Keyword dispatch in `TemplatePreparation` used bare `endsWith` at 19 sites, so a fragment ending in an identifier that merely carries a keyword suffix (`nowhere`, `key_values`, `dataset`) silently reclassified the next interpolated value: an integer became a where-object, a string an insert row. The failure was a wrong query, not an error. All 19 sites now use shared word-boundary helpers in `SqlParser`: a new `endsWithKeyword` alongside the existing `startsWithKeyword` (now shared), including the `startsWith("FROM")` site in the DELETE case, which had the same flaw in the other direction.

`SqlParser.hasWhereClause` was a regex `find()` over the whole statement, so `UPDATE t SET x = (SELECT a FROM b WHERE c)`, an unqualified full-table update, matched and the unsafe-statement check was suppressed on precisely the statement it exists to flag. It now scans the comment-, literal- and quoted-identifier-cleared SQL with parenthesis-depth tracking and only accepts a WHERE at the top level of the statement. The unused `WHERE_PATTERN` is removed.

The new tests were verified against the unfixed sources: the unsafe-flag tests fail there (the warning is suppressed) and the dispatch tests error with misclassification messages. Coverage: keyword-boundary and top-level-WHERE matrices in `SqlParserTest`, preparation-level dispatch and `unsafeWarning()` tests in `TemplatePreparationTest`, and an end-to-end test showing the subquery-WHERE update throws until `unsafe()` is used.

Fixes #391