### PR TITLE
feat: templates declare DataSources that hand out manual-commit connections

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1021,6 +1021,33 @@ Since 1.13, a `transaction` or `transactionBlocking` block binds to the first `O
 
 Templates that should share a transaction must use the same transaction provider instance. This is automatic for repositories of one application (the Spring Boot starter and the Ktor plugin configure one provider per application context or plugin installation). Mixing templates with *different* transaction providers inside one block fails fast with a descriptive error, since a single commit cannot span two transaction systems.
 
+### Manual-Commit Connection Pools
+
+Storm-managed transactions expect connections to arrive from the `DataSource` in auto-commit mode and fail fast otherwise: a connection arriving with auto-commit disabled is indistinguishable from a connection carrying an unfinished transaction, and silently adopting it would let Storm commit or roll back work it does not own.
+
+Some pools are deliberately configured to hand out manual-commit connections, for example HikariCP with `autoCommit=false`, to save the two `setAutoCommit` round trips per transaction on drivers that issue a statement for them. Declare that mode on the template builder:
+
+```kotlin
+val orm = ORMTemplate.builder(dataSource)
+    .manualCommitConnections()
+    .build()
+```
+
+```java
+ORMTemplate orm = ORMTemplate.builder(dataSource)
+        .manualCommitConnections()
+        .build();
+```
+
+The declaration only selects which arrival state is correct; it is verified in both directions, so misconfiguration stays loud in every combination. A declared template that receives an auto-commit connection fails fast naming the misdeclaration, exactly like an undeclared template that receives a manual-commit one.
+
+With the declaration in place:
+
+- The transactional path performs no `setAutoCommit` flips and releases connections in their arrived state, so the pool gets back exactly what it handed out.
+- Statements executed outside a transaction still commit per statement: Storm enables auto-commit while it uses the connection and restores the arrived state before release. Without this, the pool would roll back uncommitted work when the connection is returned.
+
+The declaration configures Storm's built-in JDBC connection handling and cannot be combined with a custom connection provider; integrations that construct the provider themselves pass the declared mode to its constructor, `JdbcConnectionProviderImpl(true)`. Platform-managed connections, such as templates wired to Spring's transaction management, are not affected: the platform owns commit semantics there.
+
 ### Spring-Managed Transactions
 
 While Storm's programmatic transaction API works standalone, many applications use Spring's transaction management for its declarative `@Transactional` support and integration with other Spring components. Storm integrates seamlessly with Spring's transaction management.

--- a/storm-core/src/main/java/st/orm/core/spi/JdbcConnectionProviderImpl.java
+++ b/storm-core/src/main/java/st/orm/core/spi/JdbcConnectionProviderImpl.java
@@ -33,9 +33,33 @@ import st.orm.PersistenceException;
  * closed directly on the data source. Integrations that bind connections to an external transaction subsystem
  * supply their own {@link ConnectionProvider} via the template builder.</p>
  *
+ * <p>The provider declares the auto-commit state in which the data source hands out connections, auto-commit
+ * by default, and verifies every fresh connection against the declaration in both directions.</p>
+ *
  * @since 1.13
  */
 public final class JdbcConnectionProviderImpl implements ConnectionProvider {
+
+    private final boolean manualCommitConnections;
+
+    public JdbcConnectionProviderImpl() {
+        this(false);
+    }
+
+    /**
+     * Creates a provider that declares the auto-commit state in which the data source hands out connections.
+     *
+     * <p>The declared mode is verified in both directions on every fresh connection, so a wrong declaration
+     * fails fast in every combination. For a declared manual-commit pool the transactional path performs no
+     * auto-commit flips and releases connections in their arrived state; non-transactional connections get
+     * auto-commit enabled while Storm uses them and restored before release, so each statement commits.</p>
+     *
+     * @param manualCommitConnections whether the data source hands out connections with auto-commit disabled.
+     * @since 1.14
+     */
+    public JdbcConnectionProviderImpl(boolean manualCommitConnections) {
+        this.manualCommitConnections = manualCommitConnections;
+    }
 
     @Override
     public Connection getConnection(DataSource dataSource, @Nullable TransactionContext context) {
@@ -43,7 +67,7 @@ public final class JdbcConnectionProviderImpl implements ConnectionProvider {
             if (!(context instanceof JdbcTransactionContext jdbcContext)) {
                 throw new IllegalArgumentException("Transaction context must be of type JdbcTransactionContext.");
             }
-            var connection = jdbcContext.getConnection(dataSource);
+            var connection = jdbcContext.getConnection(dataSource, manualCommitConnections);
             ConcurrencyDetector.beforeAccess(connection, context);
             return connection;
         }
@@ -69,16 +93,40 @@ public final class JdbcConnectionProviderImpl implements ConnectionProvider {
     }
 
     private Connection getRegularConnection(DataSource dataSource) {
+        Connection connection;
         try {
-            return dataSource.getConnection();
+            connection = dataSource.getConnection();
         } catch (Throwable t) {
             throw new PersistenceException("Failed to get connection from DataSource.", t);
         }
+        JdbcTransactionContext.verifyArrivedAutoCommitState(connection, manualCommitConnections);
+        // Non-transactional statements execute in auto-commit mode. On a declared manual-commit pool the
+        // connection arrives with auto-commit disabled, so auto-commit is enabled here and restored on release;
+        // leaving it disabled would let the pool roll back uncommitted statements on release, silently losing
+        // writes.
+        if (manualCommitConnections) {
+            try {
+                connection.setAutoCommit(true);
+            } catch (Throwable t) {
+                try {
+                    connection.close();
+                } catch (Throwable ignore) {}
+                throw new PersistenceException("Failed to get connection from DataSource.", t);
+            }
+        }
+        return connection;
     }
 
     private void releaseRegularConnection(Connection connection) {
         try {
-            connection.close();
+            try {
+                // Return the connection to the pool in its arrived state.
+                if (manualCommitConnections) {
+                    connection.setAutoCommit(false);
+                }
+            } finally {
+                connection.close();
+            }
         } catch (Throwable t) {
             throw new PersistenceException("Failed to release connection.", t);
         }

--- a/storm-core/src/main/java/st/orm/core/spi/JdbcTransactionContext.java
+++ b/storm-core/src/main/java/st/orm/core/spi/JdbcTransactionContext.java
@@ -90,6 +90,7 @@ public final class JdbcTransactionContext implements TransactionContext {
         boolean ownsConnection;
         @Nullable Integer originalIsolationLevel;
         @Nullable Boolean originalReadOnly;
+        @Nullable Boolean originalAutoCommit;
         @Nullable Savepoint savepoint;
         boolean rollbackOnly;
         boolean rollbackInherited;
@@ -176,12 +177,34 @@ public final class JdbcTransactionContext implements TransactionContext {
      * Obtains a JDBC connection for the current transaction, creating or reusing one based on the transaction
      * propagation rules.
      *
+     * <p>Connections are expected to arrive from the data source in auto-commit mode.</p>
+     *
      * @param dataSource the data source to get the connection from.
      * @return the JDBC connection.
      * @throws PersistenceException if the connection cannot be obtained.
      */
     public Connection getConnection(DataSource dataSource) {
-        useDataSource(dataSource);
+        return getConnection(dataSource, false);
+    }
+
+    /**
+     * Obtains a JDBC connection for the current transaction, creating or reusing one based on the transaction
+     * propagation rules.
+     *
+     * <p>The {@code manualCommitConnections} declaration selects which arrival state is correct for connections
+     * freshly obtained from the data source; the arrival state is verified in both directions, so a wrong
+     * declaration fails fast rather than silently corrupting transaction semantics. In declared mode the
+     * transactional path performs no auto-commit flips and releases connections in their arrived state.</p>
+     *
+     * @param dataSource the data source to get the connection from.
+     * @param manualCommitConnections whether the data source is declared to hand out connections with
+     * auto-commit disabled.
+     * @return the JDBC connection.
+     * @throws PersistenceException if the connection cannot be obtained.
+     * @since 1.14
+     */
+    public Connection getConnection(DataSource dataSource, boolean manualCommitConnections) {
+        useDataSource(dataSource, manualCommitConnections);
         return currentState().connection;
     }
 
@@ -356,7 +379,7 @@ public final class JdbcTransactionContext implements TransactionContext {
         }
     }
 
-    private void useDataSource(DataSource dataSource) {
+    private void useDataSource(DataSource dataSource, boolean manualCommitConnections) {
         for (int i = 0; i < stack.size(); i++) {
             var state = stack.get(i);
             if (state.connection == null) {
@@ -367,14 +390,14 @@ public final class JdbcTransactionContext implements TransactionContext {
                         if (outerBound) {
                             joinOuterTransaction(state, outer);
                         } else {
-                            openNewTransaction(state, dataSource);
+                            openNewTransaction(state, dataSource, manualCommitConnections);
                         }
                     }
                     case SUPPORTS -> {
                         if (outerBound) {
                             joinOuterTransaction(state, outer);
                         } else {
-                            openConnection(state, dataSource); // Non-transactional.
+                            openConnection(state, dataSource, manualCommitConnections); // Non-transactional.
                         }
                     }
                     case MANDATORY -> {
@@ -388,25 +411,25 @@ public final class JdbcTransactionContext implements TransactionContext {
                         if (outerBound) {
                             suspendTransaction(state, outer);
                         }
-                        openNewTransaction(state, dataSource);
+                        openNewTransaction(state, dataSource, manualCommitConnections);
                     }
                     case NOT_SUPPORTED -> {
                         if (outerBound) {
                             suspendTransaction(state, outer);
                         }
-                        openConnection(state, dataSource); // Non-transactional.
+                        openConnection(state, dataSource, manualCommitConnections); // Non-transactional.
                     }
                     case NEVER -> {
                         if (outerBound) {
                             throw new PersistenceException("Existing transaction found for NEVER propagation.");
                         }
-                        openConnection(state, dataSource); // Non-transactional.
+                        openConnection(state, dataSource, manualCommitConnections); // Non-transactional.
                     }
                     case NESTED -> {
                         if (outerBound) {
                             openNestedTransaction(state, outer, dataSource);
                         } else {
-                            openNewTransaction(state, dataSource);
+                            openNewTransaction(state, dataSource, manualCommitConnections);
                         }
                     }
                 }
@@ -490,8 +513,8 @@ public final class JdbcTransactionContext implements TransactionContext {
                     }
                 } finally {
                     // Always return the connection to the pool — even if commit() threw — so the pool does not
-                    // retain a connection with autoCommit=false (which would fail the auto-commit precondition
-                    // on the next openNewTransaction()).
+                    // retain a connection in a different state than it handed out (which would fail the
+                    // arrival-state precondition on the next openNewTransaction()).
                     try {
                         close(connection, state);
                     } catch (SQLException closeException) {
@@ -531,8 +554,8 @@ public final class JdbcTransactionContext implements TransactionContext {
                     }
                 } finally {
                     // Always return the connection to the pool — even if rollback() threw — so the pool does
-                    // not retain a connection with autoCommit=false (which would fail the auto-commit
-                    // precondition on the next openNewTransaction()).
+                    // not retain a connection in a different state than it handed out (which would fail the
+                    // arrival-state precondition on the next openNewTransaction()).
                     try {
                         close(connection, state);
                     } catch (SQLException closeException) {
@@ -577,7 +600,11 @@ public final class JdbcTransactionContext implements TransactionContext {
         if (state.originalReadOnly != null) {
             connection.setReadOnly(state.originalReadOnly);
         }
-        connection.setAutoCommit(true);
+        // Restore auto-commit only when this frame changed it, so the pool gets the connection back in its
+        // arrived state: auto-commit for regular pools, manual-commit for declared pools.
+        if (state.originalAutoCommit != null) {
+            connection.setAutoCommit(state.originalAutoCommit);
+        }
         connection.close();
     }
 
@@ -591,7 +618,7 @@ public final class JdbcTransactionContext implements TransactionContext {
     /**
      * Opens a fresh JDBC connection for REQUIRED (when no outer) or REQUIRES_NEW.
      */
-    private void openNewTransaction(TransactionState state, DataSource dataSource) {
+    private void openNewTransaction(TransactionState state, DataSource dataSource, boolean manualCommitConnections) {
         // Lock the TransactionState so that only one thread can initialize its connection. Without this, two
         // threads could race to assign different connections (or tx modes) to the same state. Ensuring a
         // single, consistent connection instance lets downstream logic detect and fail fast on concurrent
@@ -605,36 +632,43 @@ public final class JdbcTransactionContext implements TransactionContext {
                 return;
             }
             LOGGER.trace("Opening new transaction ({}).", state.transactionId);
-            var connection = dataSource.getConnection();
+            Connection connection;
+            try {
+                connection = dataSource.getConnection();
+            } catch (SQLException e) {
+                throw new PersistenceException("Failed to open transaction.", e);
+            }
             LOGGER.trace("Obtained connection {} ({}).", connection, state.transactionId);
-            if (!connection.getAutoCommit()) {
-                throw new PersistenceException("""
-                        Connection returned from DataSource must be in auto-commit mode, but arrived with \
-                        auto-commit disabled. Either the pool is configured for manual-commit connections, or the \
-                        connection carries an unfinished transaction. Configure the pool to hand out auto-commit \
-                        connections; Storm disables auto-commit for the duration of a transaction and re-enables it \
-                        before releasing the connection.""");
+            verifyArrivedAutoCommitState(connection, manualCommitConnections);
+            try {
+                // Only read and change the connection settings when explicitly requested: reading the isolation
+                // level can cost a round trip on some drivers, and close() restores (another round trip) only what
+                // was captured here.
+                if (state.isolationLevel != null) {
+                    state.originalIsolationLevel = connection.getTransactionIsolation();
+                    connection.setTransactionIsolation(state.isolationLevel);
+                }
+                if (state.readOnly != null) {
+                    state.originalReadOnly = connection.isReadOnly();
+                    connection.setReadOnly(state.readOnly);
+                }
+                // A declared manual-commit pool hands the connection out with auto-commit already disabled (the
+                // arrival state is verified above), so the transactional path performs no flips and the
+                // connection is released in its arrived state.
+                if (!manualCommitConnections) {
+                    connection.setAutoCommit(false);
+                    state.originalAutoCommit = true;
+                }
+            } catch (SQLException e) {
+                closeQuietly(connection, state.transactionId);
+                throw new PersistenceException("Failed to open transaction.", e);
             }
-            // Only read and change the connection settings when explicitly requested: reading the isolation
-            // level can cost a round trip on some drivers, and close() restores (another round trip) only what
-            // was captured here.
-            if (state.isolationLevel != null) {
-                state.originalIsolationLevel = connection.getTransactionIsolation();
-                connection.setTransactionIsolation(state.isolationLevel);
-            }
-            if (state.readOnly != null) {
-                state.originalReadOnly = connection.isReadOnly();
-                connection.setReadOnly(state.readOnly);
-            }
-            connection.setAutoCommit(false);
             state.dataSource = dataSource;
             state.ownsConnection = true;
             if (state.deadlineNanos == null && state.timeoutSeconds != null) {
                 state.deadlineNanos = deadlineFromNow(state.timeoutSeconds);
             }
             state.connection = connection;
-        } catch (SQLException e) {
-            throw new PersistenceException("Failed to open transaction.", e);
         } finally {
             state.bindLock.unlock();
         }
@@ -643,7 +677,7 @@ public final class JdbcTransactionContext implements TransactionContext {
     /**
      * Opens a non-transactional connection (auto-commit).
      */
-    private void openConnection(TransactionState state, DataSource dataSource) {
+    private void openConnection(TransactionState state, DataSource dataSource, boolean manualCommitConnections) {
         // Lock the TransactionState so that only one thread can initialize its connection; see
         // openNewTransaction for the rationale.
         if (state.connection != null) {
@@ -655,19 +689,80 @@ public final class JdbcTransactionContext implements TransactionContext {
                 return;
             }
             LOGGER.trace("Opening connection ({}).", state.transactionId);
-            var connection = dataSource.getConnection();
-            connection.setAutoCommit(true);
+            Connection connection;
+            try {
+                connection = dataSource.getConnection();
+            } catch (SQLException e) {
+                throw new PersistenceException("Failed to open connection.", e);
+            }
             LOGGER.trace("Obtained connection {} ({}).", connection, state.transactionId);
+            verifyArrivedAutoCommitState(connection, manualCommitConnections);
+            // Non-transactional scopes execute each statement in auto-commit mode. On a declared manual-commit
+            // pool the connection arrives with auto-commit disabled, so auto-commit is enabled for the scope and
+            // restored to the arrived state before the connection is released; leaving it disabled would let the
+            // pool roll back uncommitted statements on release, silently losing writes.
+            if (manualCommitConnections) {
+                try {
+                    connection.setAutoCommit(true);
+                    state.originalAutoCommit = false;
+                } catch (SQLException e) {
+                    closeQuietly(connection, state.transactionId);
+                    throw new PersistenceException("Failed to open connection.", e);
+                }
+            }
             state.dataSource = dataSource;
             state.ownsConnection = true;
             // Non-transactional: deadline is not meaningful (no commit), but the decorator still uses
             // remainingSeconds().
             state.deadlineNanos = state.timeoutSeconds == null ? null : deadlineFromNow(state.timeoutSeconds);
             state.connection = connection;
-        } catch (SQLException e) {
-            throw new PersistenceException("Failed to open connection.", e);
         } finally {
             state.bindLock.unlock();
+        }
+    }
+
+    /**
+     * Verifies that a connection freshly obtained from a data source arrived in the declared auto-commit state,
+     * closing the connection and failing fast on a mismatch.
+     *
+     * <p>An undeclared template requires auto-commit arrivals: a connection arriving with auto-commit disabled
+     * is indistinguishable from a connection carrying an unfinished transaction, and silently adopting it would
+     * let Storm commit or roll back work it does not own. A declared template requires manual-commit arrivals
+     * for the same reason in the opposite direction: a trusted-but-wrong declaration would commit transactional
+     * work per statement and turn rollback into a no-op. The declaration only selects which arrival state is
+     * correct; misconfiguration stays loud in every combination.</p>
+     */
+    static void verifyArrivedAutoCommitState(Connection connection, boolean manualCommitConnections) {
+        boolean autoCommit;
+        try {
+            autoCommit = connection.getAutoCommit();
+        } catch (SQLException e) {
+            closeQuietly(connection, null);
+            throw new PersistenceException("Failed to determine the auto-commit state of the connection.", e);
+        }
+        if (autoCommit == manualCommitConnections) {
+            closeQuietly(connection, null);
+            if (manualCommitConnections) {
+                throw new PersistenceException("""
+                        Connection returned from DataSource arrived in auto-commit mode, but the template \
+                        declares manual-commit connections. Remove the manualCommitConnections declaration, or \
+                        configure the pool to hand out manual-commit connections.""");
+            }
+            throw new PersistenceException("""
+                    Connection returned from DataSource must be in auto-commit mode, but arrived with \
+                    auto-commit disabled. Either the pool is configured for manual-commit connections, or the \
+                    connection carries an unfinished transaction. Configure the pool to hand out auto-commit \
+                    connections, or declare the pool's mode via \
+                    ORMTemplate.builder(dataSource).manualCommitConnections() if manual-commit connections are \
+                    intended.""");
+        }
+    }
+
+    private static void closeQuietly(Connection connection, @Nullable String transactionId) {
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            LOGGER.warn("Failed to close connection after failed open ({}).", transactionId, e);
         }
     }
 

--- a/storm-core/src/main/java/st/orm/core/template/ORMTemplate.java
+++ b/storm-core/src/main/java/st/orm/core/template/ORMTemplate.java
@@ -32,6 +32,8 @@ import st.orm.core.repository.ProjectionRepository;
 import st.orm.core.repository.RepositoryLookup;
 import st.orm.core.spi.ConnectionProvider;
 import st.orm.core.spi.ExceptionMapper;
+import st.orm.core.spi.JdbcConnectionProviderImpl;
+import st.orm.core.spi.Providers;
 import st.orm.core.spi.QueryObserver;
 import st.orm.core.spi.SqlCommenter;
 import st.orm.core.spi.TransactionTemplateProvider;
@@ -430,6 +432,7 @@ public interface ORMTemplate extends QueryTemplate, RepositoryLookup {
         private StormConfig config = StormConfig.defaults();
         private @Nullable UnaryOperator<TemplateDecorator> decorator;
         private @Nullable ConnectionProvider connectionProvider;
+        private boolean manualCommitConnections;
         private @Nullable TransactionTemplateProvider transactionTemplateProvider;
         private @Nullable ExceptionMapper exceptionMapper;
         private @Nullable QueryObserver queryObserver;
@@ -472,6 +475,35 @@ public interface ORMTemplate extends QueryTemplate, RepositoryLookup {
          */
         public Builder connectionProvider(ConnectionProvider connectionProvider) {
             this.connectionProvider = requireNonNull(connectionProvider, "connectionProvider");
+            return this;
+        }
+
+        /**
+         * Declares that the data source hands out connections with auto-commit disabled.
+         *
+         * <p>Storm-managed transactions require connections to arrive from the data source in auto-commit mode
+         * and fail fast otherwise, since a manual-commit arrival is indistinguishable from a connection carrying
+         * an unfinished transaction. Pools that are deliberately configured to hand out manual-commit
+         * connections, for example to save the two auto-commit round trips per transaction, declare that mode
+         * here.</p>
+         *
+         * <p>The declared mode is verified in both directions: a declared template that receives an auto-commit
+         * connection fails fast naming the misdeclaration, exactly like an undeclared template that receives a
+         * manual-commit one. With the declaration in place, the transactional path performs no auto-commit flips
+         * and releases connections in their arrived state; non-transactional connections get auto-commit enabled
+         * while Storm uses them and restored before release, so each statement still commits.</p>
+         *
+         * <p>The declaration configures Storm's built-in JDBC connection handling and cannot be combined with a
+         * custom {@link #connectionProvider(ConnectionProvider) connection provider}; a provider that manages
+         * connections itself carries its own arrival-state contract, such as
+         * {@code new JdbcConnectionProviderImpl(true)}. Only valid for data source backed templates;
+         * {@link #build()} fails fast otherwise.</p>
+         *
+         * @return this builder.
+         * @since 1.14
+         */
+        public Builder manualCommitConnections() {
+            this.manualCommitConnections = true;
             return this;
         }
 
@@ -534,12 +566,37 @@ public interface ORMTemplate extends QueryTemplate, RepositoryLookup {
         public ORMTemplate build() {
             PreparedStatementTemplateImpl template;
             if (dataSource != null) {
-                template = new PreparedStatementTemplateImpl(dataSource, config, connectionProvider,
+                var effectiveConnectionProvider = connectionProvider;
+                if (manualCommitConnections) {
+                    if (connectionProvider != null) {
+                        throw new PersistenceException(
+                                "A manual-commit declaration cannot be combined with a custom connection " +
+                                "provider; the declaration configures Storm's built-in JDBC connection " +
+                                "handling. Construct the connection provider in the declared mode instead.");
+                    }
+                    // The declaration only governs Storm's built-in JDBC connection handling. Silently
+                    // replacing a discovered platform provider would change how connections bind to the
+                    // platform's transaction subsystem, so a non-default resolution fails fast instead.
+                    var discovered = Providers.getConnectionProvider();
+                    if (!(discovered instanceof JdbcConnectionProviderImpl)) {
+                        throw new PersistenceException(
+                                "A manual-commit declaration only applies to Storm's built-in JDBC connection " +
+                                "handling, but connection provider discovery resolved " +
+                                discovered.getClass().getName() + ". Configure that provider for " +
+                                "manual-commit connections instead.");
+                    }
+                    effectiveConnectionProvider = new JdbcConnectionProviderImpl(true);
+                }
+                template = new PreparedStatementTemplateImpl(dataSource, config, effectiveConnectionProvider,
                         transactionTemplateProvider, exceptionMapper, queryObserver, sqlCommenter);
             } else {
                 if (connectionProvider != null) {
                     throw new PersistenceException(
                             "A connection provider cannot be configured for a connection backed template.");
+                }
+                if (manualCommitConnections) {
+                    throw new PersistenceException(
+                            "A manual-commit declaration cannot be configured for a connection backed template.");
                 }
                 assert connection != null;
                 template = new PreparedStatementTemplateImpl(connection, config,

--- a/storm-core/src/test/java/st/orm/core/spi/ManualCommitConnectionsTest.java
+++ b/storm-core/src/test/java/st/orm/core/spi/ManualCommitConnectionsTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.core.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static st.orm.core.template.TemplateString.raw;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
+import st.orm.PersistenceException;
+import st.orm.TransactionPropagation;
+import st.orm.core.template.ORMTemplate;
+
+/**
+ * Tests for the manual-commit connection declaration: verified arrival state in both directions, flip-free
+ * transactional handling on declared pools, and explicit commit handling on the non-transactional paths.
+ */
+public class ManualCommitConnectionsTest {
+
+    private static DataSource h2DataSource;
+
+    @BeforeAll
+    static void setUp() throws SQLException {
+        h2DataSource = org.springframework.boot.jdbc.DataSourceBuilder.create()
+                .url("jdbc:h2:mem:manualCommitConnections;DB_CLOSE_DELAY=-1")
+                .username("sa")
+                .password("")
+                .driverClassName("org.h2.Driver")
+                .build();
+        try (var connection = h2DataSource.getConnection(); var statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE IF NOT EXISTS manual_city (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255))");
+        }
+    }
+
+    @BeforeEach
+    void resetTable() throws SQLException {
+        try (var connection = h2DataSource.getConnection(); var statement = connection.createStatement()) {
+            statement.execute("DELETE FROM manual_city");
+        }
+    }
+
+    /**
+     * A pool that hands out connections in a configurable auto-commit state, tracking the auto-commit flips
+     * Storm performs after handout and the auto-commit state each connection is released in.
+     */
+    static final class TrackingDataSource extends DelegatingDataSource {
+        final boolean manualCommitHandout;
+        final AtomicInteger autoCommitFlips = new AtomicInteger();
+        final List<Boolean> releasedAutoCommitStates = new ArrayList<>();
+
+        TrackingDataSource(DataSource target, boolean manualCommitHandout) {
+            super(target);
+            this.manualCommitHandout = manualCommitHandout;
+        }
+
+        void resetTracking() {
+            autoCommitFlips.set(0);
+            releasedAutoCommitStates.clear();
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            var connection = super.getConnection();
+            // The handout flip below happens on the raw connection, so the proxy counts only the flips
+            // performed after handout.
+            if (manualCommitHandout) {
+                connection.setAutoCommit(false);
+            }
+            return (Connection) Proxy.newProxyInstance(
+                    Connection.class.getClassLoader(),
+                    new Class<?>[] { Connection.class },
+                    (proxy, method, args) -> {
+                        if (method.getName().equals("setAutoCommit")) {
+                            autoCommitFlips.incrementAndGet();
+                        }
+                        if (method.getName().equals("close")) {
+                            releasedAutoCommitStates.add(connection.getAutoCommit());
+                        }
+                        try {
+                            return method.invoke(connection, args);
+                        } catch (InvocationTargetException e) {
+                            throw e.getTargetException();
+                        }
+                    });
+        }
+    }
+
+    private static ORMTemplate declaredTemplate(TrackingDataSource dataSource) {
+        var template = ORMTemplate.builder(dataSource)
+                .connectionProvider(new JdbcConnectionProviderImpl(true))
+                .transactionTemplateProvider(new JdbcTransactionTemplateProviderImpl())
+                .build();
+        dataSource.resetTracking(); // Building the template probes a connection for dialect detection.
+        return template;
+    }
+
+    private static ORMTemplate undeclaredTemplate(TrackingDataSource dataSource) {
+        var template = ORMTemplate.builder(dataSource)
+                .connectionProvider(new JdbcConnectionProviderImpl())
+                .transactionTemplateProvider(new JdbcTransactionTemplateProviderImpl())
+                .build();
+        dataSource.resetTracking();
+        return template;
+    }
+
+    private static <R> R inTransaction(TransactionRunner.Block<R, RuntimeException> block) {
+        return inTransaction(null, block);
+    }
+
+    private static <R> R inTransaction(TransactionPropagation propagation,
+                                       TransactionRunner.Block<R, RuntimeException> block) {
+        return TransactionRunner.execute(
+                new TransactionScope.Options(propagation, null, null, null, false), block);
+    }
+
+    private static int countRows() throws SQLException {
+        try (var connection = h2DataSource.getConnection();
+             var statement = connection.createStatement();
+             var resultSet = statement.executeQuery("SELECT COUNT(*) FROM manual_city")) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        }
+    }
+
+    private static void assertMessageChainContains(Throwable thrown, String text) {
+        for (var current = thrown; current != null; current = current.getCause()) {
+            if (current.getMessage() != null && current.getMessage().contains(text)) {
+                return;
+            }
+        }
+        throw new AssertionError("Expected message containing '" + text + "', got: " + thrown);
+    }
+
+    @Test
+    public void transactionCommitsWithoutFlipsOnDeclaredManualCommitPool() throws SQLException {
+        var pool = new TrackingDataSource(h2DataSource, true);
+        var orm = declaredTemplate(pool);
+        inTransaction(ignore -> orm.query(raw("INSERT INTO manual_city (name) VALUES ('Amsterdam')")).executeUpdate());
+        assertEquals(1, countRows());
+        assertEquals(0, pool.autoCommitFlips.get(),
+                "The declared transactional path must not flip auto-commit.");
+        assertEquals(List.of(false), pool.releasedAutoCommitStates,
+                "The connection must be released in its arrived manual-commit state.");
+    }
+
+    @Test
+    public void transactionRollsBackOnDeclaredManualCommitPool() throws SQLException {
+        var pool = new TrackingDataSource(h2DataSource, true);
+        var orm = declaredTemplate(pool);
+        assertThrows(IllegalStateException.class, () -> inTransaction(ignore -> {
+            orm.query(raw("INSERT INTO manual_city (name) VALUES ('Utrecht')")).executeUpdate();
+            throw new IllegalStateException("fail the block");
+        }));
+        assertEquals(0, countRows(), "The failed block must be rolled back, not committed per statement.");
+        assertEquals(0, pool.autoCommitFlips.get());
+        assertEquals(List.of(false), pool.releasedAutoCommitStates);
+    }
+
+    @Test
+    public void declaredTemplateFailsFastOnAutoCommitPool() {
+        var pool = new TrackingDataSource(h2DataSource, false);
+        var orm = declaredTemplate(pool);
+        var transactional = assertThrows(PersistenceException.class,
+                () -> inTransaction(ignore -> orm.query(raw("SELECT id FROM manual_city")).getResultList()));
+        assertMessageChainContains(transactional, "declares manual-commit connections");
+        var nonTransactional = assertThrows(PersistenceException.class,
+                () -> orm.query(raw("SELECT id FROM manual_city")).getResultList());
+        assertMessageChainContains(nonTransactional, "declares manual-commit connections");
+    }
+
+    @Test
+    public void undeclaredTemplateFailsFastOnManualCommitPool() throws SQLException {
+        var pool = new TrackingDataSource(h2DataSource, true);
+        var orm = undeclaredTemplate(pool);
+        var transactional = assertThrows(PersistenceException.class,
+                () -> inTransaction(ignore -> orm.query(raw("SELECT id FROM manual_city")).getResultList()));
+        assertMessageChainContains(transactional, "manualCommitConnections()");
+        var nonTransactional = assertThrows(PersistenceException.class,
+                () -> orm.query(raw("INSERT INTO manual_city (name) VALUES ('Rotterdam')")).executeUpdate());
+        assertMessageChainContains(nonTransactional, "manualCommitConnections()");
+        assertEquals(0, countRows(), "No statement may execute on an unverified manual-commit connection.");
+    }
+
+    @Test
+    public void nonTransactionalWriteCommitsOnDeclaredManualCommitPool() throws SQLException {
+        var pool = new TrackingDataSource(h2DataSource, true);
+        var orm = declaredTemplate(pool);
+        orm.query(raw("INSERT INTO manual_city (name) VALUES ('Eindhoven')")).executeUpdate();
+        assertEquals(1, countRows(),
+                "A non-transactional write must commit; the pool would roll back an uncommitted statement.");
+        assertEquals(List.of(false), pool.releasedAutoCommitStates,
+                "The connection must be restored to its arrived manual-commit state before release.");
+    }
+
+    @Test
+    public void notSupportedScopeCommitsImmediatelyOnDeclaredManualCommitPool() throws SQLException {
+        var pool = new TrackingDataSource(h2DataSource, true);
+        var orm = declaredTemplate(pool);
+        assertThrows(IllegalStateException.class, () -> inTransaction(ignore -> {
+            orm.query(raw("INSERT INTO manual_city (name) VALUES ('inside-transaction')")).executeUpdate();
+            inTransaction(TransactionPropagation.NOT_SUPPORTED, nested ->
+                    orm.query(raw("INSERT INTO manual_city (name) VALUES ('outside-transaction')")).executeUpdate());
+            throw new IllegalStateException("fail the outer block");
+        }));
+        try (var connection = h2DataSource.getConnection();
+             var statement = connection.createStatement();
+             var resultSet = statement.executeQuery("SELECT name FROM manual_city")) {
+            assertTrue(resultSet.next());
+            assertEquals("outside-transaction", resultSet.getString(1),
+                    "The NOT_SUPPORTED write must survive the outer rollback.");
+            assertFalse(resultSet.next(), "The transactional write must be rolled back.");
+        }
+    }
+
+    @Test
+    public void declarationRejectedWithCustomConnectionProvider() {
+        var builder = ORMTemplate.builder(h2DataSource)
+                .connectionProvider(new JdbcConnectionProviderImpl())
+                .manualCommitConnections();
+        var thrown = assertThrows(PersistenceException.class, builder::build);
+        assertMessageChainContains(thrown, "cannot be combined with a custom connection provider");
+    }
+
+    @Test
+    public void declarationRejectedForConnectionBackedTemplate() throws SQLException {
+        try (var connection = h2DataSource.getConnection()) {
+            var builder = ORMTemplate.builder(connection).manualCommitConnections();
+            var thrown = assertThrows(PersistenceException.class, builder::build);
+            assertMessageChainContains(thrown, "connection backed template");
+        }
+    }
+
+    @Test
+    public void declarationRejectedWhenDiscoveryResolvesPlatformProvider() {
+        // The test classpath registers a @BeforeAny platform provider that wins discovery; the declaration only
+        // governs the built-in JDBC provider and must fail fast rather than silently replace the platform's
+        // connection handling.
+        var builder = ORMTemplate.builder(h2DataSource).manualCommitConnections();
+        var thrown = assertThrows(PersistenceException.class, builder::build);
+        assertMessageChainContains(thrown, "TestSpringConnectionProvider");
+    }
+}

--- a/storm-java21/src/main/java/st/orm/template/ORMTemplate.java
+++ b/storm-java21/src/main/java/st/orm/template/ORMTemplate.java
@@ -394,6 +394,27 @@ public interface ORMTemplate extends QueryTemplate, RepositoryLookup {
         }
 
         /**
+         * Declares that the data source hands out connections with auto-commit disabled.
+         *
+         * <p>The declared mode is verified in both directions: a declared template that receives an auto-commit
+         * connection fails fast naming the misdeclaration, exactly like an undeclared template that receives a
+         * manual-commit one. With the declaration in place, the transactional path performs no auto-commit flips
+         * and releases connections in their arrived state; non-transactional connections get auto-commit enabled
+         * while Storm uses them and restored before release, so each statement still commits.</p>
+         *
+         * <p>Cannot be combined with a custom {@link #connectionProvider(st.orm.core.spi.ConnectionProvider)
+         * connection provider} and only valid for data source backed templates; {@link #build()} fails fast
+         * otherwise.</p>
+         *
+         * @return this builder.
+         * @since 1.14
+         */
+        public Builder manualCommitConnections() {
+            core.manualCommitConnections();
+            return this;
+        }
+
+        /**
          * Sets the transaction template provider used by the template to participate in transactions.
          *
          * <p>Templates that should share transactions must be configured with the <em>same provider instance</em>.</p>

--- a/storm-kotlin/src/main/kotlin/st/orm/template/ORMTemplate.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/ORMTemplate.kt
@@ -357,6 +357,22 @@ public interface ORMTemplate :
         public fun connectionProvider(connectionProvider: st.orm.core.spi.ConnectionProvider): Builder = apply { core.connectionProvider(connectionProvider) }
 
         /**
+         * Declares that the data source hands out connections with auto-commit disabled.
+         *
+         * The declared mode is verified in both directions: a declared template that receives an auto-commit
+         * connection fails fast naming the misdeclaration, exactly like an undeclared template that receives a
+         * manual-commit one. With the declaration in place, the transactional path performs no auto-commit flips
+         * and releases connections in their arrived state; non-transactional connections get auto-commit enabled
+         * while Storm uses them and restored before release, so each statement still commits.
+         *
+         * Cannot be combined with a custom [connectionProvider] and only valid for data source backed templates;
+         * [build] fails fast otherwise.
+         *
+         * @since 1.14
+         */
+        public fun manualCommitConnections(): Builder = apply { core.manualCommitConnections() }
+
+        /**
          * Sets the transaction template provider used by the template to participate in transactions.
          *
          * Templates that should share transactions must be configured with the *same provider instance*.

--- a/storm-kotlin/src/test/kotlin/st/orm/template/ManualCommitConnectionsTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/ManualCommitConnectionsTest.kt
@@ -1,0 +1,93 @@
+package st.orm.template
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.h2.jdbcx.JdbcDataSource
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import st.orm.PersistenceException
+import java.sql.Connection
+import javax.sql.DataSource
+
+/**
+ * Tests for [ORMTemplate.Builder.manualCommitConnections]: the declaration resolves against the built-in JDBC
+ * connection handling and makes Storm-managed transactions work on a pool that hands out manual-commit
+ * connections, with the misdeclared combinations failing fast in both directions.
+ */
+internal class ManualCommitConnectionsTest {
+
+    private val h2 = JdbcDataSource().apply {
+        setURL("jdbc:h2:mem:manualCommitConnections;DB_CLOSE_DELAY=-1")
+        user = "sa"
+    }
+
+    @BeforeEach
+    fun resetTable() {
+        h2.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute("CREATE TABLE IF NOT EXISTS manual_city (id INTEGER AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255))")
+                statement.execute("DELETE FROM manual_city")
+            }
+        }
+    }
+
+    /**
+     * A pool that hands out connections with auto-commit disabled.
+     */
+    private class ManualCommitDataSource(private val target: DataSource) : DataSource by target {
+        override fun getConnection(): Connection = target.connection.apply { autoCommit = false }
+    }
+
+    private fun countRows(): Int = h2.connection.use { connection ->
+        connection.createStatement().use { statement ->
+            statement.executeQuery("SELECT COUNT(*) FROM manual_city").use { resultSet ->
+                resultSet.next()
+                resultSet.getInt(1)
+            }
+        }
+    }
+
+    @Test
+    fun `declared template commits transactional work on a manual-commit pool`() {
+        val orm = ORMTemplate.builder(ManualCommitDataSource(h2)).manualCommitConnections().build()
+        transactionBlocking {
+            orm.query("INSERT INTO manual_city (name) VALUES ('Amsterdam')").executeUpdate()
+        }
+        countRows() shouldBe 1
+    }
+
+    @Test
+    fun `declared template rolls back transactional work on a manual-commit pool`() {
+        val orm = ORMTemplate.builder(ManualCommitDataSource(h2)).manualCommitConnections().build()
+        assertThrows<IllegalStateException> {
+            transactionBlocking {
+                orm.query("INSERT INTO manual_city (name) VALUES ('Utrecht')").executeUpdate()
+                error("fail the block")
+            }
+        }
+        countRows() shouldBe 0
+    }
+
+    @Test
+    fun `declared template fails fast on an auto-commit pool`() {
+        val orm = ORMTemplate.builder(h2).manualCommitConnections().build()
+        val thrown = assertThrows<PersistenceException> {
+            transactionBlocking {
+                orm.query("SELECT id FROM manual_city").resultList
+            }
+        }
+        thrown.message shouldContain "declares manual-commit connections"
+    }
+
+    @Test
+    fun `undeclared template fails fast on a manual-commit pool`() {
+        val orm = ORMTemplate.builder(ManualCommitDataSource(h2)).build()
+        val thrown = assertThrows<PersistenceException> {
+            transactionBlocking {
+                orm.query("SELECT id FROM manual_city").resultList
+            }
+        }
+        thrown.message shouldContain "manualCommitConnections()"
+    }
+}


### PR DESCRIPTION
Fixes #450.

Storm-managed transactions require connections to arrive from the DataSource in auto-commit mode and fail fast otherwise; a pool deliberately configured to hand out manual-commit connections (for example HikariCP with `autoCommit=false`, saving the two `setAutoCommit` round trips per transaction) could not be used with the transaction API at all.

`ORMTemplate.builder(dataSource).manualCommitConnections()` declares that mode, mirrored on the Java and Kotlin builders. The declaration resolves to the built-in JDBC connection provider in declared mode; `JdbcConnectionProviderImpl(true)` is the constructor form for integrations that wire the provider themselves.

Behavior:

- The declared mode is verified in both directions on every fresh connection. A declared template that receives an auto-commit connection fails fast naming the misdeclaration, exactly like an undeclared template that receives a manual-commit one; a trusted-but-wrong declaration would commit transactional work per statement and turn rollback into a no-op. The undeclared precondition message now names the declaration as the fix.
- In declared mode the transactional path performs no auto-commit flips and releases connections in their arrived state, so the pool gets back exactly what it handed out. Auto-commit restoration on release is captured per frame (`originalAutoCommit`), following the existing isolation/read-only pattern.
- The non-transactional paths (plain statements and SUPPORTS/NOT_SUPPORTED/NEVER scopes) enable auto-commit while Storm uses the connection and restore the arrived state before release, so each statement still commits; on a manual-commit pool an uncommitted non-transactional write would otherwise be rolled back by the pool on release, which is silent data loss. These paths now verify the arrival state instead of forcing auto-commit on, so an undeclared manual-commit pool fails fast here too instead of losing writes.
- The cursor-streaming path needs no change: inside a transaction auto-commit is already off, and outside one it operates on the auto-commit state Storm establishes at acquisition.
- Builder validation fails fast when the declaration is combined with a custom connection provider, with a connection-backed template, or when provider discovery resolves a platform connection provider; the declaration only governs Storm's built-in JDBC connection handling.
- The failed-precondition paths in `openNewTransaction`/`openConnection` now close the freshly obtained connection instead of leaking it.

Tests cover the full matrix in storm-core (declared/undeclared x manual/auto-commit pool, transactional commit and rollback, non-transactional commit handling, NOT_SUPPORTED scope, builder validations, released-state and flip-count assertions) and the builder declaration end-to-end in storm-kotlin.

Docs: new "Manual-Commit Connection Pools" section in docs/transactions.md; visible at /docs/next until the next release snapshot.