### PR TITLE
chore: suppress module-not-found warnings for storm-core qualified exports

### DIFF
--- a/storm-core/src/main/java/module-info.java
+++ b/storm-core/src/main/java/module-info.java
@@ -1,3 +1,6 @@
+// The qualified exports below target sibling modules that depend on storm-core, so they are never
+// observable while storm-core itself compiles; suppress the resulting "module not found" warnings.
+@SuppressWarnings("module")
 module storm.core {
     uses st.orm.core.spi.ORMReflectionProvider;
     uses st.orm.core.spi.ORMConverterProvider;


### PR DESCRIPTION
Building storm-core prints a wall of `[WARNING] module not found: storm.h2` (and 20 more) because its impl packages are exported to Storm's sibling modules only. Those siblings depend on storm-core, so none of them are observable while storm-core itself compiles, and javac warns for every qualified-export target it cannot see. The exports themselves work as intended: targets are resolved lazily, so the siblings get access once they compile with storm-core on their module path.

This annotates the module declaration with `@SuppressWarnings("module")`, which suppresses exactly this lint category for exactly this descriptor. No compiler flags change, so any other module-related warnings elsewhere still surface.

storm-kotlin is the only other module with a qualified export (`st.orm.template.impl to kotlin.reflect`), but it also `requires kotlin.reflect`, so that target is observable and never warned.

Verified with a clean `mvn compile` of storm-core: the warnings are gone.