### PR TITLE
fix: validation modes fail fast on unknown values

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -340,3 +340,5 @@ The `schema-mode` values:
 | `storm.validation.record_mode` | `fail` | Record validation mode: `fail`, `warn`, or `none` |
 | `storm.validation.schema_mode` | `fail` | Schema validation mode: `none`, `warn`, or `fail` (Spring Boot and Ktor) |
 | `storm.validation.strict` | `false` | When `true`, schema validation warnings are treated as errors |
+
+Mode values are matched case-insensitively after trimming, and a blank value means the default. Any other value is a configuration error: Storm fails fast with an error naming the property, the given value, and the valid values, so a typo cannot silently change validation behavior.

--- a/storm-core/src/main/java/st/orm/core/template/impl/RecordValidation.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/RecordValidation.java
@@ -15,6 +15,7 @@
  */
 package st.orm.core.template.impl;
 
+import static java.util.Locale.ROOT;
 import static java.util.Optional.empty;
 import static st.orm.StormConfig.VALIDATION_RECORD_MODE;
 import static st.orm.core.spi.Providers.getORMConverter;
@@ -102,12 +103,12 @@ final class RecordValidation {
             if (validationCompleted) {
                 return;
             }
-            if ("none".equalsIgnoreCase(recordMode)) {
+            if ("none".equals(recordMode)) {
                 LOGGER.info("Skipping Data type validation. Set storm.validation.record_mode=fail to enable validation.");
                 validationCompleted = true;
                 return;
             }
-            boolean warningsOnly = "warn".equalsIgnoreCase(recordMode);
+            boolean warningsOnly = "warn".equals(recordMode);
             LOGGER.info("Validating Data types for correctness.");
             var dataTypes = TypeDiscovery.getDataTypes();
             var validationErrors = new AtomicReference<>(0);
@@ -142,15 +143,25 @@ final class RecordValidation {
     /**
      * Resolves the record validation mode from the given configuration.
      *
+     * <p>The value is trimmed and matched case-insensitively; an absent or blank value means the {@code fail}
+     * default. Any other value is a configuration error and fails fast, so a typo cannot silently change the
+     * validation semantics.</p>
+     *
      * @param config the Storm configuration.
      * @return the resolved record validation mode: {@code "none"}, {@code "warn"}, or {@code "fail"}.
+     * @throws PersistenceException if the configured value is not a valid mode.
      */
-    private static String resolveRecordMode(StormConfig config) {
+    static String resolveRecordMode(StormConfig config) {
         String recordMode = config.getProperty(VALIDATION_RECORD_MODE, null);
-        if (recordMode != null) {
-            return recordMode.trim();
+        if (recordMode == null || recordMode.isBlank()) {
+            return "fail";
         }
-        return "fail";
+        String mode = recordMode.trim().toLowerCase(ROOT);
+        if (!"none".equals(mode) && !"warn".equals(mode) && !"fail".equals(mode)) {
+            throw new PersistenceException("Invalid %s: '%s'. Valid values are: none, warn, fail."
+                    .formatted(VALIDATION_RECORD_MODE, recordMode.trim()));
+        }
+        return mode;
     }
 
     /**

--- a/storm-core/src/test/java/st/orm/core/template/impl/RecordValidationTest.java
+++ b/storm-core/src/test/java/st/orm/core/template/impl/RecordValidationTest.java
@@ -1,10 +1,13 @@
 package st.orm.core.template.impl;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static st.orm.StormConfig.VALIDATION_RECORD_MODE;
 
 import java.util.List;
+import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import st.orm.Data;
@@ -13,9 +16,11 @@ import st.orm.FK;
 import st.orm.GenerationStrategy;
 import st.orm.Inline;
 import st.orm.PK;
+import st.orm.PersistenceException;
 import st.orm.Projection;
 import st.orm.ProjectionQuery;
 import st.orm.Ref;
+import st.orm.StormConfig;
 import st.orm.Version;
 import st.orm.core.template.SqlTemplate.NamedParameter;
 import st.orm.core.template.SqlTemplate.Parameter;
@@ -712,6 +717,34 @@ class RecordValidationTest {
                 () -> RecordValidation.validateDataType(EntityWithProjectionInside.class));
         assertTrue(exception.getMessage().contains("@FK") || exception.getMessage().contains("@Inline"),
                 "Expected error message to mention @FK or @Inline, got: " + exception.getMessage());
+    }
+
+    // Record validation mode resolution
+
+    @Test
+    void testRecordModeDefaultsToFail() {
+        assertEquals("fail", RecordValidation.resolveRecordMode(StormConfig.defaults()));
+    }
+
+    @Test
+    void testRecordModeBlankFallsBackToFail() {
+        var config = StormConfig.of(Map.of(VALIDATION_RECORD_MODE, "  "));
+        assertEquals("fail", RecordValidation.resolveRecordMode(config));
+    }
+
+    @Test
+    void testRecordModeMatchesCaseInsensitivelyAfterTrimming() {
+        var config = StormConfig.of(Map.of(VALIDATION_RECORD_MODE, "  WARN  "));
+        assertEquals("warn", RecordValidation.resolveRecordMode(config));
+    }
+
+    @Test
+    void testRecordModeUnknownValueFailsFast() {
+        var config = StormConfig.of(Map.of(VALIDATION_RECORD_MODE, "fial"));
+        PersistenceException exception = assertThrows(PersistenceException.class,
+                () -> RecordValidation.resolveRecordMode(config));
+        assertEquals("Invalid storm.validation.record_mode: 'fial'. Valid values are: none, warn, fail.",
+                exception.getMessage());
     }
 
 }

--- a/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.kt
+++ b/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.kt
@@ -18,12 +18,14 @@ package st.orm.spring.boot.autoconfigure
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
@@ -338,6 +340,23 @@ class StormAutoConfigurationTest {
             .run { context ->
                 context.getBean(ORMTemplate::class.java) shouldNotBe null
                 output.out.contains("Storm schema validation passed (mode=fail).") shouldBe true
+            }
+    }
+
+    @Test
+    fun `schema validation unknown mode fails context startup`() {
+        // A typo in the mode must fail startup instead of silently skipping schema validation.
+        contextRunner
+            .withPropertyValues(
+                "spring.datasource.url=jdbc:h2:mem:schemaUnknownTest;DB_CLOSE_DELAY=-1",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+                "storm.validation.schema-mode=fial",
+            )
+            .run { context ->
+                val failure = context.startupFailure.shouldBeInstanceOf<InvalidConfigurationPropertyValueException>()
+                failure.message shouldContain "storm.validation.schema-mode"
+                failure.message shouldContain "'fial'"
+                failure.message shouldContain "Valid values are: none, warn, fail."
             }
     }
 

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
@@ -243,6 +243,7 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
             ?: application.environment.config.propertyOrNull("storm.validation.schemaMode")?.getString()
             ?: application.environment.config.propertyOrNull("storm.validation.schema_mode")?.getString()
             ?: "fail",
+        property = "storm.validation.schemaMode",
         description = "primary database",
     ) { type -> claimedPackages.keys.none { type.java.name.startsWith("$it.") } }
     for (databaseConfig in pluginConfig.databases.values) {
@@ -253,6 +254,7 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
                 ?: application.environment.config.propertyOrNull("storm.databases.$name.validation.schemaMode")?.getString()
                 ?: application.environment.config.propertyOrNull("storm.databases.$name.validation.schema_mode")?.getString()
                 ?: "fail",
+            property = "storm.databases.$name.validation.schemaMode",
             description = "database '$name'",
         ) { type -> databaseConfig.repositoryPackages.any { type.java.name.startsWith("$it.") } }
     }
@@ -412,23 +414,28 @@ private fun Application.registerRepositories(registry: RepositoryRegistry): List
 
 /**
  * Runs schema validation for one database's template, limited to the types accepted by [filter].
+ *
+ * The mode is matched case-insensitively after trimming; a blank value means the `fail` default, matching the
+ * Spring entry point. Any other value is a configuration error and fails installation, so a typo cannot
+ * silently disable validation. [property] names the configuration key in that error.
  */
 private fun Application.runSchemaValidation(
     template: ORMTemplate,
     configuredMode: String,
+    property: String,
     description: String,
     filter: (KClass<out st.orm.Data>) -> Boolean,
 ) {
-    val schemaMode = configuredMode.trim().lowercase()
-    if (schemaMode == "none" || schemaMode.isBlank()) {
-        return
-    }
-    when (schemaMode) {
+    when (configuredMode.trim().lowercase().ifEmpty { "fail" }) {
+        "none" -> {}
         "fail" -> {
             template.validateSchemaOrThrow(filter)
             log.info("Storm schema validation passed for $description (mode=fail).")
         }
         "warn" -> template.validateSchema(filter).forEach { log.warn(it) }
-        else -> log.warn("Unknown schema validation mode: '$configuredMode'. Expected 'none', 'warn', or 'fail'.")
+        else -> throw IllegalStateException(
+            "Invalid schema validation mode '$configuredMode' for $description " +
+                "(schemaValidation option or $property). Valid values are: none, warn, fail.",
+        )
     }
 }

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormDatabaseConfig.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormDatabaseConfig.kt
@@ -78,7 +78,8 @@ public class StormDatabaseConfig internal constructor(internal val name: String)
     public var sqlCommenter: st.orm.core.spi.SqlCommenter? = null
 
     /**
-     * Schema validation mode for this database: `"none"`, `"warn"`, or `"fail"`.
+     * Schema validation mode for this database: `"none"`, `"warn"`, or `"fail"`. Any other value aborts
+     * installation.
      *
      * When not set, the mode is read from the HOCON configuration under
      * `storm.databases.<name>.validation.schemaMode` (or `schema_mode`), defaulting to `"fail"`. Validation covers

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormPluginConfig.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormPluginConfig.kt
@@ -186,7 +186,7 @@ public class StormPluginConfig {
     public var registerDependencies: Boolean = true
 
     /**
-     * Schema validation mode: `"none"`, `"warn"`, or `"fail"`.
+     * Schema validation mode: `"none"`, `"warn"`, or `"fail"`. Any other value aborts installation.
      *
      * When not set, the mode is read from the application configuration under
      * `storm.validation.schemaMode` (or `storm.validation.schema_mode`), matching the Spring Boot

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormPluginTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormPluginTest.kt
@@ -290,16 +290,48 @@ class StormPluginTest {
     }
 
     @Test
-    fun `unknown schema validation mode does not throw`() {
+    fun `unknown schema validation mode fails startup`() {
+        // A valid schema proves the failure is the unrecognized mode, not a validation mismatch.
+        val dataSource = createTestDataSource()
+        initializeSchema(dataSource)
+        try {
+            testApplication {
+                application {
+                    try {
+                        install(Storm) {
+                            this.dataSource = dataSource
+                            schemaValidation = "invalid"
+                        }
+                        throw AssertionError("Expected unknown schema validation mode to fail startup")
+                    } catch (expected: IllegalStateException) {
+                        expected.message shouldBe "Invalid schema validation mode 'invalid' for primary database " +
+                            "(schemaValidation option or storm.validation.schemaMode). " +
+                            "Valid values are: none, warn, fail."
+                    }
+                }
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `blank schema validation mode falls back to the fail default`() {
+        // No schema initialized: blank means unset, so the fail default must abort startup instead of
+        // skipping validation.
         val dataSource = createTestDataSource()
         try {
             testApplication {
                 application {
-                    install(Storm) {
-                        this.dataSource = dataSource
-                        schemaValidation = "invalid"
+                    try {
+                        install(Storm) {
+                            this.dataSource = dataSource
+                            schemaValidation = "  "
+                        }
+                        throw AssertionError("Expected schema validation to fail startup")
+                    } catch (expected: st.orm.PersistenceException) {
+                        // Blank resolved to the fail default and validation ran.
                     }
-                    orm shouldNotBe null
                 }
             }
         } finally {

--- a/storm-spring-boot-starter/src/test/java/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.java
+++ b/storm-spring-boot-starter/src/test/java/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
@@ -281,6 +282,25 @@ class StormAutoConfigurationTest {
                 )
                 .run(context -> {
                     assertThat(context).hasSingleBean(ORMTemplate.class);
+                });
+    }
+
+    @Test
+    void schemaValidationUnknownModeShouldFailContextStartup() {
+        // A typo in the mode must fail startup instead of silently skipping schema validation.
+        contextRunner
+                .withPropertyValues(
+                        "spring.datasource.url=jdbc:h2:mem:schemaUnknownTest;DB_CLOSE_DELAY=-1",
+                        "spring.datasource.driver-class-name=org.h2.Driver",
+                        "storm.validation.schema-mode=fial"
+                )
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .isInstanceOf(InvalidConfigurationPropertyValueException.class)
+                            .hasMessageContaining("storm.validation.schema-mode")
+                            .hasMessageContaining("'fial'")
+                            .hasMessageContaining("Valid values are: none, warn, fail.");
                 });
     }
 

--- a/storm-spring/src/main/java/st/orm/spring/boot/StormValidationAutoConfiguration.java
+++ b/storm-spring/src/main/java/st/orm/spring/boot/StormValidationAutoConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
 import org.springframework.context.annotation.Bean;
 import st.orm.core.template.impl.SchemaValidator;
 
@@ -32,7 +33,8 @@ import st.orm.core.template.impl.SchemaValidator;
  * <p>Validation runs after all singleton beans have been fully initialized, guaranteeing that migration tools
  * like Flyway and Liquibase (or any bean-based migration mechanism) have completed their work before
  * validation occurs. The mode is read from {@code storm.validation.schema-mode}: {@code fail} (default),
- * {@code warn}, or {@code none}.</p>
+ * {@code warn}, or {@code none}. Any other value fails startup, so a typo cannot silently disable
+ * validation.</p>
  *
  * @since 1.13
  */
@@ -54,14 +56,17 @@ public class StormValidationAutoConfiguration {
             if ("none".equalsIgnoreCase(schemaMode)) {
                 return;
             }
+            if (!"fail".equalsIgnoreCase(schemaMode) && !"warn".equalsIgnoreCase(schemaMode)) {
+                // A typo must fail startup rather than run the application with schema validation silently disabled.
+                throw new InvalidConfigurationPropertyValueException("storm.validation.schema-mode", configured,
+                        "Valid values are: none, warn, fail.");
+            }
             SchemaValidator validator = SchemaValidator.of(dataSource);
             if ("fail".equalsIgnoreCase(schemaMode)) {
                 validator.validateOrThrow();
                 LOGGER.info("Storm schema validation passed (mode=fail).");
-            } else if ("warn".equalsIgnoreCase(schemaMode)) {
-                validator.validateOrWarn();
             } else {
-                LOGGER.warn("Unknown schema validation mode: '{}'. Expected 'none', 'warn', or 'fail'.", schemaMode);
+                validator.validateOrWarn();
             }
         };
     }


### PR DESCRIPTION
Fixes #433

Unknown values for the three validation mode properties were handled three different ways, and two of them masked a typo. All three now fail fast with an error naming the property, the given value, and the valid values. Matching stays trim-then-case-insensitive, and a blank value means the default.

## Changes

- **`storm.validation.record_mode`** (`RecordValidation`): an unknown value previously behaved as `fail` by accident; `resolveRecordMode` now normalizes the value and throws a `PersistenceException` for anything other than `none`, `warn`, or `fail`. The normalized value lets `validate()` compare with plain `equals`.
- **`storm.validation.schema-mode`** (Spring, `StormValidationAutoConfiguration`): an unknown value previously logged a boot warning and skipped schema validation entirely; it now throws `InvalidConfigurationPropertyValueException`, failing startup with Boot's standard property-error report.
- **Ktor** (`runSchemaValidation`): an unknown value previously logged a warning and skipped validation; it now throws an `IllegalStateException` naming the value, the database, and both configuration routes (the `schemaValidation` plugin option and the `storm.validation.schemaMode` config key, per-database variant included).
- **Blank alignment**: the Ktor entry point treated a blank mode as `none` while Spring treated it as the `fail` default; blank now means the `fail` default in both.

## Tests

- Core: `resolveRecordMode` unit tests for the default, blank fallback, trim/case normalization, and the unknown-value error message.
- Both starters: an unknown `storm.validation.schema-mode` fails context startup with the property, value, and valid values in the failure.
- Ktor: the `unknown schema validation mode does not throw` test is inverted to assert the startup failure and its message, and a new test proves a blank mode runs validation in fail mode.

All four suites pass in a full `-am` reactor build; a repo-wide sweep found no other place configuring one of these modes with a value outside `none`/`warn`/`fail`.

Docs: `docs/validation.md` gains two sentences describing the fail-fast behavior (visible at `/docs/next` until the next release snapshot).