### PR TITLE
fix: discover MariaDB sequences during schema validation

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/SqlDialect.java
+++ b/storm-core/src/main/java/st/orm/core/template/SqlDialect.java
@@ -439,6 +439,8 @@ public interface SqlDialect {
     enum SequenceDiscoveryStrategy {
         /** Use {@code INFORMATION_SCHEMA.SEQUENCES}. */
         INFORMATION_SCHEMA,
+        /** Use {@code INFORMATION_SCHEMA.TABLES} rows with {@code TABLE_TYPE = 'SEQUENCE'}. */
+        INFORMATION_SCHEMA_TABLES,
         /** Use {@code ALL_SEQUENCES} dictionary view. */
         ALL_SEQUENCES,
         /** Sequences are not discoverable; skip sequence validation. */

--- a/storm-core/src/main/java/st/orm/core/template/impl/DatabaseSchema.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/DatabaseSchema.java
@@ -138,6 +138,7 @@ public final class DatabaseSchema {
     private final SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable;
     private final SortedMap<String, List<DbForeignKey>> foreignKeysByTable;
     private final SortedMap<String, Boolean> sequences;
+    private final boolean sequencesDiscovered;
     private final Map<ConstraintKind, SortedSet<String>> discoveredByKind;
 
     private DatabaseSchema(
@@ -146,6 +147,7 @@ public final class DatabaseSchema {
             @Nonnull SortedMap<String, List<DbUniqueKey>> uniqueKeysByTable,
             @Nonnull SortedMap<String, List<DbForeignKey>> foreignKeysByTable,
             @Nonnull SortedMap<String, Boolean> sequences,
+            boolean sequencesDiscovered,
             @Nonnull Map<ConstraintKind, SortedSet<String>> discoveredByKind
     ) {
         this.columnsByTable = columnsByTable;
@@ -153,6 +155,7 @@ public final class DatabaseSchema {
         this.uniqueKeysByTable = uniqueKeysByTable;
         this.foreignKeysByTable = foreignKeysByTable;
         this.sequences = sequences;
+        this.sequencesDiscovered = sequencesDiscovered;
         this.discoveredByKind = discoveredByKind;
     }
 
@@ -268,9 +271,9 @@ public final class DatabaseSchema {
                 primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, constraintDiscoveryStrategy,
                 discoveredByKind);
         // Discover sequences using the dialect-provided strategy.
-        readSequences(connection, catalog, schemaPattern, sequences, sequenceDiscoveryStrategy);
+        boolean sequencesDiscovered = readSequences(connection, catalog, schemaPattern, sequences, sequenceDiscoveryStrategy);
         return new DatabaseSchema(columnsByTable, primaryKeysByTable, uniqueKeysByTable, foreignKeysByTable, sequences,
-                discoveredByKind);
+                sequencesDiscovered, discoveredByKind);
     }
 
     // ------------------------------------------------------------------------------------------------------------------
@@ -679,26 +682,28 @@ public final class DatabaseSchema {
     /**
      * Reads sequences using the specified discovery strategy.
      *
-     * <p>If the selected strategy fails, sequence validation is silently skipped.</p>
+     * @return {@code true} if sequences were actually read, {@code false} if the strategy is
+     *         {@link SequenceDiscoveryStrategy#NONE} or the read failed, leaving the sequences unknown.
      */
-    private static void readSequences(
+    private static boolean readSequences(
             @Nonnull Connection connection,
             @Nullable String catalog,
             @Nullable String schemaPattern,
             @Nonnull SortedMap<String, Boolean> sequences,
             @Nonnull SequenceDiscoveryStrategy strategy
     ) {
-        switch (strategy) {
+        return switch (strategy) {
             case INFORMATION_SCHEMA -> readSequencesFromInformationSchema(connection, catalog, schemaPattern, sequences);
+            case INFORMATION_SCHEMA_TABLES -> readSequencesFromInformationSchemaTables(connection, catalog, schemaPattern, sequences);
             case ALL_SEQUENCES -> readSequencesFromAllSequences(connection, schemaPattern, sequences);
-            case NONE -> { }
-        }
+            case NONE -> false;
+        };
     }
 
     /**
      * Attempts to read sequences from INFORMATION_SCHEMA.SEQUENCES.
      */
-    private static void readSequencesFromInformationSchema(
+    private static boolean readSequencesFromInformationSchema(
             @Nonnull Connection connection,
             @Nullable String catalog,
             @Nullable String schemaPattern,
@@ -715,15 +720,51 @@ public final class DatabaseSchema {
                     sequences.put(resultSet.getString("SEQUENCE_NAME"), Boolean.TRUE);
                 }
             }
+            return true;
         } catch (SQLException ignored) {
             // INFORMATION_SCHEMA.SEQUENCES not available; sequence validation will be skipped.
+            return false;
+        }
+    }
+
+    /**
+     * Attempts to read sequences from INFORMATION_SCHEMA.TABLES rows with TABLE_TYPE = 'SEQUENCE'.
+     *
+     * <p>MariaDB exposes sequences as a table type rather than through a dedicated view. The
+     * {@code INFORMATION_SCHEMA.SEQUENCES} view only exists since MariaDB 11.5 and keys
+     * {@code SEQUENCE_CATALOG} to {@code 'def'}, so the {@code TABLES} view is the only source that works across
+     * all versions that support sequences.</p>
+     */
+    private static boolean readSequencesFromInformationSchemaTables(
+            @Nonnull Connection connection,
+            @Nullable String catalog,
+            @Nullable String schemaPattern,
+            @Nonnull SortedMap<String, Boolean> sequences
+    ) {
+        // For databases that use catalogs as schemas, the catalog value represents the database name and maps to
+        // TABLE_SCHEMA in INFORMATION_SCHEMA views (not TABLE_CATALOG).
+        String effectiveSchema = schemaPattern != null ? schemaPattern : catalog;
+        try {
+            StringBuilder sql = new StringBuilder("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'SEQUENCE'");
+            List<String> parameters = new ArrayList<>();
+            appendFilter(sql, true, "TABLE_SCHEMA", effectiveSchema, parameters);
+            try (var statement = prepareSchemaQuery(connection, sql.toString(), parameters);
+                 var resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    sequences.put(resultSet.getString("TABLE_NAME"), Boolean.TRUE);
+                }
+            }
+            return true;
+        } catch (SQLException ignored) {
+            // INFORMATION_SCHEMA.TABLES not available; sequence validation will be skipped.
+            return false;
         }
     }
 
     /**
      * Attempts to read sequences from Oracle's ALL_SEQUENCES dictionary view.
      */
-    private static void readSequencesFromAllSequences(
+    private static boolean readSequencesFromAllSequences(
             @Nonnull Connection connection,
             @Nullable String schemaPattern,
             @Nonnull SortedMap<String, Boolean> sequences
@@ -738,8 +779,10 @@ public final class DatabaseSchema {
                     sequences.put(resultSet.getString("SEQUENCE_NAME"), Boolean.TRUE);
                 }
             }
+            return true;
         } catch (SQLException ignored) {
             // ALL_SEQUENCES not available; sequence validation will be skipped.
+            return false;
         }
     }
 
@@ -834,5 +877,19 @@ public final class DatabaseSchema {
      */
     public boolean sequenceExists(@Nonnull String sequenceName) {
         return sequences.containsKey(sequenceName);
+    }
+
+    /**
+     * Returns whether sequences were actually read from the database.
+     *
+     * <p>A discovery strategy that is {@link SequenceDiscoveryStrategy#NONE} or that fails leaves the sequence map
+     * empty, which reads exactly like a schema without sequences. Callers that would otherwise report a sequence as
+     * missing must check this first, so a database that cannot answer the query is reported as unknown rather than
+     * as wrong.</p>
+     *
+     * @return {@code true} if the read succeeded, {@code false} if the sequences are unknown.
+     */
+    public boolean sequencesDiscovered() {
+        return sequencesDiscovered;
     }
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/SchemaValidator.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SchemaValidator.java
@@ -496,17 +496,20 @@ public final class SchemaValidator {
                                 .formatted(qualifiedTableName, entityPkColumns, dbPkColumns)));
             }
         }
