### PR TITLE
fix!: keep explicit dialects across withConfig and fail fast on ambiguous dialect resolution

### DIFF
--- a/storm-core/src/main/java/st/orm/core/spi/Providers.java
+++ b/storm-core/src/main/java/st/orm/core/spi/Providers.java
@@ -235,11 +235,20 @@ public final class Providers {
         return getSqlDialect(StormConfig.defaults());
     }
 
+    /**
+     * Resolves the SQL dialect from the classpath, without a database in view.
+     *
+     * <p>Enablement is re-evaluated on every resolution, and an ambiguous resolution fails fast.</p>
+     *
+     * @param config the Storm configuration to apply.
+     * @return the SQL dialect.
+     * @throws PersistenceException if no dialect provider is found or the resolution is ambiguous.
+     */
     public static SqlDialect getSqlDialect(@Nonnull StormConfig config) {
-        return enabled(SQL_DIALECT_PROVIDERS)
-                .map(p -> p.getSqlDialect(config))
-                .findFirst()
-                .orElseThrow();
+        return selectUnique(SQL_DIALECT_PROVIDERS, "SQL dialect provider",
+                "SqlTemplate.withDialect(...), or by binding the template to a DataSource or Connection so the " +
+                        "dialect is derived from the database")
+                .getSqlDialect(config);
     }
 
     public static SqlDialect getSqlDialect(@Nonnull Predicate<? super SqlDialectProvider> filter) {

--- a/storm-core/src/main/java/st/orm/core/template/SqlTemplate.java
+++ b/storm-core/src/main/java/st/orm/core/template/SqlTemplate.java
@@ -286,14 +286,19 @@ public interface SqlTemplate extends TemplateDecorator {
     /**
      * Returns the SQL dialect used by this template.
      *
+     * <p>When no dialect has been set via {@link #withDialect(SqlDialect)}, the dialect is resolved from the
+     * classpath on first use. That resolution fails with a descriptive exception when multiple dialect providers
+     * are eligible without a defined order.</p>
+     *
      * @return the SQL dialect used by this template.
      * @since 1.2
      */
     SqlDialect dialect();
 
     /**
-     * Returns a new SQL template with the specified Storm configuration. The SQL dialect is re-resolved from the
-     * provided configuration.
+     * Returns a new SQL template with the specified Storm configuration. A dialect set via
+     * {@link #withDialect(SqlDialect)} is retained; a classpath-resolved dialect is re-resolved under the new
+     * configuration, as dialects capture their configuration at construction.
      *
      * @param config the Storm configuration to apply.
      * @return a new SQL template.

--- a/storm-core/src/main/java/st/orm/core/template/impl/JpaTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/JpaTemplateImpl.java
@@ -19,6 +19,7 @@ import static jakarta.persistence.TemporalType.DATE;
 import static jakarta.persistence.TemporalType.TIME;
 import static jakarta.persistence.TemporalType.TIMESTAMP;
 import static st.orm.core.template.SqlTemplate.JPA;
+import static st.orm.core.template.impl.LazySupplier.lazy;
 import static st.orm.core.template.impl.RecordValidation.validate;
 
 import jakarta.annotation.Nonnull;
@@ -28,6 +29,7 @@ import jakarta.persistence.PersistenceException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.sql.DataSource;
@@ -83,9 +85,21 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
     private final TableAliasResolver tableAliasResolver;
     private final Predicate<Provider> providerFilter;
     private final RefFactory refFactory;
-    private final SqlTemplate sqlTemplate;
+
+    /**
+     * Built on first use: without a provider filter it consumes the resolved dialect, whose classpath fallback must
+     * stay untouched until the template is actually used.
+     */
+    private final Supplier<SqlTemplate> sqlTemplate;
+
     private final StormConfig config;
-    private final SqlDialect dialect;
+
+    /**
+     * The dialect of the persistence unit's database, or a classpath fallback resolved on first use when the database
+     * is unknown. Deferring the fallback keeps an ambiguous classpath from failing template construction, so a
+     * provider filter can still be applied via {@link #withProviderFilter(Predicate)}.
+     */
+    private final Supplier<SqlDialect> dialect;
 
     public JpaTemplateImpl(@Nonnull EntityManager entityManager) {
         this(entityManager, StormConfig.defaults());
@@ -112,7 +126,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
         this.config = config;
         this.dialect = resolveDialect(entityManager, config);
         this.refFactory = new RefFactoryImpl(this, modelBuilder, providerFilter);
-        this.sqlTemplate = createSqlTemplate();
+        this.sqlTemplate = lazy(this::createSqlTemplate);
     }
 
     /**
@@ -121,19 +135,19 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
      * <p>Asking the persistence unit for its data source is the portable way to reach the database: unwrapping an
      * entity manager to a {@link java.sql.Connection} is not supported by every provider. A persistence unit
      * configured with a connection URL rather than a data source, or one whose database cannot be reached while the
-     * template is being built, leaves the database unknown, and the dialect then comes from the classpath as
-     * before.</p>
+     * template is being built, leaves the database unknown, and the dialect then comes from the classpath, resolved
+     * on first use.</p>
      */
-    private static SqlDialect resolveDialect(@Nonnull EntityManager entityManager, @Nonnull StormConfig config) {
+    private static Supplier<SqlDialect> resolveDialect(@Nonnull EntityManager entityManager, @Nonnull StormConfig config) {
         DataSource dataSource = dataSourceOf(entityManager);
         if (dataSource == null) {
-            return Providers.getSqlDialect(config);
+            return lazy(() -> Providers.getSqlDialect(config));
         }
         try {
-            return Providers.getSqlDialect(dataSource, config);
+            return new LazySupplier<>(Providers.getSqlDialect(dataSource, config));
         } catch (RuntimeException e) {
             LOGGER.debug("Failed to determine the database of the persistence unit.", e);
-            return Providers.getSqlDialect(config);
+            return lazy(() -> Providers.getSqlDialect(config));
         }
     }
 
@@ -163,7 +177,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
                             @Nonnull TableAliasResolver tableAliasResolver,
                             @Nullable Predicate<Provider> providerFilter,
                             @Nonnull StormConfig config,
-                            @Nonnull SqlDialect dialect) {
+                            @Nonnull Supplier<SqlDialect> dialect) {
         this.dialect = dialect;
         this.templateProcessor = templateProcessor;
         this.modelBuilder = modelBuilder;
@@ -171,7 +185,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
         this.providerFilter = providerFilter;
         this.config = config;
         this.refFactory = new RefFactoryImpl(this, modelBuilder, providerFilter);
-        this.sqlTemplate = createSqlTemplate();
+        this.sqlTemplate = lazy(this::createSqlTemplate);
     }
 
     private SqlTemplate createSqlTemplate() {
@@ -183,7 +197,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
         // The shared template resolves a dialect without a database in view, so the dialect resolved for this
         // persistence unit is applied on top. An explicit provider filter still wins.
         return template.withDialect(
-                providerFilter != null ? Providers.getSqlDialect(providerFilter, config) : dialect);
+                providerFilter != null ? Providers.getSqlDialect(providerFilter, config) : dialect.get());
     }
 
     private void setParameters(@Nonnull jakarta.persistence.Query query, @Nonnull List<SqlTemplate.Parameter> parameters) {
@@ -252,7 +266,7 @@ public final class JpaTemplateImpl implements JpaTemplate, QueryFactory {
      */
     @Override
     public SqlTemplate sqlTemplate() {
-        return  SqlInterceptorManager.customize(sqlTemplate);
+        return  SqlInterceptorManager.customize(sqlTemplate.get());
     }
 
     /**

--- a/storm-core/src/main/java/st/orm/core/template/impl/LazySupplier.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/LazySupplier.java
@@ -68,13 +68,18 @@ public final class LazySupplier<T> implements Supplier<T> {
 
     /**
      * Gets a result. On the first invocation, the supplier is called to produce the value. The supplier is then
-     * released for garbage collection.
+     * released for garbage collection. A resolved value is returned with a single volatile read, so shared
+     * suppliers on hot paths stay free of write contention.
      *
      * @return a result.
      */
     @Override
     public T get() {
-        T result = reference.updateAndGet(value -> requireNonNullElseGet(value, supplier));
+        T result = reference.get();
+        if (result != null) {
+            return result;
+        }
+        result = reference.updateAndGet(value -> requireNonNullElseGet(value, supplier));
         supplier = null;    // Release the supplier (and its captured context) for GC.
         return result;
     }

--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlTemplateImpl.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlTemplateImpl.java
@@ -24,12 +24,14 @@ import static st.orm.core.template.impl.ElementRouter.getElementProcessor;
 import static st.orm.core.template.impl.SqlInterceptorManager.intercept;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import st.orm.BindVars;
@@ -84,15 +86,33 @@ public final class SqlTemplateImpl implements SqlTemplate {
     private final boolean inlineParameters;
     private final ModelBuilder modelBuilder;
     private final TableAliasResolver tableAliasResolver;
-    private final SqlDialect dialect;
-    private final TemplatePreparation templatePreparation;
+
+    /**
+     * The dialect set via {@link #withDialect(SqlDialect)} or a dialect-taking constructor, or {@code null} when the
+     * dialect is resolved from the classpath. An explicit dialect is preserved across {@link #withConfig(StormConfig)},
+     * whereas a classpath-resolved dialect is re-resolved under the new configuration.
+     */
+    private final @Nullable SqlDialect explicitDialect;
+
+    /**
+     * The dialect in use, resolved on first use. Classpath resolution fails fast when multiple dialect providers are
+     * eligible without a defined order, so templates that receive an explicit dialect before processing, such as the
+     * shared {@link SqlTemplate#PS} and {@link SqlTemplate#JPA} instances customized by database-bound templates,
+     * must never trigger it. All dialect-dependent state is therefore initialized lazily.
+     */
+    private final LazySupplier<SqlDialect> dialect;
+
+    private final Supplier<TemplatePreparation> templatePreparation;
     private final Function<TemplateString, Object> keyGenerator;
     private final StormConfig config;
-    private final SegmentedLruCache<Object, TemplateProcessor> cache;
+
+    /** The template cache, keyed by the resolved dialect and therefore lazy; {@code null} when caching is disabled. */
+    private final @Nullable Supplier<SegmentedLruCache<Object, TemplateProcessor>> cache;
+
     private final TemplateMetrics templateMetrics;
 
     public SqlTemplateImpl(boolean positionalOnly, boolean expandCollection, boolean supportRecords) {
-        this(positionalOnly, expandCollection, supportRecords, false, ModelBuilder.newInstance(), TableAliasResolver.DEFAULT, getSqlDialect());
+        this(positionalOnly, expandCollection, supportRecords, false, ModelBuilder.newInstance(), TableAliasResolver.DEFAULT, null, StormConfig.defaults());
     }
 
     public SqlTemplateImpl(boolean positionalOnly,
@@ -102,7 +122,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
                            @Nonnull ModelBuilder modelBuilder,
                            @Nonnull TableAliasResolver tableAliasResolver,
                            @Nonnull SqlDialect dialect) {
-        this(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, dialect, StormConfig.defaults());
+        this(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, requireNonNull(dialect), StormConfig.defaults());
     }
 
     SqlTemplateImpl(boolean positionalOnly,
@@ -111,7 +131,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
                     boolean inlineParameters,
                     @Nonnull ModelBuilder modelBuilder,
                     @Nonnull TableAliasResolver tableAliasResolver,
-                    @Nonnull SqlDialect dialect,
+                    @Nullable SqlDialect dialect,
                     @Nonnull StormConfig config) {
         this.positionalOnly = positionalOnly;
         this.expandCollection = expandCollection;
@@ -119,17 +139,20 @@ public final class SqlTemplateImpl implements SqlTemplate {
         this.inlineParameters = inlineParameters;
         this.modelBuilder = requireNonNull(modelBuilder);
         this.tableAliasResolver = requireNonNull(tableAliasResolver);
-        this.dialect = requireNonNull(dialect);
+        this.explicitDialect = dialect;
         this.config = requireNonNull(config);
-        this.templatePreparation = new TemplatePreparation(this, modelBuilder);
+        this.dialect = dialect != null ? new LazySupplier<>(dialect) : new LazySupplier<>(() -> getSqlDialect(config));
+        this.templatePreparation = new LazySupplier<>(() -> new TemplatePreparation(this, modelBuilder));
         this.keyGenerator = keyGenerator();
         int templateCacheSize = Math.max(0, getInt(config, TEMPLATE_CACHE_SIZE, 2048));
         if (templateCacheSize == 0 || inlineParameters) {
             // We don't want to cache templates with inline parameters. No caching takes place if inline parameters are enabled.
             this.cache = null;
         } else {
-            var key = List.of(positionalOnly, expandCollection, supportRecords, new IdentityKey(modelBuilder), new IdentityKey(tableAliasResolver), dialect.name(), configCacheKey(config));
-            this.cache = CacheHolder.INSTANCE.getOrCompute(key, () -> new SegmentedLruCache<>(templateCacheSize));
+            this.cache = new LazySupplier<>(() -> {
+                var key = List.of(positionalOnly, expandCollection, supportRecords, new IdentityKey(modelBuilder), new IdentityKey(tableAliasResolver), dialect().name(), configCacheKey(config));
+                return CacheHolder.INSTANCE.getOrCompute(key, () -> new SegmentedLruCache<>(templateCacheSize));
+            });
         }
         this.templateMetrics = TemplateMetrics.getInstance();
         this.templateMetrics.registerCacheSize(templateCacheSize);
@@ -148,7 +171,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
     private Function<TemplateString, Object> keyGenerator() {
         return template -> {
             try {
-                return getCompilationKey(templatePreparation.preprocess(template));
+                return getCompilationKey(templatePreparation.get().preprocess(template));
             } catch (SqlTemplateException e) {
                 throw new UncheckedSqlTemplateException(e);
             }
@@ -158,7 +181,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
     private Function<TemplateString, Object> shapeGenerator() {
         return template -> {
             try {
-                return getShapeKey(templatePreparation.preprocess(template));
+                return getShapeKey(templatePreparation.get().preprocess(template));
             } catch (SqlTemplateException e) {
                 throw new UncheckedSqlTemplateException(e);
             }
@@ -197,7 +220,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
         if (tableNameResolver == modelBuilder.tableNameResolver()) {
             return this;
         }
-        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder.tableNameResolver(tableNameResolver), tableAliasResolver, dialect, config);
+        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder.tableNameResolver(tableNameResolver), tableAliasResolver, explicitDialect, config);
     }
 
     /**
@@ -221,7 +244,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
         if (tableAliasResolver == this.tableAliasResolver) {
             return this;
         }
-        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, dialect, config);
+        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, explicitDialect, config);
     }
 
     /**
@@ -245,7 +268,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
         if (columnNameResolver == modelBuilder.columnNameResolver()) {
             return this;
         }
-        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder.columnNameResolver(columnNameResolver), tableAliasResolver, dialect, config);
+        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder.columnNameResolver(columnNameResolver), tableAliasResolver, explicitDialect, config);
     }
 
     /**
@@ -269,7 +292,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
         if (foreignKeyResolver == modelBuilder.foreignKeyResolver()) {
             return this;
         }
-        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder.foreignKeyResolver(foreignKeyResolver), tableAliasResolver, dialect, config);
+        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder.foreignKeyResolver(foreignKeyResolver), tableAliasResolver, explicitDialect, config);
     }
 
     /**
@@ -290,21 +313,23 @@ public final class SqlTemplateImpl implements SqlTemplate {
      */
     @Override
     public SqlTemplate withDialect(@Nonnull SqlDialect dialect) {
-        if (dialect == this.dialect) {
+        requireNonNull(dialect);
+        if (dialect == this.explicitDialect || this.dialect.value().orElse(null) == dialect) {
             return this;
         }
         return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, dialect, config);
     }
 
     /**
-     * Returns the SQL dialect used by this template.
+     * Returns the SQL dialect used by this template, resolving it from the classpath on first use when no dialect
+     * has been set explicitly.
      *
      * @return the SQL dialect used by this template.
      * @since 1.2
      */
     @Override
     public SqlDialect dialect() {
-        return dialect;
+        return dialect.get();
     }
 
     @Override
@@ -312,7 +337,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
         if (config == this.config) {
             return this;
         }
-        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, getSqlDialect(config), config);
+        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, explicitDialect, config);
     }
 
     /**
@@ -326,7 +351,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
         if (supportRecords == this.supportRecords) {
             return this;
         }
-        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, dialect, config);
+        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, explicitDialect, config);
     }
 
     /**
@@ -353,7 +378,7 @@ public final class SqlTemplateImpl implements SqlTemplate {
         if (inlineParameters == this.inlineParameters) {
             return this;
         }
-        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, dialect, config);
+        return new SqlTemplateImpl(positionalOnly, expandCollection, supportRecords, inlineParameters, modelBuilder, tableAliasResolver, explicitDialect, config);
     }
 
     /**
@@ -408,6 +433,8 @@ public final class SqlTemplateImpl implements SqlTemplate {
         TemplateProcessor processor;
         try {
             try (var request = templateMetrics.startRequest()) {
+                var templatePreparation = this.templatePreparation.get();
+                var cache = this.cache == null ? null : this.cache.get();
                 bindingContext = templatePreparation.preprocess(template);
                 compilationKey = cache == null ? null : getCompilationKey(bindingContext);
                 processor = compilationKey == null ? null : cache.get(compilationKey);

--- a/storm-core/src/test/java/st/orm/core/spi/SqlDialectProviderResolutionTest.java
+++ b/storm-core/src/test/java/st/orm/core/spi/SqlDialectProviderResolutionTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.spi;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Collections.enumeration;
+import static java.util.stream.Collectors.joining;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.Nonnull;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import st.orm.PersistenceException;
+import st.orm.StormConfig;
+import st.orm.core.template.SqlDialect;
+import st.orm.core.template.SqlTemplate;
+
+/**
+ * Tests for the fail-fast classpath resolution of the SQL dialect.
+ */
+public class SqlDialectProviderResolutionTest {
+
+    @TempDir
+    Path tempDir;
+
+    /** Dialect provider without ordering constraints; an unordered peer of {@link UnorderedProviderB}. */
+    public static class UnorderedProviderA implements SqlDialectProvider {
+        @Override
+        public SqlDialect getSqlDialect(@Nonnull StormConfig config) {
+            return new DefaultSqlDialect(config);
+        }
+    }
+
+    /** Dialect provider without ordering constraints; an unordered peer of {@link UnorderedProviderA}. */
+    public static class UnorderedProviderB implements SqlDialectProvider {
+        @Override
+        public SqlDialect getSqlDialect(@Nonnull StormConfig config) {
+            return new DefaultSqlDialect(config);
+        }
+    }
+
+    /** Class loader that substitutes the {@link SqlDialectProvider} service registrations. */
+    private static final class ServiceSubstitutingClassLoader extends ClassLoader {
+
+        private static final String SERVICE_RESOURCE = "META-INF/services/" + SqlDialectProvider.class.getName();
+
+        private final URL services;
+
+        ServiceSubstitutingClassLoader(@Nonnull ClassLoader parent, @Nonnull URL services) {
+            super(parent);
+            this.services = services;
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (SERVICE_RESOURCE.equals(name)) {
+                return enumeration(List.of(services));
+            }
+            return super.getResources(name);
+        }
+    }
+
+    private void withDialectProviders(@Nonnull List<Class<?>> providers, @Nonnull Runnable runnable) {
+        URL services;
+        try {
+            Path file = tempDir.resolve("dialect-providers");
+            Files.writeString(file, providers.stream().map(Class::getName).collect(joining("\n")));
+            services = file.toUri().toURL();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        Thread thread = currentThread();
+        ClassLoader original = thread.getContextClassLoader();
+        thread.setContextClassLoader(new ServiceSubstitutingClassLoader(getClass().getClassLoader(), services));
+        try {
+            runnable.run();
+        } finally {
+            thread.setContextClassLoader(original);
+        }
+    }
+
+    @Test
+    public void testUnorderedPeersFailFast() {
+        withDialectProviders(List.of(UnorderedProviderA.class, UnorderedProviderB.class), () -> {
+            var exception = assertThrows(PersistenceException.class,
+                    () -> Providers.getSqlDialect(StormConfig.defaults()));
+            assertTrue(exception.getMessage().contains(UnorderedProviderA.class.getName()),
+                    "Error must name the candidate providers");
+            assertTrue(exception.getMessage().contains(UnorderedProviderB.class.getName()),
+                    "Error must name the candidate providers");
+        });
+    }
+
+    @Test
+    public void testSingleProviderResolves() {
+        withDialectProviders(List.of(DefaultSqlDialectProviderImpl.class), () ->
+                assertEquals(new DefaultSqlDialect(StormConfig.defaults()).name(),
+                        Providers.getSqlDialect(StormConfig.defaults()).name()));
+    }
+
+    @Test
+    public void testOrderedProvidersResolveUnique() {
+        withDialectProviders(List.of(FetchSizeSqlDialectProviderImpl.class, DefaultSqlDialectProviderImpl.class), () ->
+                assertEquals("FetchSizeTest", Providers.getSqlDialect(StormConfig.defaults()).name(),
+                        "The provider ordered before any other must win without an ambiguity error"));
+    }
+
+    @Test
+    public void testAmbientDialectResolutionIsLazy() {
+        withDialectProviders(List.of(UnorderedProviderA.class, UnorderedProviderB.class), () -> {
+            // Deriving a template from the shared ambient instance must not resolve the dialect: database-bound
+            // templates derive and then set the dialect resolved for their database.
+            SqlTemplate template = SqlTemplate.PS.withConfig(StormConfig.of(Map.of()));
+            SqlDialect dialect = new DefaultSqlDialect();
+            assertSame(dialect, template.withDialect(dialect).dialect(),
+                    "An explicitly set dialect must not trigger classpath resolution");
+            assertThrows(PersistenceException.class, template::dialect,
+                    "Using the ambient dialect on an ambiguous classpath must fail fast");
+        });
+    }
+}

--- a/storm-core/src/test/java/st/orm/core/template/impl/SqlTemplateImplTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/SqlTemplateImplTest.java
@@ -6,11 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static st.orm.StormConfig.ANSI_ESCAPING;
 import static st.orm.core.template.TemplateString.raw;
 
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import st.orm.StormConfig;
+import st.orm.core.spi.DefaultSqlDialect;
 import st.orm.core.template.Sql;
+import st.orm.core.template.SqlDialect;
 import st.orm.core.template.SqlTemplate;
 import st.orm.core.template.SqlTemplateException;
 import st.orm.core.template.TableAliasResolver;
@@ -119,6 +123,44 @@ public class SqlTemplateImplTest {
         SqlTemplate result = template.withConfig(st.orm.StormConfig.defaults());
         // The defaults singleton comparison; if same instance, returns this.
         assertNotNull(result);
+    }
+
+    @Test
+    public void testWithConfigRetainsExplicitDialect() {
+        SqlDialect dialect = new DefaultSqlDialect();
+        SqlTemplate template = SqlTemplate.PS.withDialect(dialect)
+                .withConfig(StormConfig.of(Map.of(ANSI_ESCAPING, "true")));
+        assertSame(dialect, template.dialect(), "Explicitly set dialect must survive withConfig");
+    }
+
+    @Test
+    public void testWithConfigAppliesConfigToClasspathResolvedDialect() {
+        assertEquals("\"name\"",
+                SqlTemplate.PS.withConfig(StormConfig.of(Map.of(ANSI_ESCAPING, "true"))).dialect().escape("name"),
+                "Classpath-resolved dialect must be re-resolved under the new configuration");
+        assertEquals("name",
+                SqlTemplate.PS.withConfig(StormConfig.of(Map.of(ANSI_ESCAPING, "false"))).dialect().escape("name"),
+                "Classpath-resolved dialect must be re-resolved under the new configuration");
+    }
+
+    @Test
+    public void testWithResolversRetainExplicitDialect() {
+        SqlDialect dialect = new DefaultSqlDialect();
+        SqlTemplate template = SqlTemplate.PS.withDialect(dialect)
+                .withTableNameResolver(type -> "prefix_" + type.type().getSimpleName())
+                .withTableAliasResolver((type, counter) -> "alias");
+        assertSame(dialect, template.dialect(), "Explicitly set dialect must survive resolver customization");
+    }
+
+    @Test
+    public void testWithResolversRetainClasspathResolution() {
+        SqlTemplate template = SqlTemplate.PS.withTableNameResolver(type -> "prefix_" + type.type().getSimpleName());
+        assertEquals("\"name\"",
+                template.withConfig(StormConfig.of(Map.of(ANSI_ESCAPING, "true"))).dialect().escape("name"),
+                "Resolver customization must not pin the classpath-resolved dialect");
+        assertEquals("name",
+                template.withConfig(StormConfig.of(Map.of(ANSI_ESCAPING, "false"))).dialect().escape("name"),
+                "Resolver customization must not pin the classpath-resolved dialect");
     }
 
     // positionalOnly and expandCollection


### PR DESCRIPTION
Fixes #404.

## Problem

Two related resolution defects:

1. `SqlTemplateImpl.withConfig` re-resolved the dialect from the classpath, so `SqlTemplate.PS.withDialect(x).withConfig(c)` silently lost `x`.
2. `Providers.getSqlDialect(StormConfig)` picked the first enabled dialect provider with no ambiguity guard, unlike the unique selection used for connection and transaction providers, so the winner on a classpath with several dialect modules depended on classpath order.

## Changes

**`Providers.getSqlDialect(StormConfig)`** now routes through the same `selectUnique` path as the connection and transaction providers: an ambiguous resolution throws a `PersistenceException` naming the candidates, with `withDialect(...)` or database binding as the remedy. Ordered classpaths resolve exactly as before: `DefaultSqlDialectProviderImpl` is `@AfterAny` and MariaDB is `@Before(MySQL)`, so the default provider plus a single dialect module still resolves uniquely to the module's dialect.

**`SqlTemplateImpl`** tracks the explicitly set dialect separately from the resolved one. `withConfig` retains an explicit dialect and re-resolves a classpath-resolved one under the new configuration (dialects capture their configuration at construction). The other `with*` methods pass the explicit dialect through, so derived templates keep their resolution mode.

**Ambient resolution is lazy.** `SqlTemplate.PS`/`JPA` resolved a dialect in their static initializers, and every database-bound template derives from them via `withConfig(...)` before applying the dialect resolved for its database. With an eager fail-fast guard, class initialization would have failed on multi-dialect classpaths that are perfectly valid under the per-database resolution rules of #359. The dialect, the dialect-keyed template cache, and the template preparation are now initialized on first use, so the ambiguity error surfaces only when an ambient dialect is actually used, at query time, consistent with #359.

**`JpaTemplateImpl`** defers its classpath fallback the same way: it previously resolved in the constructor, which would have made the `withProviderFilter(...)` remedy unreachable on an ambiguous classpath. The fallback dialect and the derived `SqlTemplate` are now lazy; the data-source path still resolves by database product at construction.

## Tests

- `SqlDialectProviderResolutionTest` (new): unordered peers fail fast naming both candidates; single and ordered provider sets resolve; ambient resolution is lazy (an explicit dialect works on an ambiguous classpath while `dialect()` on an ambient template fails fast). Uses a context class loader that substitutes the dialect service registrations.
- `SqlTemplateImplTest`: explicit dialect survives `withConfig` and resolver customization; classpath-resolved dialects are re-resolved under the new configuration, asserted in both ANSI escaping directions since the surefire run sets `-Dstorm.ansi_escaping=true`.

Full reactor green (30 modules, zero failures).