### PR TITLE
fix: deserialize compound primary key Ref objects

### DIFF
--- a/storm-jackson2/src/main/java/st/orm/jackson/StormModule.java
+++ b/storm-jackson2/src/main/java/st/orm/jackson/StormModule.java
@@ -158,7 +158,8 @@ public class StormModule extends SimpleModule {
      * <ul>
      *   <li>Entity (loaded): {@code {"@entity": {...}}}</li>
      *   <li>Projection (loaded): {@code {"@id": ..., "@projection": {...}}}</li>
-     *   <li>Unloaded: raw id value (e.g., {@code 42} or {@code "abc"})</li>
+     *   <li>Unloaded: raw id value (e.g., {@code 42} or {@code "abc"}), or the PK record as a plain object for
+     *       compound PKs (e.g., {@code {"vetId":1,"specialtyId":2}})</li>
      * </ul>
      */
     private static class RefSerializer extends StdSerializer<Ref<?>> implements ContextualSerializer {
@@ -219,11 +220,13 @@ public class StormModule extends SimpleModule {
     /**
      * Deserializer for Ref instances.
      *
-     * <p>Handles three input formats:
+     * <p>Handles four input formats:
      * <ul>
      *   <li>{@code {"@entity": {...}}} - Entity, uses {@code Ref.of()}</li>
      *   <li>{@code {"@id": ..., "@projection": {...}}} - Projection with id, uses {@code Ref.of()}</li>
      *   <li>Raw id value (e.g., {@code 42}) - uses RefFactory if available, otherwise {@code Ref.of()}</li>
+     *   <li>Plain object without {@code @entity}/{@code @projection} (e.g., {@code {"vetId":1,"specialtyId":2}}) -
+     *       compound PK, uses RefFactory if available, otherwise {@code Ref.of()}</li>
      * </ul>
      *
      * <p>Also supports {@code null} values (e.g. nullable elements in {@code List<Ref<T>>}).
@@ -303,6 +306,11 @@ public class StormModule extends SimpleModule {
                 JsonNode projectionNode = node.get(PROJECTION_FIELD);
                 Data projection = ctx.readTreeAsValue(projectionNode, targetType);
                 return createLoadedRefWithId(parser, targetClass, projection, id);
+            } else if (pkType != null && REFLECTION.findRecordType(pkType).isPresent()) {
+                // A plain object is the inline record of a compound PK; unloaded refs serialize compound PKs
+                // this way.
+                Object id = deserializeIdFromNode(node, ctx);
+                return createRefFromId(targetClass, id);
             } else {
                 throw JsonMappingException.from(parser, "Ref object must contain @entity or @projection field");
             }

--- a/storm-jackson2/src/test/java/st/orm/jackson/StormModuleTest.java
+++ b/storm-jackson2/src/test/java/st/orm/jackson/StormModuleTest.java
@@ -20,6 +20,8 @@ import st.orm.PK;
 import st.orm.Projection;
 import st.orm.Ref;
 import st.orm.core.spi.RefFactory;
+import st.orm.jackson.model.VetSpecialty;
+import st.orm.jackson.model.VetSpecialtyPK;
 
 public class StormModuleTest {
 
@@ -57,6 +59,8 @@ public class StormModuleTest {
     public record NoPkRefHolder(@Nullable Ref<NoPkData> data) {}
 
     public record NoPkRefListHolder(@Nonnull List<Ref<NoPkData>> data) {}
+
+    public record CompoundPkRefHolder(@Nonnull Ref<VetSpecialty> entity) {}
 
     // Tests for constructor variations.
 
@@ -342,6 +346,39 @@ public class StormModuleTest {
         String loadedJson = mapper.writeValueAsString(loadedHolder);
         ProjectionRefHolder deserializedLoaded = mapper.readValue(loadedJson, ProjectionRefHolder.class);
         assertEquals(loadedHolder, deserializedLoaded);
+    }
+
+    @Test
+    public void unloadedCompoundPkRefShouldSerializeAsPkObject() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new StormModule());
+
+        Ref<VetSpecialty> ref = Ref.of(VetSpecialty.class, new VetSpecialtyPK(1, 2));
+        String json = mapper.writeValueAsString(new CompoundPkRefHolder(ref));
+        assertEquals("{\"entity\":{\"vetId\":1,\"specialtyId\":2}}", json);
+    }
+
+    @Test
+    public void compoundPkObjectShouldDeserializeToUnloadedRef() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new StormModule());
+
+        String json = "{\"entity\":{\"vetId\":1,\"specialtyId\":2}}";
+        CompoundPkRefHolder holder = mapper.readValue(json, CompoundPkRefHolder.class);
+        assertNotNull(holder.entity());
+        assertEquals(new VetSpecialtyPK(1, 2), holder.entity().id());
+    }
+
+    @Test
+    public void compoundPkRefSerializationShouldRoundTrip() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new StormModule());
+
+        Ref<VetSpecialty> ref = Ref.of(VetSpecialty.class, new VetSpecialtyPK(3, 4));
+        CompoundPkRefHolder holder = new CompoundPkRefHolder(ref);
+        String json = mapper.writeValueAsString(holder);
+        CompoundPkRefHolder deserialized = mapper.readValue(json, CompoundPkRefHolder.class);
+        assertEquals(holder, deserialized);
     }
 
     @Test

--- a/storm-jackson3/src/main/java/st/orm/jackson/StormModule.java
+++ b/storm-jackson3/src/main/java/st/orm/jackson/StormModule.java
@@ -163,7 +163,8 @@ public class StormModule extends SimpleModule {
      * <ul>
      *   <li>Entity (loaded): {@code {"@entity": {...}}}</li>
      *   <li>Projection (loaded): {@code {"@id": ..., "@projection": {...}}}</li>
-     *   <li>Unloaded: raw id value (e.g., {@code 42} or {@code "abc"})</li>
+     *   <li>Unloaded: raw id value (e.g., {@code 42} or {@code "abc"}), or the PK record as a plain object for
+     *       compound PKs (e.g., {@code {"vetId":1,"specialtyId":2}})</li>
      * </ul>
      */
     private static class RefSerializer extends StdSerializer<Ref<?>> {
@@ -224,11 +225,13 @@ public class StormModule extends SimpleModule {
     /**
      * Deserializer for Ref instances.
      *
-     * <p>Handles three input formats:
+     * <p>Handles four input formats:
      * <ul>
      *   <li>{@code {"@entity": {...}}} - Entity, uses {@code Ref.of()}</li>
      *   <li>{@code {"@id": ..., "@projection": {...}}} - Projection with id, uses {@code Ref.of()}</li>
      *   <li>Raw id value (e.g., {@code 42}) - uses RefFactory if available, otherwise {@code Ref.of()}</li>
+     *   <li>Plain object without {@code @entity}/{@code @projection} (e.g., {@code {"vetId":1,"specialtyId":2}}) -
+     *       compound PK, uses RefFactory if available, otherwise {@code Ref.of()}</li>
      * </ul>
      *
      * <p>Also supports {@code null} values (e.g. nullable elements in {@code List<Ref<T>>}).
@@ -308,6 +311,11 @@ public class StormModule extends SimpleModule {
                 JsonNode projectionNode = node.get(PROJECTION_FIELD);
                 Data projection = ctx.readTreeAsValue(projectionNode, targetType);
                 return createLoadedRefWithId(parser, targetClass, projection, id);
+            } else if (pkType != null && REFLECTION.findRecordType(pkType).isPresent()) {
+                // A plain object is the inline record of a compound PK; unloaded refs serialize compound PKs
+                // this way.
+                Object id = deserializeIdFromNode(node, ctx);
+                return createRefFromId(targetClass, id);
             } else {
                 throw DatabindException.from(parser, "Ref object must contain @entity or @projection field");
             }

--- a/storm-jackson3/src/test/java/st/orm/jackson/StormModuleTest.java
+++ b/storm-jackson3/src/test/java/st/orm/jackson/StormModuleTest.java
@@ -12,6 +12,7 @@ import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.Test;
 import st.orm.Data;
 import st.orm.Entity;
 import st.orm.PK;
@@ -39,7 +40,7 @@ class StormModuleTest {
 
     // RefSerializer tests
 
-    @org.junit.jupiter.api.Test
+    @Test
     void serializeUnloadedEntityRefToRawId() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -49,7 +50,7 @@ class StormModuleTest {
         assertEquals("{\"entity\":42}", json);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void serializeLoadedEntityRefWithEntityWrapper() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -60,7 +61,7 @@ class StormModuleTest {
         assertEquals("{\"entity\":{\"@entity\":{\"id\":7,\"name\":\"Test\"}}}", json);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void serializeLoadedProjectionRefWithProjectionWrapper() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -73,7 +74,7 @@ class StormModuleTest {
                 json);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void serializeNullRefFieldToNull() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -85,7 +86,7 @@ class StormModuleTest {
 
     // RefDeserializer tests
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeRawIdToDetachedRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -95,7 +96,7 @@ class StormModuleTest {
         assertEquals(42, holder.entity().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeRawIdWithRefFactory() throws Exception {
         RefFactory factory = new RefFactory() {
             @SuppressWarnings({"unchecked", "rawtypes"})
@@ -118,7 +119,7 @@ class StormModuleTest {
         assertEquals(99, holder.entity().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeEntityObjectToLoadedRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -133,7 +134,7 @@ class StormModuleTest {
         assertEquals("Test", entity.name());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeProjectionObjectToLoadedRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -148,7 +149,7 @@ class StormModuleTest {
         assertEquals("Label", projection.label());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeNullRefFieldToNull() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -157,7 +158,7 @@ class StormModuleTest {
         assertNull(holder.entity());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeObjectWithoutEntityOrProjectionFieldShouldThrow() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -166,7 +167,7 @@ class StormModuleTest {
                 () -> mapper.readValue("{\"entity\":{\"unknown\":1}}", EntityHolder.class));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeStringIdToDetachedRef() throws Exception {
         // Test VALUE_STRING token path
         record StringIdEntity(@PK String id, @Nonnull String name)
@@ -180,7 +181,7 @@ class StormModuleTest {
         assertEquals("abc", holder.entity().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeListOfRefsWithNullElement() throws Exception {
         // Test List<Ref<T>> with null elements - exercises the container unwrapping + null handling
         var mapper = JsonMapper.builder()
@@ -195,7 +196,7 @@ class StormModuleTest {
         assertEquals(7, holder.entities().get(2).id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void roundTripEntityRefShouldPreserveLoadedState() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -209,7 +210,7 @@ class StormModuleTest {
         assertEquals(entity, restored.entity().fetch());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void roundTripProjectionRefShouldPreserveLoadedState() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -227,7 +228,7 @@ class StormModuleTest {
 
     public record CompoundPkRefHolder(@Nullable Ref<VetSpecialty> entity) {}
 
-    @org.junit.jupiter.api.Test
+    @Test
     void serializeUnloadedCompoundPkRefToPkObject() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -237,7 +238,7 @@ class StormModuleTest {
         assertEquals("{\"entity\":{\"vetId\":1,\"specialtyId\":2}}", json);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeCompoundPkObjectToUnloadedRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -248,7 +249,7 @@ class StormModuleTest {
         assertEquals(new VetSpecialtyPK(1, 2), holder.entity().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void roundTripCompoundPkRefShouldPreserveId() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -271,7 +272,7 @@ class StormModuleTest {
 
     public record NoPkDataProjectionHolder(@Nullable Ref<NoPkDataProjection> data) {}
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeIntIdFallbackForNoPkData() throws Exception {
         // When pkType is null (no @PK on target), the fallback deserializeId path is used.
         // This exercises the VALUE_NUMBER_INT fallback in deserializeId.
@@ -283,7 +284,7 @@ class StormModuleTest {
         assertEquals(42, ((Number) holder.data().id()).intValue());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeStringIdFallbackForNoPkData() throws Exception {
         // Exercises the VALUE_STRING fallback in deserializeId.
         var mapper = JsonMapper.builder()
@@ -294,7 +295,7 @@ class StormModuleTest {
         assertEquals("abc", holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeFloatIdFallbackForNoPkData() throws Exception {
         // Exercises the VALUE_NUMBER_FLOAT fallback in deserializeId.
         var mapper = JsonMapper.builder()
@@ -305,7 +306,7 @@ class StormModuleTest {
         assertEquals(3.14, holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeLargeIntIdFallbackForNoPkData() throws Exception {
         // Exercises the VALUE_NUMBER_INT fallback with a value > Integer.MAX_VALUE.
         var mapper = JsonMapper.builder()
@@ -317,7 +318,7 @@ class StormModuleTest {
         assertEquals(largeValue, holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeNegativeLargeIntIdFallbackForNoPkData() throws Exception {
         // Exercises the VALUE_NUMBER_INT fallback with a value < Integer.MIN_VALUE.
         // This covers the short-circuit branch when value < Integer.MIN_VALUE.
@@ -330,7 +331,7 @@ class StormModuleTest {
         assertEquals(negativeValue, holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeProjectionObjectWithIntIdNodeFallbackForNoPk() throws Exception {
         // Exercises the deserializeIdFromNode fallback path for a Projection without @PK.
         // When pkType is null, the node.isInt() path is taken.
@@ -344,7 +345,7 @@ class StormModuleTest {
         assertEquals(5, holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeProjectionObjectWithStringIdNodeFallbackForNoPk() throws Exception {
         // Exercises the deserializeIdFromNode node.isTextual() path.
         record NoPkStringProjection(String id, @Nonnull String value)
@@ -360,7 +361,7 @@ class StormModuleTest {
         assertEquals("abc", holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeProjectionObjectWithLongIdNodeFallbackForNoPk() throws Exception {
         // Exercises the deserializeIdFromNode node.isLong() path.
         record NoPkLongProjection(Long id, @Nonnull String value)
@@ -378,7 +379,7 @@ class StormModuleTest {
         assertEquals(largeValue, holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeProjectionObjectWithDoubleIdNodeFallbackForNoPk() throws Exception {
         // Exercises the deserializeIdFromNode node.isDouble() path.
         record NoPkDoubleProjection(Double id, @Nonnull String value)
@@ -394,7 +395,7 @@ class StormModuleTest {
         assertEquals(3.14, holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void constructorWithRefFactoryShouldPassThroughToSupplier() throws Exception {
         RefFactory factory = new RefFactory() {
             @SuppressWarnings({"unchecked", "rawtypes"})
@@ -446,7 +447,7 @@ class StormModuleTest {
 
     // Constructor with null RefFactory
 
-    @org.junit.jupiter.api.Test
+    @Test
     void constructorWithNullRefFactoryShouldCreateModuleWithDetachedRefs() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule((RefFactory) null))
@@ -456,7 +457,7 @@ class StormModuleTest {
         assertEquals(1, holder.entity().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void constructorWithNullSupplierResultShouldCreateDetachedRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule(() -> null))
@@ -468,7 +469,7 @@ class StormModuleTest {
 
     // Serialization for different ID types
 
-    @org.junit.jupiter.api.Test
+    @Test
     void unloadedRefWithStringIdShouldSerializeAsStringValue() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -478,7 +479,7 @@ class StormModuleTest {
         assertEquals("{\"entity\":\"abc-123\"}", json);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void unloadedRefWithLongIdShouldSerializeAsLongValue() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -490,7 +491,7 @@ class StormModuleTest {
 
     // Deserialization for different ID types
 
-    @org.junit.jupiter.api.Test
+    @Test
     void rawLongIdShouldDeserializeToUnloadedRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -502,7 +503,7 @@ class StormModuleTest {
 
     // Deserialization error paths
 
-    @org.junit.jupiter.api.Test
+    @Test
     void projectionObjectWithoutIdFieldShouldThrowException() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -511,7 +512,7 @@ class StormModuleTest {
                 () -> mapper.readValue("{\"projection\":{\"@projection\":{\"id\":5,\"label\":\"Test\"}}}", ProjectionHolder.class));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void booleanTokenShouldThrowExceptionDuringRefDeserialization() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -520,7 +521,7 @@ class StormModuleTest {
                 () -> mapper.readValue("{\"entity\":true}", EntityHolder.class));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void arrayTokenShouldThrowExceptionDuringRefDeserialization() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -531,7 +532,7 @@ class StormModuleTest {
 
     // Set and Map container types
 
-    @org.junit.jupiter.api.Test
+    @Test
     void refInSetShouldDeserializeCorrectly() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -540,7 +541,7 @@ class StormModuleTest {
         assertEquals(3, holder.entities().size());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void refInMapValueShouldDeserializeCorrectly() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -551,7 +552,7 @@ class StormModuleTest {
         assertEquals(2, holder.entities().get("b").id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void refSetSerializationShouldRoundTrip() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -566,7 +567,7 @@ class StormModuleTest {
         assertEquals(2, deserialized.entities().size());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void refMapSerializationShouldWork() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -581,7 +582,7 @@ class StormModuleTest {
 
     // NoPk projection node fallback paths
 
-    @org.junit.jupiter.api.Test
+    @Test
     void noPkProjectionWithIntIdNodeShouldDeserializeViaNodeFallback() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -593,7 +594,7 @@ class StormModuleTest {
         assertEquals(42, holder.projection().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void noPkProjectionWithLongIdNodeShouldDeserializeViaNodeFallback() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -604,7 +605,7 @@ class StormModuleTest {
         assertEquals(9999999999L, holder.projection().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void noPkProjectionWithDoubleIdNodeShouldDeserializeViaNodeFallback() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -616,7 +617,7 @@ class StormModuleTest {
         assertEquals(3.14, holder.projection().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void noPkProjectionWithStringIdNodeShouldDeserializeViaNodeFallback() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -628,7 +629,7 @@ class StormModuleTest {
         assertEquals("abc", holder.projection().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void noPkProjectionWithObjectIdNodeShouldDeserializeViaObjectFallback() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -642,7 +643,7 @@ class StormModuleTest {
 
     // Entity via @projection path and non-Entity via @entity path
 
-    @org.junit.jupiter.api.Test
+    @Test
     void projectionPathWithEntityDataShouldCreateEntityRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -654,7 +655,7 @@ class StormModuleTest {
         assertNotNull(holder.entity().getOrNull());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void entityPathWithNonEntityDataShouldThrowException() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -663,7 +664,7 @@ class StormModuleTest {
                 () -> mapper.readValue("{\"data\":{\"@entity\":{\"id\":42,\"value\":\"test\"}}}", DataRefHolder.class));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void projectionPathWithPlainDataAndIdShouldCreateUnloadedRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -677,7 +678,7 @@ class StormModuleTest {
 
     // NoPk data serialization and list tests
 
-    @org.junit.jupiter.api.Test
+    @Test
     void unloadedNoPkRefShouldSerializeAsRawId() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -687,7 +688,7 @@ class StormModuleTest {
         assertTrue(json.contains("42"));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void noPkDataSerializerShouldHandleMissingPkTypeGracefully() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -697,7 +698,7 @@ class StormModuleTest {
         assertTrue(json.contains("text-id"));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void noPkRefListWithMixedIdTypesShouldDeserializeViaFallback() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -709,7 +710,7 @@ class StormModuleTest {
         assertEquals(3, ((Number) holder.data().get(2).id()).intValue());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void noPkRefWithNullIdInListShouldReturnNullRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -722,7 +723,7 @@ class StormModuleTest {
 
     // Double ID round-trip
 
-    @org.junit.jupiter.api.Test
+    @Test
     void doubleIdRefShouldRoundTrip() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -734,7 +735,7 @@ class StormModuleTest {
         assertEquals(3.14, deserialized.entity().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void loadedDoubleIdEntityRefShouldRoundTrip() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -749,7 +750,7 @@ class StormModuleTest {
 
     // Additional round-trip tests
 
-    @org.junit.jupiter.api.Test
+    @Test
     void stringIdRefShouldRoundTrip() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -760,7 +761,7 @@ class StormModuleTest {
         assertEquals(holder, deserialized);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void loadedStringIdEntityRefShouldRoundTrip() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -772,7 +773,7 @@ class StormModuleTest {
         assertEquals(holder, deserialized);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void loadedLongIdEntityRefShouldRoundTrip() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -786,7 +787,7 @@ class StormModuleTest {
 
     // Null projection ref
 
-    @org.junit.jupiter.api.Test
+    @Test
     void nullProjectionRefShouldSerializeToNull() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -796,7 +797,7 @@ class StormModuleTest {
         assertEquals("{\"projection\":null}", json);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void nullProjectionRefShouldDeserializeFromNull() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -808,7 +809,7 @@ class StormModuleTest {
     // Raw Ref without type info
 
     @SuppressWarnings("rawtypes")
-    @org.junit.jupiter.api.Test
+    @Test
     void rawRefWithoutTypeInfoShouldThrowOnDeserialization() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -819,7 +820,7 @@ class StormModuleTest {
 
     // NoPk boolean error
 
-    @org.junit.jupiter.api.Test
+    @Test
     void noPkDataWithBooleanShouldThrowExceptionViaFallbackPath() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -840,7 +841,7 @@ class StormModuleTest {
 
     public record RefListHolder(@Nonnull List<Ref<SimpleEntity>> entities) {}
 
-    @org.junit.jupiter.api.Test
+    @Test
     void serializerShouldHandleDirectRefSerializationWithoutProperty() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -851,7 +852,7 @@ class StormModuleTest {
         assertTrue(json.contains("42"));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void nonRefFieldShouldNotAffectSerialization() throws Exception {
         record NonRefHolder(@Nonnull String value) {}
 
@@ -863,7 +864,7 @@ class StormModuleTest {
         assertEquals("{\"value\":\"test\"}", json);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void refListWithLoadedEntitiesAndNullsShouldDeserializeCorrectly() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -877,7 +878,7 @@ class StormModuleTest {
         assertNotNull(holder.entities().get(2).getOrNull());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void supplierReturningNullFactoryShouldCreateDetachedRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule(() -> null))
@@ -889,7 +890,7 @@ class StormModuleTest {
         assertNull(holder.entity().getOrNull());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void defaultConstructorShouldCreateModuleWithDetachedRefs() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -901,7 +902,7 @@ class StormModuleTest {
         assertNull(holder.entity().getOrNull());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void projectionWithEntityTypeInProjectionPathShouldCreateEntityRef() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -915,7 +916,7 @@ class StormModuleTest {
         assertEquals("Via Projection Path", loaded.name());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void refFactorySupplierShouldBeCalledDuringDeserialization() throws Exception {
         var factoryCallCount = new int[]{0};
         RefFactory factory = new RefFactory() {
@@ -941,7 +942,7 @@ class StormModuleTest {
         assertEquals(3, factoryCallCount[0]);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void simpleNoPkDataWithProjectionFormatAndNullIdShouldThrow() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -953,7 +954,7 @@ class StormModuleTest {
 
     public record SimpleNoPkDataProjectionHolder(@Nullable Ref<SimpleNoPkData> data) {}
 
-    @org.junit.jupiter.api.Test
+    @Test
     void simpleNoPkDataWithProjectionFormatAndNonNullIdShouldCreateRefWithId() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -964,7 +965,7 @@ class StormModuleTest {
         assertEquals(42, ((Number) holder.data().id()).intValue());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void emptyRefListShouldDeserializeCorrectly() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -975,7 +976,7 @@ class StormModuleTest {
         assertEquals(0, holder.entities().size());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void loadedEntityRefInListShouldSerializeAndDeserialize() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -997,7 +998,7 @@ class StormModuleTest {
 
     public record ProjectionRefListHolder(@Nonnull List<Ref<SimpleProjection>> projections) {}
 
-    @org.junit.jupiter.api.Test
+    @Test
     void loadedProjectionRefInListShouldSerializeAndDeserialize() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1019,7 +1020,7 @@ class StormModuleTest {
             @Nullable Ref<SimpleEntity> entity,
             @Nullable Ref<SimpleProjection> projection) {}
 
-    @org.junit.jupiter.api.Test
+    @Test
     void multipleRefTypesInSameHolderShouldDeserializeCorrectly() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1032,7 +1033,7 @@ class StormModuleTest {
         assertEquals(7, holder.projection().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void entityPathWithSimpleNoPkDataShouldThrowException() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1042,7 +1043,7 @@ class StormModuleTest {
                 mapper.readValue(json, SimpleNoPkDataProjectionHolder.class));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void simpleNoPkDataSerializerShouldHandleMissingPkTypeGracefully() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1053,7 +1054,7 @@ class StormModuleTest {
         assertTrue(json.contains("text-id"));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeIdWithFloatValueForSimpleNoPkShouldWork() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1064,7 +1065,7 @@ class StormModuleTest {
         assertEquals(3.14, ((Number) holder.data().id()).doubleValue(), 0.001);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeIdWithStringValueForSimpleNoPkShouldWork() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1075,7 +1076,7 @@ class StormModuleTest {
         assertEquals("abc-123", holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeIdWithLongValueForSimpleNoPkShouldReturnLong() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1086,7 +1087,7 @@ class StormModuleTest {
         assertEquals(3000000000L, ((Number) holder.data().id()).longValue());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeIdFromNodeWithLongValueForSimpleNoPkShouldWork() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1097,7 +1098,7 @@ class StormModuleTest {
         assertEquals(3000000000L, ((Number) holder.data().id()).longValue());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeIdFromNodeWithDoubleValueForSimpleNoPkShouldWork() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1108,7 +1109,7 @@ class StormModuleTest {
         assertEquals(2.71, ((Number) holder.data().id()).doubleValue(), 0.001);
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void deserializeIdFromNodeWithStringValueForSimpleNoPkShouldWork() throws Exception {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1119,7 +1120,7 @@ class StormModuleTest {
         assertEquals("uuid-value", holder.data().id());
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void projectionWithoutIdFieldShouldThrow() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())
@@ -1129,7 +1130,7 @@ class StormModuleTest {
                 mapper.readValue(json, ProjectionRefHolder.class));
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void refObjectWithoutEntityOrProjectionFieldShouldThrow() {
         var mapper = JsonMapper.builder()
                 .addModule(new StormModule())

--- a/storm-jackson3/src/test/java/st/orm/jackson/StormModuleTest.java
+++ b/storm-jackson3/src/test/java/st/orm/jackson/StormModuleTest.java
@@ -18,6 +18,8 @@ import st.orm.PK;
 import st.orm.Projection;
 import st.orm.Ref;
 import st.orm.core.spi.RefFactory;
+import st.orm.jackson.model.VetSpecialty;
+import st.orm.jackson.model.VetSpecialtyPK;
 import tools.jackson.databind.DatabindException;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -219,6 +221,42 @@ class StormModuleTest {
         assertNotNull(restored.projection());
         assertTrue(restored.projection().isLoaded());
         assertEquals(projection, restored.projection().fetch());
+    }
+
+    // Tests for compound PK refs (plain object without @entity/@projection)
+
+    public record CompoundPkRefHolder(@Nullable Ref<VetSpecialty> entity) {}
+
+    @org.junit.jupiter.api.Test
+    void serializeUnloadedCompoundPkRefToPkObject() throws Exception {
+        var mapper = JsonMapper.builder()
+                .addModule(new StormModule())
+                .build();
+        var holder = new CompoundPkRefHolder(Ref.of(VetSpecialty.class, new VetSpecialtyPK(1, 2)));
+        var json = mapper.writeValueAsString(holder);
+        assertEquals("{\"entity\":{\"vetId\":1,\"specialtyId\":2}}", json);
+    }
+
+    @org.junit.jupiter.api.Test
+    void deserializeCompoundPkObjectToUnloadedRef() throws Exception {
+        var mapper = JsonMapper.builder()
+                .addModule(new StormModule())
+                .build();
+        String json = "{\"entity\":{\"vetId\":1,\"specialtyId\":2}}";
+        var holder = mapper.readValue(json, CompoundPkRefHolder.class);
+        assertNotNull(holder.entity());
+        assertEquals(new VetSpecialtyPK(1, 2), holder.entity().id());
+    }
+
+    @org.junit.jupiter.api.Test
+    void roundTripCompoundPkRefShouldPreserveId() throws Exception {
+        var mapper = JsonMapper.builder()
+                .addModule(new StormModule())
+                .build();
+        var original = new CompoundPkRefHolder(Ref.of(VetSpecialty.class, new VetSpecialtyPK(3, 4)));
+        var json = mapper.writeValueAsString(original);
+        var restored = mapper.readValue(json, CompoundPkRefHolder.class);
+        assertEquals(original, restored);
     }
 
     // Tests for Data record without @PK (fallback deserialization paths)

--- a/storm-kotlinx-serialization/src/main/kotlin/st/orm/serialization/StormSerializersModule.kt
+++ b/storm-kotlinx-serialization/src/main/kotlin/st/orm/serialization/StormSerializersModule.kt
@@ -191,9 +191,17 @@ public class RefSerializer<T : Data>(
             val data = json.decodeFromJsonElement(targetSerializer, payload)
             createLoadedRef(data, id)
         }
-        else -> throw SerializationException(
-            "Ref object must contain $ENTITY_FIELD or $PROJECTION_FIELD",
-        )
+        else -> {
+            val pkType = PkTypeResolver.resolve(targetClass)
+            if (pkType == null || !PkTypeResolver.isRecord(pkType)) {
+                throw SerializationException(
+                    "Ref object must contain $ENTITY_FIELD or $PROJECTION_FIELD",
+                )
+            }
+            // A plain object is the inline record of a compound PK; unloaded refs serialize compound PKs this way.
+            val id = checkNotNull(decodeId(json, obj, targetClass))
+            createRef(targetClass as Class<Data>, id) as Ref<T>
+        }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -285,6 +293,12 @@ private object PkTypeResolver {
         }
         return if (cached == NO_PK) null else cached
     }
+
+    /**
+     * Returns whether the given PK type is itself a record type (Java record or Kotlin data class), i.e. a
+     * compound PK.
+     */
+    fun isRecord(type: Class<*>): Boolean = reflection.findRecordType(type).isPresent
 }
 
 /**

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/RefSerializerTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/RefSerializerTest.kt
@@ -20,6 +20,8 @@ import st.orm.Entity
 import st.orm.PK
 import st.orm.Projection
 import st.orm.Ref
+import st.orm.serialization.model.VetSpecialty
+import st.orm.serialization.model.VetSpecialtyPK
 
 /**
  * Unit tests for [RefSerializer] and [StormSerializersModule] covering edge cases
@@ -143,6 +145,37 @@ class RefSerializerTest {
         loaded.shouldBeInstanceOf<SimpleProjection>()
         loaded.id shouldBe 3
         loaded.name shouldBe "proj"
+    }
+
+    // Compound PK refs (plain object without @entity/@projection)
+
+    @Serializable
+    data class CompoundPkRefHolder(@Contextual val ref: Ref<VetSpecialty>?)
+
+    @Test
+    fun `serialize unloaded compound pk ref produces pk object`() {
+        val ref = Ref.of(VetSpecialty::class.java, VetSpecialtyPK(1, 2))
+        val holder = CompoundPkRefHolder(ref = ref)
+        val json = jsonMapper.encodeToString(holder)
+        json shouldBe """{"ref":{"vetId":1,"specialtyId":2}}"""
+    }
+
+    @Test
+    fun `deserialize compound pk object into unloaded ref`() {
+        val holder = jsonMapper.decodeFromString<CompoundPkRefHolder>(
+            """{"ref":{"vetId":1,"specialtyId":2}}""",
+        )
+        holder.ref.shouldNotBeNull()
+        holder.ref!!.id() shouldBe VetSpecialtyPK(1, 2)
+    }
+
+    @Test
+    fun `compound pk ref round-trips through serialization`() {
+        val holder = CompoundPkRefHolder(ref = Ref.of(VetSpecialty::class.java, VetSpecialtyPK(3, 4)))
+        val json = jsonMapper.encodeToString(holder)
+        val decoded = jsonMapper.decodeFromString<CompoundPkRefHolder>(json)
+        decoded.ref.shouldNotBeNull()
+        decoded.ref!!.id() shouldBe VetSpecialtyPK(3, 4)
     }
 
     // Deserialization error paths in deserializeObject

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Vet.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Vet.kt
@@ -1,11 +1,13 @@
 package st.orm.serialization.model
 
+import kotlinx.serialization.Serializable
 import st.orm.Entity
 import st.orm.PK
 
 /**
  * Simple domain object representing a veterinarian.
  */
+@Serializable
 data class Vet(
     @PK val id: Int = 0,
     override val firstName: String,

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/VetSpecialty.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/VetSpecialty.kt
@@ -1,7 +1,9 @@
 package st.orm.serialization.model
 
+import kotlinx.serialization.Serializable
 import st.orm.*
 
+@Serializable
 data class VetSpecialty(
     @PK(generation = GenerationStrategy.NONE) val id: VetSpecialtyPK, // Implicitly @Inlined
     @FK @Persist(insertable = false) val vet: Vet,

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/VetSpecialtyPK.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/VetSpecialtyPK.kt
@@ -1,5 +1,8 @@
 package st.orm.serialization.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class VetSpecialtyPK(
     val vetId: Int,
     val specialtyId: Int,


### PR DESCRIPTION
Unloaded refs over a compound-PK entity serialize the PK record as a plain JSON object (e.g. `{"vetId":1,"specialtyId":2}`), but deserialization routed every JSON object to the `@entity`/`@projection` path and threw, so the advertised compound-PK format could not round-trip.

The Ref deserializers in `storm-jackson2`, `storm-jackson3` and `storm-kotlinx-serialization` now treat an object without a discriminator field as the compound PK, gated on `ORMReflection.findRecordType(pkType)` (recognizes Java records and Kotlin data classes). The decoded PK goes through the same RefFactory-aware id path as raw ids, so attached refs work identically. Simple-PK targets keep the descriptive "must contain @entity or @projection" error.

Tests exercise `Ref<VetSpecialty>` round-trips in each module. The kotlinx test models `VetSpecialty`, `VetSpecialtyPK` and `Vet` gained `@Serializable`, which contextual Ref resolution and PK encoding require.

Fixes #390