### PR TITLE
fix!: derive KeyDelegate nullability from the underlying field

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/impl/MetamodelFactory.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/MetamodelFactory.java
@@ -144,14 +144,7 @@ public final class MetamodelFactory {
     public static Metamodel<?, ?> canonical(@Nonnull Metamodel<?, ?> metamodel) {
         try {
             Class<? extends Data> rootTable = metamodel.root();
-            Class<? extends Data> fieldResolutionClass = rootTable;
-            if (rootTable.isSealed() && isSealedEntity(rootTable)) {
-                Class<?>[] permitted = rootTable.getPermittedSubclasses();
-                if (permitted != null && permitted.length > 0) {
-                    fieldResolutionClass = (Class<? extends Data>) permitted[0];
-                }
-            }
-            String foreignKeyPath = primaryKeyThroughForeignKeyPath(fieldResolutionClass, metamodel.fieldPath());
+            String foreignKeyPath = primaryKeyThroughForeignKeyPath(fieldResolutionClass(rootTable), metamodel.fieldPath());
             if (foreignKeyPath == null) {
                 return metamodel;
             }
@@ -183,6 +176,69 @@ public final class MetamodelFactory {
             result.addAll(child.flatten());
         }
         return List.copyOf(result);
+    }
+
+    /**
+     * Returns whether the field designated by the given metamodel allows NULL values, following the semantics of
+     * {@link Metamodel.Key#isNullable()}. A metamodel that carries the {@link Metamodel.Key} marker answers for
+     * itself. For any other metamodel the record field at the metamodel's path decides: a unique field applies its
+     * {@code nullsDistinct} setting, an inline record derives its nullability from its constituent fields, and a
+     * plain field is as nullable as the field itself, because no unique constraint restricts its NULL values.
+     *
+     * <p>This backs {@link Metamodel#key(Metamodel)} delegates, which wrap metamodels that do not carry the key
+     * marker themselves.</p>
+     */
+    public static boolean isNullable(@Nonnull Metamodel<?, ?> metamodel) {
+        if (metamodel instanceof Metamodel.Key<?, ?> key) {
+            return key.isNullable();
+        }
+        String path = metamodel.fieldPath();
+        if (path.isEmpty()) {
+            // The root metamodel designates the row itself rather than a column.
+            return false;
+        }
+        try {
+            RecordField field = getRecordField(fieldResolutionClass(metamodel.root()), path);
+            boolean nullsDistinct = getNullsDistinct(field);
+            boolean inline = !Ref.class.isAssignableFrom(field.type())
+                    && getORMConverter(field).isEmpty()
+                    && isRecord(field.type())
+                    && !Data.class.isAssignableFrom(field.type());
+            if (inline) {
+                // Mirrors SimpleKeyMetamodel: an inline record is nullable when its unique constraint treats NULLs
+                // as distinct and any of its constituent fields is nullable.
+                boolean fieldIsUnique = field.isAnnotationPresent(UK.class) || field.isAnnotationPresent(PK.class);
+                if (!fieldIsUnique || !nullsDistinct) {
+                    return false;
+                }
+                for (var leaf : metamodel.flatten()) {
+                    if (leaf instanceof Metamodel.Key<?, ?> leafKey && leafKey.isNullable()) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            return field.nullable() && nullsDistinct;
+        } catch (SqlTemplateException e) {
+            throw new PersistenceException("Failed to resolve nullability for metamodel field at path '%s' on type %s.".formatted(path, metamodel.root().getName()), e);
+        }
+    }
+
+    /**
+     * Returns the class that field resolution should inspect for the given root table. For sealed entity interfaces,
+     * resolution is delegated to the first permitted subclass: the sealed interface itself declares accessor methods
+     * but is not a record, so {@code getRecordField()} cannot inspect it directly. This mirrors the delegation
+     * pattern used by {@code findPkField()}.
+     */
+    @SuppressWarnings("unchecked")
+    private static Class<? extends Data> fieldResolutionClass(@Nonnull Class<? extends Data> rootTable) {
+        if (rootTable.isSealed() && isSealedEntity(rootTable)) {
+            Class<?>[] permitted = rootTable.getPermittedSubclasses();
+            if (permitted != null && permitted.length > 0) {
+                return (Class<? extends Data>) permitted[0];
+            }
+        }
+        return rootTable;
     }
 
     /**
@@ -242,17 +298,7 @@ public final class MetamodelFactory {
         if (path.isEmpty()) {
             return (Metamodel<T, E>) root(rootTable);
         }
-        // For sealed entity interfaces, delegate field resolution to the first permitted subclass.
-        // The sealed interface itself declares accessor methods but is not a record, so getRecordField()
-        // cannot inspect it directly. This mirrors the delegation pattern used by findPkField().
-        Class<? extends Data> fieldResolutionClass = rootTable;
-        if (rootTable.isSealed() && isSealedEntity(rootTable)) {
-            Class<?>[] permitted = rootTable.getPermittedSubclasses();
-            if (permitted != null && permitted.length > 0) {
-                //noinspection unchecked
-                fieldResolutionClass = (Class<? extends Data>) permitted[0];
-            }
-        }
+        Class<? extends Data> fieldResolutionClass = fieldResolutionClass(rootTable);
         Class<E> fieldType;
         String effectivePath;
         StringBuilder effectiveField;

--- a/storm-core/src/test/java/st/orm/core/RepositoryPreparedStatementIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/RepositoryPreparedStatementIntegrationTest.java
@@ -2592,6 +2592,27 @@ public class RepositoryPreparedStatementIntegrationTest {
     }
 
     @Test
+    public void testScrollRejectsWrappedNullableKey() {
+        // Owner.telephone is @Nullable and not unique; its key() view keeps the field's nullability,
+        // so scroll rejects it as a cursor key.
+        var key = Metamodel.key(Owner_.telephone);
+        assertTrue(key.isNullable());
+        assertThrows(PersistenceException.class, () ->
+                ORMTemplate.of(dataSource)
+                        .selectFrom(Owner.class)
+                        .scroll(Scrollable.of(key, 5)));
+    }
+
+    @Test
+    public void testScrollWithWrappedNonNullableKey() {
+        // Owner.lastName is @Nonnull; its key() view passes the nullability validation.
+        var window = ORMTemplate.of(dataSource)
+                .selectFrom(Owner.class)
+                .scroll(Scrollable.of(Metamodel.key(Owner_.lastName), 5));
+        assertEquals(5, window.content().size());
+    }
+
+    @Test
     public void testScrollAcceptsNullsNotDistinctCompoundKey() {
         // EntityWithNullsNotDistinctUK has @UK(nullsDistinct = false) NullableCompoundUK.
         // The key should NOT be considered nullable, so scroll should not throw PersistenceException.
@@ -2607,10 +2628,11 @@ public class RepositoryPreparedStatementIntegrationTest {
     public void testMetamodelKeyFactory() {
         // Owner_.id is already a Key (via @PK -> @UK), so key() should return the same instance.
         assertSame(Owner_.id, Metamodel.key(Owner_.id));
-        // Owner_.address is not unique, so key() should wrap it in a KeyDelegate.
+        // Owner_.address is an inline record, which carries the Key marker; key() returns it as-is.
         var addressKey = Metamodel.key(Owner_.address);
         assertNotNull(addressKey);
         assertInstanceOf(Metamodel.Key.class, addressKey);
+        assertSame(Owner_.address, addressKey);
         // The delegate should be equal to the original metamodel.
         assertEquals(Owner_.address, addressKey);
         assertEquals(addressKey, Owner_.address);

--- a/storm-core/src/test/java/st/orm/core/template/MetamodelTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/MetamodelTest.java
@@ -16,6 +16,7 @@ import st.orm.core.model.NullableCompoundUK;
 import st.orm.core.model.Owner;
 import st.orm.core.model.Owner_;
 import st.orm.core.model.Pet;
+import st.orm.core.model.Pet_;
 import st.orm.core.model.VetSpecialty;
 import st.orm.core.model.VetSpecialtyPK;
 import st.orm.core.model.VetSpecialty_;
@@ -274,6 +275,47 @@ public class MetamodelTest {
         // Owner_.address is an inline record without @UK, so isNullable() defaults to false.
         Metamodel.Key<?, ?> key = Owner_.address;
         assertFalse(key.isNullable());
+    }
+
+    // Metamodel.key() factory nullability tests.
+
+    @Test
+    public void testWrappedNullableFieldIsNullable() {
+        // Owner.telephone is @Nullable and not unique, so its generated metamodel carries no Key marker;
+        // the key() view derives nullability from the underlying field.
+        Metamodel.Key<Owner, String> key = Metamodel.key(Owner_.telephone);
+        assertInstanceOf(Metamodel.KeyDelegate.class, key);
+        assertTrue(key.isNullable());
+    }
+
+    @Test
+    public void testWrappedNonNullableFieldIsNotNullable() {
+        // Owner.firstName is @Nonnull, so its key() view is non-nullable.
+        Metamodel.Key<Owner, String> key = Metamodel.key(Owner_.firstName);
+        assertInstanceOf(Metamodel.KeyDelegate.class, key);
+        assertFalse(key.isNullable());
+    }
+
+    @Test
+    public void testWrappedFactoryMetamodelWithNullableFieldIsNullable() {
+        // The factory route for manually constructed metamodels keeps the field's nullability.
+        Metamodel<Owner, String> telephone = Metamodel.of(Owner.class, "telephone");
+        assertTrue(Metamodel.key(telephone).isNullable());
+    }
+
+    @Test
+    public void testWrappedNestedFieldResolvesNullabilityAtLeaf() {
+        // A nested path resolves nullability at the leaf field.
+        Metamodel<Pet, String> telephone = Metamodel.of(Pet.class, "owner.telephone");
+        assertTrue(Metamodel.key(telephone).isNullable());
+        Metamodel<Pet, String> firstName = Metamodel.of(Pet.class, "owner.firstName");
+        assertFalse(Metamodel.key(firstName).isNullable());
+    }
+
+    @Test
+    public void testWrappedNullableForeignKeyIsNullable() {
+        // Pet.owner is a @Nullable @FK, so its foreign key column allows NULLs.
+        assertTrue(Metamodel.key(Pet_.owner).isNullable());
     }
 
     @Test

--- a/storm-foundation/src/main/java/st/orm/Metamodel.java
+++ b/storm-foundation/src/main/java/st/orm/Metamodel.java
@@ -222,6 +222,9 @@ public interface Metamodel<T extends Data, E> extends Navigable<T, E> {
      * context where the key is used. Using a non-unique column as a keyset pagination key will silently skip rows when
      * duplicate values span page boundaries.</p>
      *
+     * <p>The returned key reports {@link Key#isNullable()} from the underlying field: a nullable field stays nullable
+     * when viewed as a key, so keyset pagination keeps rejecting it.</p>
+     *
      * @param metamodel the metamodel to view as a key.
      * @return a {@code Key} instance backed by the given metamodel.
      * @param <T> the root table type.
@@ -263,7 +266,16 @@ public interface Metamodel<T extends Data, E> extends Navigable<T, E> {
         @Override public boolean isIdentical(@Nonnull T a, @Nonnull T b) { return delegate.isIdentical(a, b); }
         @Override public boolean isSame(@Nonnull T a, @Nonnull T b)  { return delegate.isSame(a, b); }
         @Override public List<Metamodel<T, ?>> flatten()             { return delegate.flatten(); }
-        @Override public boolean isNullable()                        { return delegate instanceof Key<?, ?> key && key.isNullable(); }
+
+        /**
+         * Returns the nullability of the underlying field. A delegate around a {@link Key} answers through that key;
+         * any other delegate derives the answer from the record field the metamodel designates, so a nullable field
+         * wrapped by {@link #key(Metamodel)} is still rejected as a keyset pagination cursor.
+         */
+        @Override
+        public boolean isNullable() {
+            return delegate instanceof Key<?, ?> key ? key.isNullable() : MetamodelHelper.isNullable(delegate);
+        }
 
         @Override
         public boolean equals(Object o) {

--- a/storm-foundation/src/main/java/st/orm/MetamodelHelper.java
+++ b/storm-foundation/src/main/java/st/orm/MetamodelHelper.java
@@ -37,8 +37,8 @@ class MetamodelHelper {
                 return (Metamodel<T, T>) ROOT_METHOD.invoke(null, rootTable);
             } catch (InvocationTargetException e) {
                 throw e.getTargetException();
-            } catch (ReflectiveOperationException e) {
-                throw new RuntimeException("Reflection invocation failed for MetamodelFactory.of", e);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException("Reflection invocation failed for MetamodelFactory.root", e);
             }
         } catch (RuntimeException e) {
             throw e;
@@ -54,7 +54,7 @@ class MetamodelHelper {
                 return (Metamodel<T, E>) OF_METHOD.invoke(null, rootTable, path);
             } catch (InvocationTargetException e) {
                 throw e.getTargetException();
-            } catch (ReflectiveOperationException e) {
+            } catch (IllegalAccessException e) {
                 throw new RuntimeException("Reflection invocation failed for MetamodelFactory.of", e);
             }
         } catch (RuntimeException e) {
@@ -71,7 +71,7 @@ class MetamodelHelper {
                 return (List<Metamodel<T, ?>>) FLATTEN_METHOD.invoke(null, metamodel);
             } catch (InvocationTargetException e) {
                 throw e.getTargetException();
-            } catch (ReflectiveOperationException e) {
+            } catch (IllegalAccessException e) {
                 throw new RuntimeException("Reflection invocation failed for MetamodelFactory.flatten", e);
             }
         } catch (RuntimeException e) {
@@ -87,7 +87,7 @@ class MetamodelHelper {
                 return (Boolean) IS_NULLABLE_METHOD.invoke(null, metamodel);
             } catch (InvocationTargetException e) {
                 throw e.getTargetException();
-            } catch (ReflectiveOperationException e) {
+            } catch (IllegalAccessException e) {
                 throw new RuntimeException("Reflection invocation failed for MetamodelFactory.isNullable", e);
             }
         } catch (RuntimeException e) {

--- a/storm-foundation/src/main/java/st/orm/MetamodelHelper.java
+++ b/storm-foundation/src/main/java/st/orm/MetamodelHelper.java
@@ -10,6 +10,7 @@ class MetamodelHelper {
     private static final Method ROOT_METHOD;
     private static final Method OF_METHOD;
     private static final Method FLATTEN_METHOD;
+    private static final Method IS_NULLABLE_METHOD;
 
     static {
         try {
@@ -17,6 +18,7 @@ class MetamodelHelper {
             ROOT_METHOD = factoryClass.getMethod("root", Class.class);
             OF_METHOD = factoryClass.getMethod("of", Class.class, String.class);
             FLATTEN_METHOD = factoryClass.getMethod("flatten", Navigable.class);
+            IS_NULLABLE_METHOD = factoryClass.getMethod("isNullable", Metamodel.class);
         } catch (ReflectiveOperationException e) {
             var ex = new ExceptionInInitializerError("Failed to initialize Metamodel. Please ensure that storm-core is present in the classpath.");
             ex.initCause(e);
@@ -71,6 +73,22 @@ class MetamodelHelper {
                 throw e.getTargetException();
             } catch (ReflectiveOperationException e) {
                 throw new RuntimeException("Reflection invocation failed for MetamodelFactory.flatten", e);
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new PersistenceException(t);
+        }
+    }
+
+    static boolean isNullable(@Nonnull Metamodel<?, ?> metamodel) {
+        try {
+            try {
+                return (Boolean) IS_NULLABLE_METHOD.invoke(null, metamodel);
+            } catch (InvocationTargetException e) {
+                throw e.getTargetException();
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException("Reflection invocation failed for MetamodelFactory.isNullable", e);
             }
         } catch (RuntimeException e) {
             throw e;

--- a/storm-foundation/src/test/java/st/orm/KeyDelegateTest.java
+++ b/storm-foundation/src/test/java/st/orm/KeyDelegateTest.java
@@ -92,10 +92,10 @@ class KeyDelegateTest {
     }
 
     @Test
-    void keyDelegateIsNotNullableForNonKeyMetamodel() {
-        TestMetamodel metamodel = new TestMetamodel();
-        Metamodel.Key<TestData, Integer> key = Metamodel.key(metamodel);
-        assertFalse(key.isNullable());
+    void keyDelegateIsNotNullableWhenDelegateIsNonNullableKey() {
+        TestKeyMetamodel nonNullableKey = new TestKeyMetamodel(false);
+        Metamodel.KeyDelegate<TestData, Integer> delegate = new Metamodel.KeyDelegate<>(nonNullableKey);
+        assertFalse(delegate.isNullable());
     }
 
     @Test


### PR DESCRIPTION
Fixes #403

## Problem

`Metamodel.key()` returns the argument unchanged when it already implements `Key` and wraps it in `KeyDelegate` otherwise. `KeyDelegate.isNullable()` returned `delegate instanceof Key<?, ?> key && key.isNullable()`, but by construction the delegate is never a `Key`, so every factory-built delegate reported non-nullable. That is precisely the check keyset pagination relies on to reject nullable cursor keys, so a wrapped nullable metamodel used as a pagination key silently skipped NULL rows across page boundaries: the exact failure mode the `key()` docs warn about.

## Fix

`KeyDelegate.isNullable()` now derives the answer from the underlying metamodel. A delegate around a `Key` still answers through that key; any other delegate resolves the record field at the metamodel's path through a new `MetamodelFactory.isNullable(Metamodel)`, bridged from storm-foundation via the reflective `MetamodelHelper` (the same pattern as `root`/`of`/`flatten`):

- a unique field applies its `nullsDistinct` setting, matching factory-built key metamodels;
- an inline record derives from its constituent fields, mirroring `SimpleKeyMetamodel`;
- a plain field reports its own nullability, because no unique constraint restricts its NULL values.

Nullability comes from the same `RecordField.nullable()` source the rest of the framework uses (null-marked-by-default contract; Kotlin resolves from the language type via the Kotlin reflection provider), so Java and Kotlin behave identically and no new dependency is introduced. The sealed-entity field-resolution block that appeared three times in `MetamodelFactory` is extracted into a shared `fieldResolutionClass` helper.

## Breaking change

- `scroll` with a `Metamodel.key()`-wrapped nullable field now throws the descriptive `PersistenceException` instead of silently skipping NULL rows. This also applies to previously issued `Scrollable` tokens revalidated on their next `scroll` call. Callers that genuinely need such a key can implement `Key`/`AbstractKeyMetamodel` explicitly.
- A wrapped custom metamodel whose path does not resolve to a record field previously reported non-nullable; it now fails at validation time with a descriptive error.

`findBy`/`getBy`/`getByRef` do not consult `isNullable()` and are unaffected; non-nullable wrapped keys scroll exactly as before; `KeyDelegate`'s record shape and equality semantics are unchanged.

## Tests

- `MetamodelTest`: wrapped nullable and non-nullable scalar fields, the documented `Metamodel.of` factory route, nested paths resolving at the leaf field, and a nullable `@FK` column.
- `RepositoryPreparedStatementIntegrationTest`: `scroll` rejects a wrapped nullable key and still accepts a wrapped non-nullable key; `testMetamodelKeyFactory` tightened with `assertSame` for the inline-record case, which already carries the `Key` marker.
- `KeyDelegateTest` (storm-foundation, runs without storm-core): the test that asserted the always-false behavior is replaced by direct-key coverage of both nullability answers; derivation coverage lives in storm-core, where the factory is on the classpath.

Full reactor green (`mvn test`, all modules).