### PR TITLE
fix: Ktor plugin closes only the pools it created and tolerates eager DI resolution failures

### DIFF
--- a/docs/ktor-integration.md
+++ b/docs/ktor-integration.md
@@ -134,7 +134,7 @@ install(Storm) {
 | `autoRegisterRepositories` | `true` | Registers all repository interfaces from the compile-time type index during installation, so `repository<T>()` works without further setup. |
 | `repositories(...)` | All indexed | Narrows repository auto-registration to the given packages (including sub-packages). |
 
-When the application stops, the plugin automatically closes the DataSource if it is a HikariDataSource that the plugin created. If you provide your own DataSource, manage its lifecycle yourself.
+When the application stops, the plugin automatically closes the connection pools it created from configuration. If you provide your own DataSource, the plugin never closes it; manage its lifecycle yourself.
 
 ---
 

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
@@ -122,7 +122,11 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
 
     // ---- Primary database ----
 
-    val dataSource = pluginConfig.dataSource ?: createDataSourceFromConfig(application)
+    // Ownership is decided at creation: only pools the plugin builds from configuration are closed at
+    // shutdown, never a user-supplied instance.
+    val ownedDataSources = mutableListOf<DataSource>()
+    val dataSource = pluginConfig.dataSource
+        ?: createDataSourceFromConfig(application).also { ownedDataSources += it }
     val stormConfig = pluginConfig.config ?: readStormConfig(application)
 
     // Run the migration hook (e.g., Flyway) before the ORM template is created and the schema is
@@ -170,6 +174,7 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
         val name = databaseConfig.name
         val databaseDataSource = databaseConfig.dataSource
             ?: createDataSourceFromConfig(application, "storm.databases.$name.datasource")
+                .also { ownedDataSources += it }
         val databaseStormConfig = databaseConfig.config
             ?: readStormConfig(application, "storm.databases.$name")
         databaseConfig.migration?.invoke(databaseDataSource)
@@ -226,9 +231,16 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
         // deferred that the container cancels at shutdown, logging a spurious "Exception during cleanup"
         // warning for the key and each of its covariant supertype keys. Resolving every provided key once
         // at startup completes those deferreds. The instances already exist, so this creates nothing.
+        // Resolution failures stay per key: this loop only suppresses shutdown noise, so a key nothing in
+        // the application ever resolves (an ambiguous covariant repository key, for example) must not abort
+        // startup, which is what an exception thrown through Events.raise would do.
         application.monitor.subscribe(ApplicationStarted) {
             for (providedKey in providedKeys) {
-                application.dependencies.getBlocking<Any?>(providedKey)
+                try {
+                    application.dependencies.getBlocking<Any?>(providedKey)
+                } catch (e: Throwable) {
+                    application.log.debug("Eager resolution of $providedKey failed; the key stays lazily resolvable.", e)
+                }
             }
         }
     }
@@ -315,10 +327,9 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
         }
     }
 
-    // Register shutdown hook to close the DataSources that are managed HikariDataSources.
+    // Close the pools the plugin created; user-supplied data sources stay under the caller's control.
     application.monitor.subscribe(ApplicationStopped) {
-        closeDataSourceIfManaged(dataSource)
-        namedDataSources.values.forEach { closeDataSourceIfManaged(it) }
+        ownedDataSources.forEach { closeOwnedDataSource(it) }
     }
 }
 

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormDataSource.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormDataSource.kt
@@ -69,10 +69,13 @@ internal fun createDataSourceFromConfig(application: Application, path: String =
 }
 
 /**
- * Closes the [DataSource] if it is a [HikariDataSource] (managed by the plugin).
+ * Closes a [DataSource] the plugin created from configuration.
+ *
+ * Ownership is decided at creation time: only pools the plugin built itself are closed at shutdown, never a
+ * user-supplied instance. The close goes through [AutoCloseable], which the created pool type implements; this
+ * keeps the shutdown path free of pool-implementation classes, which are provided scope and may be absent at
+ * runtime when every data source is user-supplied.
  */
-internal fun closeDataSourceIfManaged(dataSource: DataSource) {
-    if (dataSource is HikariDataSource) {
-        dataSource.close()
-    }
+internal fun closeOwnedDataSource(dataSource: DataSource) {
+    (dataSource as? AutoCloseable)?.close()
 }

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormPluginTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormPluginTest.kt
@@ -15,6 +15,7 @@ import io.ktor.server.testing.testApplication
 import org.junit.jupiter.api.Test
 import st.orm.ktor.model.PetType
 import st.orm.template.ORMTemplate
+import javax.sql.DataSource
 
 class StormPluginTest {
 
@@ -349,5 +350,49 @@ class StormPluginTest {
                 expected.message shouldBe "Storm plugin is not installed. Call install(Storm) in your application module."
             }
         }
+    }
+
+    @Test
+    fun `user-supplied data source is not closed at shutdown`() {
+        val dataSource = createTestDataSource()
+        initializeSchema(dataSource)
+        try {
+            testApplication {
+                application {
+                    install(Storm) {
+                        this.dataSource = dataSource
+                    }
+                }
+                startApplication()
+            }
+            dataSource.isClosed shouldBe false
+            // The pool must remain usable after the application stopped.
+            dataSource.connection.use { }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `plugin-created data source is closed at shutdown`() {
+        lateinit var created: DataSource
+        testApplication {
+            environment {
+                config = MapApplicationConfig(
+                    "storm.datasource.jdbcUrl" to "jdbc:h2:mem:storm-owned-${System.nanoTime()};DB_CLOSE_DELAY=-1",
+                    "storm.datasource.driverClassName" to "org.h2.Driver",
+                    "storm.datasource.username" to "sa",
+                    "storm.datasource.password" to "",
+                )
+            }
+            application {
+                install(Storm) {
+                    schemaValidation = "none"
+                }
+                created = stormDataSource
+            }
+            startApplication()
+        }
+        (created as HikariDataSource).isClosed shouldBe true
     }
 }


### PR DESCRIPTION
Fixes #398.

Three lifecycle defects in the Ktor plugin:

- `closeDataSourceIfManaged` closed any `HikariDataSource`, including user-supplied ones, contradicting the documented contract ("that the plugin created"). Ownership is now decided at creation: the plugin records the pools it builds from configuration (primary and named databases) and the shutdown hook closes only those.
- The shutdown path needed the `HikariDataSource` class to resolve even when every data source was user-supplied, so a runtime without HikariCP (which is provided scope) threw `NoClassDefFoundError`, swallowed at DEBUG by Ktor's `safeRaiseEvent`. The ownership-based close goes through `AutoCloseable`, keeping pool-implementation classes out of the shutdown path entirely; they are only touched on the creation path, where they are present by construction.
- The eager DI resolution loop resolves every provided key on `ApplicationStarted` to suppress spurious cleanup warnings at shutdown, but `ApplicationStarted` is raised through plain `Events.raise`, so a resolution failure (an ambiguous covariant repository key, for example) aborted application start for a key nothing in the app ever needed. Failures are now caught per key and logged at DEBUG; the key stays lazily resolvable.

Tests pin the ownership contract in both directions: a user-supplied pool survives shutdown and stays usable, and a configuration-created pool is closed. The per-key guard has no deterministic trigger on the Ktor version in use (covariant-key ambiguity appears with Ktor 3.4.3 and later).

docs/ktor-integration.md now states the ownership rule; visible at /docs/next until the next release snapshot.