### PR TITLE
fix: isolate StormExtension databases per test class

### DIFF
--- a/storm-test/pom.xml
+++ b/storm-test/pom.xml
@@ -72,5 +72,10 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-testkit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/storm-test/src/main/java/st/orm/test/StormExtension.java
+++ b/storm-test/src/main/java/st/orm/test/StormExtension.java
@@ -65,19 +65,27 @@ public class StormExtension implements BeforeAllCallback, ParameterResolver {
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        StormTest annotation = context.getRequiredTestClass().getAnnotation(StormTest.class);
+        Class<?> testClass = context.getRequiredTestClass();
+        StormTest annotation = testClass.getAnnotation(StormTest.class);
         if (annotation == null) {
             return;
         }
-        DataSource dataSource = findDataSourceFactory(context.getRequiredTestClass());
+        DataSource dataSource = findDataSourceFactory(testClass);
         if (dataSource == null) {
-            String url = annotation.url().isEmpty()
-                    ? "jdbc:h2:mem:" + context.getRequiredTestClass().getSimpleName() + ";DB_CLOSE_DELAY=-1"
-                    : annotation.url();
-            dataSource = new SimpleDataSource(url, annotation.username(), annotation.password());
+            if (annotation.url().isEmpty()) {
+                // The nanoTime suffix keeps equally named test classes in different packages, and repeated runs of
+                // the same class within one JVM, from sharing a database.
+                String url = "jdbc:h2:mem:" + testClass.getSimpleName() + "-" + System.nanoTime()
+                        + ";DB_CLOSE_DELAY=-1";
+                dataSource = new SimpleDataSource(url, annotation.username(), annotation.password());
+                // DB_CLOSE_DELAY=-1 keeps the database alive for the JVM lifetime; shut it down when the class-level
+                // store closes. Only the database created here is shut down, never a user-provided one.
+                getStore(context).put(DatabaseShutdown.class, new DatabaseShutdown(dataSource));
+            } else {
+                dataSource = new SimpleDataSource(annotation.url(), annotation.username(), annotation.password());
+            }
         }
         if (annotation.scripts().length > 0) {
-            Class<?> testClass = context.getRequiredTestClass();
             try (Connection conn = dataSource.getConnection()) {
                 for (String script : annotation.scripts()) {
                     String sql = readScript(testClass, script);
@@ -124,26 +132,37 @@ public class StormExtension implements BeforeAllCallback, ParameterResolver {
         return getStore(context).get(DataSource.class, DataSource.class);
     }
 
+    /**
+     * Returns the store for the given context. In {@link #beforeAll} the context is the class-level context, so the
+     * {@link DataSource} is stored per test class; concurrently executing test classes never see each other's entry.
+     * Lookups from method-level contexts fall back to ancestor stores, which also makes the entry visible to
+     * {@code @Nested} test classes.
+     */
     private ExtensionContext.Store getStore(ExtensionContext context) {
-        return context.getRoot().getStore(NAMESPACE);
+        return context.getStore(NAMESPACE);
     }
 
     /**
-     * Looks for a static {@code dataSource()} method on the test class. If found, invokes it and returns the result.
-     * This also checks for a Kotlin companion object with a {@code dataSource()} method.
+     * Looks for a static {@code dataSource()} method on the test class or one of its superclasses. If found, invokes
+     * it and returns the result. This also checks for a Kotlin companion object with a {@code dataSource()} method.
+     *
+     * <p>Superclasses are searched because {@link StormTest} is {@code @Inherited}: the annotation and the factory
+     * method may both live on an abstract base class while the extension runs for the concrete subclass.</p>
      *
      * @return the {@link DataSource} returned by the factory method, or {@code null} if no such method exists.
      */
     private static DataSource findDataSourceFactory(Class<?> testClass) throws Exception {
-        // Check for a Java static method.
-        try {
-            Method method = testClass.getDeclaredMethod("dataSource");
-            if (Modifier.isStatic(method.getModifiers())
-                    && DataSource.class.isAssignableFrom(method.getReturnType())) {
-                method.setAccessible(true);
-                return (DataSource) method.invoke(null);
+        // Check for a Java static method, nearest declaration first.
+        for (Class<?> type = testClass; type != null && type != Object.class; type = type.getSuperclass()) {
+            try {
+                Method method = type.getDeclaredMethod("dataSource");
+                if (Modifier.isStatic(method.getModifiers())
+                        && DataSource.class.isAssignableFrom(method.getReturnType())) {
+                    method.setAccessible(true);
+                    return (DataSource) method.invoke(null);
+                }
+            } catch (NoSuchMethodException ignored) {
             }
-        } catch (NoSuchMethodException ignored) {
         }
         // Check for a Kotlin companion object with a dataSource() method.
         try {
@@ -291,6 +310,25 @@ public class StormExtension implements BeforeAllCallback, ParameterResolver {
             statements.add(current.toString().trim());
         }
         return statements;
+    }
+
+    /**
+     * Shuts down the extension-created H2 database when the class-level store closes, releasing the memory that
+     * {@code DB_CLOSE_DELAY=-1} would otherwise hold onto for the remainder of the JVM lifetime.
+     *
+     * <p>Implements both {@link ExtensionContext.Store.CloseableResource} and {@link AutoCloseable} so the store
+     * invokes it on JUnit 5 as well as on JUnit 6, where {@code CloseableResource} is no longer supported.</p>
+     */
+    private record DatabaseShutdown(DataSource dataSource)
+            implements ExtensionContext.Store.CloseableResource, AutoCloseable {
+
+        @Override
+        public void close() throws SQLException {
+            try (Connection conn = dataSource.getConnection();
+                 var stmt = conn.createStatement()) {
+                stmt.execute("SHUTDOWN");
+            }
+        }
     }
 
     // --- Simple DataSource implementation ---

--- a/storm-test/src/main/java/st/orm/test/StormTest.java
+++ b/storm-test/src/main/java/st/orm/test/StormTest.java
@@ -16,6 +16,7 @@
 package st.orm.test;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -41,10 +42,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * }
  * }</pre>
  *
+ * <p>The annotation is {@code @Inherited}: it may be placed on an abstract base class and applies to every concrete
+ * subclass, each of which gets its own database.</p>
+ *
  * @since 1.9
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 @ExtendWith(StormExtension.class)
 public @interface StormTest {
 

--- a/storm-test/src/test/java/st/orm/test/SimpleTestDataSource.java
+++ b/storm-test/src/test/java/st/orm/test/SimpleTestDataSource.java
@@ -1,0 +1,54 @@
+package st.orm.test;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
+/**
+ * Minimal DataSource implementation for testing.
+ */
+record SimpleTestDataSource(String url, String username, String password) implements DataSource {
+
+    @Override
+    public java.sql.Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(url, username, password);
+    }
+
+    @Override
+    public java.sql.Connection getConnection(String username, String password) throws SQLException {
+        return DriverManager.getConnection(url, username, password);
+    }
+
+    @Override
+    public java.io.PrintWriter getLogWriter() {
+        return null;
+    }
+
+    @Override
+    public void setLogWriter(java.io.PrintWriter out) {
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) {
+    }
+
+    @Override
+    public int getLoginTimeout() {
+        return 0;
+    }
+
+    @Override
+    public java.util.logging.Logger getParentLogger() {
+        return null;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) {
+        return null;
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) {
+        return false;
+    }
+}

--- a/storm-test/src/test/java/st/orm/test/StormExtensionDataSourceFactoryTest.java
+++ b/storm-test/src/test/java/st/orm/test/StormExtensionDataSourceFactoryTest.java
@@ -3,8 +3,6 @@ package st.orm.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.sql.DriverManager;
-import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import st.orm.Entity;
@@ -40,54 +38,5 @@ class StormExtensionDataSourceFactoryTest {
     void scriptsShouldExecuteAgainstFactoryDataSource(ORMTemplate orm) {
         var items = orm.entity(Item.class).findAll();
         assertEquals(3, items.size());
-    }
-
-    /**
-     * Minimal DataSource implementation for testing.
-     */
-    private record SimpleTestDataSource(String url, String username, String password) implements DataSource {
-
-        @Override
-        public java.sql.Connection getConnection() throws SQLException {
-            return DriverManager.getConnection(url, username, password);
-        }
-
-        @Override
-        public java.sql.Connection getConnection(String username, String password) throws SQLException {
-            return DriverManager.getConnection(url, username, password);
-        }
-
-        @Override
-        public java.io.PrintWriter getLogWriter() {
-            return null;
-        }
-
-        @Override
-        public void setLogWriter(java.io.PrintWriter out) {
-        }
-
-        @Override
-        public void setLoginTimeout(int seconds) {
-        }
-
-        @Override
-        public int getLoginTimeout() {
-            return 0;
-        }
-
-        @Override
-        public java.util.logging.Logger getParentLogger() {
-            return null;
-        }
-
-        @Override
-        public <T> T unwrap(Class<T> iface) {
-            return null;
-        }
-
-        @Override
-        public boolean isWrapperFor(Class<?> iface) {
-            return false;
-        }
     }
 }

--- a/storm-test/src/test/java/st/orm/test/StormExtensionDatabaseLifecycleTest.java
+++ b/storm-test/src/test/java/st/orm/test/StormExtensionDatabaseLifecycleTest.java
@@ -1,0 +1,67 @@
+package st.orm.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+/**
+ * Verifies the lifecycle of the extension-created default H2 database: every execution of a test class gets a
+ * database of its own, so equally named test classes in different packages never share one, and the database is shut
+ * down once the test class completes.
+ */
+class StormExtensionDatabaseLifecycleTest {
+
+    static final List<String> capturedUrls = new ArrayList<>();
+
+    @Test
+    void eachClassExecutionShouldGetItsOwnDatabase() {
+        capturedUrls.clear();
+        runCapturingCase();
+        runCapturingCase();
+        assertEquals(2, capturedUrls.size());
+        assertTrue(capturedUrls.getFirst().contains("CapturingCase"),
+                "Expected the database name to start with the test class name but got: " + capturedUrls.getFirst());
+        assertNotEquals(capturedUrls.get(0), capturedUrls.get(1),
+                "Two executions of an equally named test class must not share a database.");
+    }
+
+    @Test
+    void defaultDatabaseShouldBeShutDownAfterClassCompletes() {
+        capturedUrls.clear();
+        runCapturingCase();
+        String url = capturedUrls.getFirst();
+        String databaseName = url.substring("jdbc:h2:mem:".length()).split(";")[0];
+        assertThrows(SQLException.class,
+                () -> DriverManager.getConnection("jdbc:h2:mem:" + databaseName + ";IFEXISTS=TRUE", "sa", ""),
+                "Expected the database to be shut down after the test class completed.");
+    }
+
+    private static void runCapturingCase() {
+        EngineTestKit.engine("junit-jupiter")
+                .selectors(selectClass(CapturingCase.class))
+                .execute()
+                .testEvents()
+                .assertStatistics(stats -> stats.succeeded(1));
+    }
+
+    @StormTest
+    static class CapturingCase {
+
+        @Test
+        void captureUrl(DataSource dataSource) throws Exception {
+            try (var conn = dataSource.getConnection()) {
+                capturedUrls.add(conn.getMetaData().getURL());
+            }
+        }
+    }
+}

--- a/storm-test/src/test/java/st/orm/test/StormExtensionInheritedBase.java
+++ b/storm-test/src/test/java/st/orm/test/StormExtensionInheritedBase.java
@@ -1,0 +1,17 @@
+package st.orm.test;
+
+import javax.sql.DataSource;
+
+/**
+ * Abstract base for {@link StormExtensionInheritedTest}: carries the {@link StormTest} annotation and the
+ * {@code dataSource()} factory that the concrete subclass must pick up.
+ */
+@StormTest(scripts = {"/test-schema.sql", "/test-data.sql"})
+abstract class StormExtensionInheritedBase {
+
+    static final String INHERITED_DB_NAME = "inherited_base_test";
+
+    static DataSource dataSource() {
+        return new SimpleTestDataSource("jdbc:h2:mem:" + INHERITED_DB_NAME + ";DB_CLOSE_DELAY=-1", "sa", "");
+    }
+}

--- a/storm-test/src/test/java/st/orm/test/StormExtensionInheritedTest.java
+++ b/storm-test/src/test/java/st/orm/test/StormExtensionInheritedTest.java
@@ -1,0 +1,34 @@
+package st.orm.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import st.orm.Entity;
+import st.orm.PK;
+import st.orm.core.template.ORMTemplate;
+
+/**
+ * Verifies that {@link StormTest} on an abstract base class applies to concrete subclasses: the extension finds the
+ * inherited annotation, executes its scripts, and uses the {@code dataSource()} factory declared on the base.
+ */
+class StormExtensionInheritedTest extends StormExtensionInheritedBase {
+
+    record Item(@PK Integer id, String name) implements Entity<Integer> {}
+
+    @Test
+    void inheritedFactoryShouldProvideDataSource(DataSource dataSource) throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            var url = conn.getMetaData().getURL();
+            assertTrue(url.contains(INHERITED_DB_NAME),
+                    "Expected connection URL to contain '" + INHERITED_DB_NAME + "' but got: " + url);
+        }
+    }
+
+    @Test
+    void scriptsShouldExecuteForInheritedAnnotation(ORMTemplate orm) {
+        var items = orm.entity(Item.class).findAll();
+        assertEquals(3, items.size());
+    }
+}

--- a/storm-test/src/test/java/st/orm/test/StormExtensionParallelIsolationTest.java
+++ b/storm-test/src/test/java/st/orm/test/StormExtensionParallelIsolationTest.java
@@ -1,0 +1,80 @@
+package st.orm.test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+import java.util.concurrent.CountDownLatch;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+/**
+ * Verifies that concurrently executing test classes each see their own {@link DataSource}. The extension stores the
+ * {@link DataSource} in the class-level store; a root-level store would let one class's {@code beforeAll} overwrite
+ * the entry while another class's tests are still running.
+ */
+class StormExtensionParallelIsolationTest {
+
+    /**
+     * Latched so that both classes' {@code beforeAll} callbacks have stored their {@link DataSource} before either
+     * class runs a test; without it, the overwrite this test guards against would depend on scheduling.
+     */
+    static CountDownLatch bothClassesStarted;
+
+    @Test
+    void concurrentTestClassesShouldEachSeeTheirOwnDataSource() {
+        bothClassesStarted = new CountDownLatch(2);
+        EngineTestKit.engine("junit-jupiter")
+                .selectors(selectClass(AlphaCase.class), selectClass(BetaCase.class))
+                .configurationParameter("junit.jupiter.execution.parallel.enabled", "true")
+                .configurationParameter("junit.jupiter.execution.parallel.mode.default", "same_thread")
+                .configurationParameter("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
+                .configurationParameter("junit.jupiter.execution.parallel.config.strategy", "fixed")
+                .configurationParameter("junit.jupiter.execution.parallel.config.fixed.parallelism", "2")
+                .execute()
+                .testEvents()
+                .assertStatistics(stats -> stats.started(2).succeeded(2));
+    }
+
+    static void awaitOtherClass() throws InterruptedException {
+        bothClassesStarted.countDown();
+        assertTrue(bothClassesStarted.await(30, SECONDS), "Expected both test classes to start concurrently.");
+    }
+
+    static void assertDatabaseName(DataSource dataSource, String name) throws Exception {
+        try (var conn = dataSource.getConnection()) {
+            var url = conn.getMetaData().getURL();
+            assertTrue(url.contains(name), "Expected connection URL to contain '" + name + "' but got: " + url);
+        }
+    }
+
+    @StormTest
+    static class AlphaCase {
+
+        @BeforeAll
+        static void awaitBetaCase() throws InterruptedException {
+            awaitOtherClass();
+        }
+
+        @Test
+        void dataSourceShouldBelongToThisClass(DataSource dataSource) throws Exception {
+            assertDatabaseName(dataSource, "AlphaCase");
+        }
+    }
+
+    @StormTest
+    static class BetaCase {
+
+        @BeforeAll
+        static void awaitAlphaCase() throws InterruptedException {
+            awaitOtherClass();
+        }
+
+        @Test
+        void dataSourceShouldBelongToThisClass(DataSource dataSource) throws Exception {
+            assertDatabaseName(dataSource, "BetaCase");
+        }
+    }
+}

--- a/storm-test/src/test/java/st/orm/test/StormExtensionTest.java
+++ b/storm-test/src/test/java/st/orm/test/StormExtensionTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.sql.DataSource;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import st.orm.Entity;
 import st.orm.PK;
@@ -93,5 +94,19 @@ class StormExtensionTest {
         var stmt = statements.getFirst();
         assertNotNull(stmt.statement());
         assertTrue(stmt.statement().toUpperCase().contains("SELECT"));
+    }
+
+    @Nested
+    class NestedCases {
+
+        @Test
+        void dataSourceShouldBeInjectedInNestedTests(DataSource dataSource) {
+            assertNotNull(dataSource);
+        }
+
+        @Test
+        void ormTemplateShouldQueryEntitiesInNestedTests(ORMTemplate orm) {
+            assertTrue(orm.entity(Item.class).findAll().size() >= 3);
+        }
     }
 }


### PR DESCRIPTION
Fixes three latent defects in the JUnit extension (#386):

1. **Parallel-execution store collision.** The `DataSource` was stored in the root-level store, an engine-global slot: with `junit.jupiter.execution.parallel.enabled=true`, one class's `beforeAll` overwrote the entry while another class's tests were still running. The `DataSource` now lives in the class-level store. Method-level lookups fall back to ancestor stores, which also keeps the entry visible to `@Nested` test classes.

2. **Database-name collision.** The default H2 database name came from `getSimpleName()` with `DB_CLOSE_DELAY=-1` and no teardown, so equally named test classes in different packages shared one database. The name now carries a `System.nanoTime()` suffix, the same disambiguation the Ktor test support uses. The extension-created database is additionally shut down when the class-level store closes, so it no longer stays resident for the remainder of the JVM lifetime; user-provided databases (custom `url` or `dataSource()` factory) are never shut down.

3. **Abstract-base breakage.** `@ExtendWith` discovery walks superclasses but `@StormTest` was not `@Inherited`, so an annotated abstract base registered the extension on the subclass where the annotation lookup returned null and nothing was stored. `@StormTest` is now `@Inherited`, and the static `dataSource()` factory lookup searches the superclass hierarchy so a factory declared on the base is found as well (the Kotlin companion-object path already searched superclasses).

## Tests

- `StormExtensionParallelIsolationTest` runs two test classes through an embedded Jupiter engine with concurrent class execution; a latch in each class's `@BeforeAll` guarantees both stores are populated before either class asserts, making the pre-fix overwrite deterministic rather than scheduling-dependent.
- `StormExtensionDatabaseLifecycleTest` asserts that two executions of one test class get distinct databases and that the database no longer exists after the class completes.
- `StormExtensionInheritedTest` extends an abstract base that carries both the annotation and the `dataSource()` factory.
- A `@Nested` block in `StormExtensionTest` guards the ancestor-store fallback.

Each new test was verified to fail against the pre-fix implementation. Adds `junit-platform-testkit` (test scope, version managed by the imported Spring Boot BOM).

Fixes #386