-        // 6. Sequence existence.
-        for (Column column : model.declaredColumns()) {
-            if (isIgnored(column, ignoredComponents)) {
-                continue;
-            }
-            if (column.generation() == GenerationStrategy.SEQUENCE) {
-                String sequenceName = column.sequence();
-                if (!sequenceName.isEmpty() && !schema.sequenceExists(sequenceName)) {
-                    errors.add(new SchemaValidationError(type, ErrorKind.SEQUENCE_NOT_FOUND,
-                            "Sequence '%s' not found in database (referenced by column '%s' in table '%s')."
-                                    .formatted(sequenceName, column.name(), qualifiedTableName)));
+        // 6. Sequence existence. Only validated when sequences were actually discovered: a dialect that cannot
+        // enumerate sequences leaves them unknown, and unknown must not be reported as missing.
+        if (schema.sequencesDiscovered()) {
+            for (Column column : model.declaredColumns()) {
+                if (isIgnored(column, ignoredComponents)) {
+                    continue;
+                }
+                if (column.generation() == GenerationStrategy.SEQUENCE) {
+                    String sequenceName = column.sequence();
+                    if (!sequenceName.isEmpty() && !schema.sequenceExists(sequenceName)) {
+                        errors.add(new SchemaValidationError(type, ErrorKind.SEQUENCE_NOT_FOUND,
+                                "Sequence '%s' not found in database (referenced by column '%s' in table '%s')."
+                                        .formatted(sequenceName, column.name(), qualifiedTableName)));
+                    }
                 }
             }
         }

--- a/storm-core/src/test/java/st/orm/core/template/impl/DatabaseSchemaTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/DatabaseSchemaTest.java
@@ -280,6 +280,7 @@ class DatabaseSchemaTest {
         try (Connection connection = getConnection()) {
             DatabaseSchema schema = DatabaseSchema.read(connection);
 
+            assertTrue(schema.sequencesDiscovered());
             assertTrue(schema.sequenceExists("test_seq"));
             assertTrue(schema.sequenceExists("TEST_SEQ")); // case-insensitive
             assertFalse(schema.sequenceExists("nonexistent_seq"));
@@ -343,6 +344,7 @@ class DatabaseSchemaTest {
                     ConstraintDiscoveryStrategy.INFORMATION_SCHEMA);
 
             // With NONE strategy, sequences should not be discovered
+            assertFalse(schema.sequencesDiscovered());
             assertFalse(schema.sequenceExists("my_seq"));
         }
     }

--- a/storm-core/src/test/java/st/orm/core/template/impl/SchemaValidatorConstraintDiscoveryTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/SchemaValidatorConstraintDiscoveryTest.java
@@ -26,21 +26,24 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import st.orm.Data;
 import st.orm.DbTable;
 import st.orm.Entity;
 import st.orm.FK;
+import st.orm.GenerationStrategy;
 import st.orm.PK;
 import st.orm.StormConfig;
 import st.orm.core.spi.DefaultSqlDialect;
 import st.orm.core.template.SqlDialect;
 import st.orm.core.template.SqlDialect.ConstraintDiscoveryStrategy;
+import st.orm.core.template.SqlDialect.SequenceDiscoveryStrategy;
 import st.orm.core.template.impl.SchemaValidationError.ErrorKind;
 
 /**
- * Tests that constraint validation reports what the database actually said, and stays silent about what it could
- * not be asked.
+ * Tests that constraint and sequence validation report what the database actually said, and stay silent about what
+ * it could not be asked.
  *
- * <p>A constraint discovery query that the database does not understand leaves the constraints unknown, which is
+ * <p>A discovery query that the database does not understand leaves the constraints or sequences unknown, which is
  * not the same as the database having none. Reporting the latter turns a dialect that does not fit the database
  * into a schema that looks broken.</p>
  */
@@ -55,6 +58,11 @@ class SchemaValidatorConstraintDiscoveryTest {
 
     @DbTable("child")
     record Child(@PK Integer id, @FK Parent parent) implements Entity<Integer> {}
+
+    @DbTable("parent")
+    record SequencedParent(
+            @PK(generation = GenerationStrategy.SEQUENCE, sequence = "missing_seq") Integer id
+    ) implements Entity<Integer> {}
 
     /**
      * The default dialect, reading constraints the way a database that does not match it would be read. This is what
@@ -73,6 +81,22 @@ class SchemaValidatorConstraintDiscoveryTest {
         }
     }
 
+    /**
+     * The default dialect with sequence discovery disabled, the way a dialect for a database that cannot enumerate
+     * its sequences reads the schema.
+     */
+    private static final class NoSequenceDiscoveryDialect extends DefaultSqlDialect {
+
+        NoSequenceDiscoveryDialect(@Nonnull StormConfig config) {
+            super(config);
+        }
+
+        @Override
+        public SequenceDiscoveryStrategy sequenceDiscoveryStrategy() {
+            return SequenceDiscoveryStrategy.NONE;
+        }
+    }
+
     @BeforeEach
     void setUp() throws SQLException {
         dataSource = new SimpleDriverDataSource(new org.h2.Driver(),
@@ -86,8 +110,12 @@ class SchemaValidatorConstraintDiscoveryTest {
     }
 
     private List<SchemaValidationError> validateWith(@Nonnull SqlDialect dialect) {
-        return SchemaValidator.of(dataSource, ModelBuilder.newInstance(), dialect)
-                .validate(List.of(Parent.class, Child.class));
+        return validateWith(dialect, List.of(Parent.class, Child.class));
+    }
+
+    private List<SchemaValidationError> validateWith(@Nonnull SqlDialect dialect,
+                                                     @Nonnull List<Class<? extends Data>> types) {
+        return SchemaValidator.of(dataSource, ModelBuilder.newInstance(), dialect).validate(types);
     }
 
     @Test
@@ -105,6 +133,26 @@ class SchemaValidatorConstraintDiscoveryTest {
         // the reader looking for a constraint that exists.
         assertTrue(errors.stream().noneMatch(error -> error.kind() == ErrorKind.FOREIGN_KEY_MISSING),
                 "Foreign keys must not be reported as missing when they could not be read, got: " + errors);
+    }
+
+    @Test
+    void sequenceIsReportedMissingWhenDiscoveryRan() {
+        List<SchemaValidationError> errors = validateWith(new DefaultSqlDialect(StormConfig.defaults()),
+                List.of(SequencedParent.class));
+
+        // The database was asked and answered: it has no such sequence.
+        assertTrue(errors.stream().anyMatch(error -> error.kind() == ErrorKind.SEQUENCE_NOT_FOUND),
+                "Expected SEQUENCE_NOT_FOUND for a sequence the database does not have, got: " + errors);
+    }
+
+    @Test
+    void sequenceIsNotReportedMissingWhenItCannotBeDiscovered() {
+        List<SchemaValidationError> errors = validateWith(new NoSequenceDiscoveryDialect(StormConfig.defaults()),
+                List.of(SequencedParent.class));
+
+        // The database was never asked; the sequences are unknown, not absent.
+        assertTrue(errors.stream().noneMatch(error -> error.kind() == ErrorKind.SEQUENCE_NOT_FOUND),
+                "Sequences must not be reported as missing when they could not be read, got: " + errors);
     }
 
     @Test

--- a/storm-mariadb/src/main/java/st/orm/spi/mariadb/MariaDBSqlDialect.java
+++ b/storm-mariadb/src/main/java/st/orm/spi/mariadb/MariaDBSqlDialect.java
@@ -118,6 +118,21 @@ public class MariaDBSqlDialect extends MySQLSqlDialect {
     }
 
     /**
+     * Returns the strategy for discovering sequences in the database schema.
+     *
+     * <p>MariaDB supports sequences (since 10.3) but exposes them as {@code INFORMATION_SCHEMA.TABLES} rows with
+     * {@code TABLE_TYPE = 'SEQUENCE'} rather than through the {@code INFORMATION_SCHEMA.SEQUENCES} view, which only
+     * exists since MariaDB 11.5.</p>
+     *
+     * @return {@link SequenceDiscoveryStrategy#INFORMATION_SCHEMA_TABLES}.
+     * @since 1.14
+     */
+    @Override
+    public SequenceDiscoveryStrategy sequenceDiscoveryStrategy() {
+        return SequenceDiscoveryStrategy.INFORMATION_SCHEMA_TABLES;
+    }
+
+    /**
      * MariaDB supports {@code INSERT ... RETURNING} (since 10.5), so batch {@code insertAndFetchIds} reads the keys
      * from a multi-row {@code VALUES ... RETURNING} result set.
      *

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBSchemaValidatorTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBSchemaValidatorTest.java
@@ -128,6 +128,13 @@ public class MariaDBSchemaValidatorTest {
     // Sequence entities
 
     @DbTable("vet")
+    public record SequenceExistsEntity(
+            @PK(generation = SEQUENCE, sequence = "pet_id_seq") Integer id,
+            String firstName,
+            String lastName
+    ) implements Entity<Integer> {}
+
+    @DbTable("vet")
     public record SequenceNotFoundEntity(
             @PK(generation = SEQUENCE, sequence = "nonexistent_seq") Integer id,
             String firstName,
@@ -189,6 +196,15 @@ public class MariaDBSchemaValidatorTest {
         assertFalse(errors.isEmpty());
         assertTrue(errors.stream().anyMatch(
                 error -> error.kind() == ErrorKind.PRIMARY_KEY_MISMATCH));
+    }
+
+    @Test
+    public void testSequenceExists() {
+        var validator = SchemaValidator.of(dataSource);
+        var errors = validator.validate(List.of(SequenceExistsEntity.class));
+        assertFalse(errors.stream().anyMatch(
+                error -> error.kind() == ErrorKind.SEQUENCE_NOT_FOUND),
+                "Expected no SEQUENCE_NOT_FOUND when pet_id_seq exists.");
     }
 
     @Test

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBSqlDialectTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBSqlDialectTest.java
@@ -125,6 +125,13 @@ class MariaDBSqlDialectTest {
         assertThrows(PersistenceException.class, () -> mysqlDialect.sequenceNextVal("test_seq"));
     }
 
+    @Test
+    void sequenceDiscoveryStrategyShouldReturnInformationSchemaTables() {
+        assertEquals(
+                st.orm.core.template.SqlDialect.SequenceDiscoveryStrategy.INFORMATION_SCHEMA_TABLES,
+                dialect.sequenceDiscoveryStrategy());
+    }
+
     // Provider filter
 
     @Test


### PR DESCRIPTION
## Problem

`MariaDBSqlDialect` overrides `sequenceNextVal` but inherits `sequenceDiscoveryStrategy() == NONE` from `MySQLSqlDialect`, so `DatabaseSchema` never reads sequences and `SchemaValidator` reported `SEQUENCE_NOT_FOUND` for every `@PK(generation = SEQUENCE)` on MariaDB, even though MariaDB has supported sequences since 10.3. The gap was masked by a test asymmetry: `MariaDBSchemaValidatorTest` had only the negative case, which passes vacuously when discovery is disabled.

## Fix

- New `SequenceDiscoveryStrategy.INFORMATION_SCHEMA_TABLES`: reads `INFORMATION_SCHEMA.TABLES` rows with `TABLE_TYPE = 'SEQUENCE'`, filtering `TABLE_SCHEMA` by the schema pattern or, for catalog-as-schema databases, the catalog — the same mapping `INFORMATION_SCHEMA_REFERENCING` uses for constraints. The `INFORMATION_SCHEMA.SEQUENCES` view is not usable on MariaDB: it only exists since 11.5 and keys `SEQUENCE_CATALOG` to `'def'` (verified against 11.7), so the existing catalog filter matches zero rows, while the 10.6/10.11/11.4 LTS lines lack the view entirely. The `TABLES` view answers on every version that has sequences.
- `MariaDBSqlDialect` overrides `sequenceDiscoveryStrategy()` accordingly.
- `DatabaseSchema` now records whether sequences were actually read (`sequencesDiscovered()`), mirroring the constraint side's `isDiscovered`: a `NONE` strategy or a failed read leaves the sequences unknown, and unknown is not reported as missing. `SchemaValidator` only checks sequence existence when discovery succeeded, which is what the `NONE` javadoc already promised.

## Behavior change

On MySQL and SQLite, a `@PK(generation = SEQUENCE)` no longer fails schema validation with a misleading "sequence not found in database"; neither database supports sequences, and `sequenceNextVal` throws a descriptive `PersistenceException` the moment such a key is used.

## Tests

- `MariaDBSchemaValidatorTest` gains the positive `testSequenceExists` matching PostgreSQL, Oracle and MSSQL; the negative case is now non-vacuous.
- `MariaDBSqlDialectTest` asserts the discovery strategy, matching the other dialect tests.
- `SchemaValidatorConstraintDiscoveryTest` covers both directions of the skip semantics: `SEQUENCE_NOT_FOUND` is reported when discovery ran and the sequence is absent, and suppressed when the dialect cannot discover sequences.
- `DatabaseSchemaTest` asserts `sequencesDiscovered()` for both the `INFORMATION_SCHEMA` and `NONE` strategies.
- Suites green: storm-core `SchemaValidator*`/`DatabaseSchema*` (122), storm-mariadb full (163, Testcontainers), storm-sqlite full (131).

Fixes #389