### PR TITLE
docs: align copy with the accepted Java preview state and the actual toolchain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,10 +69,10 @@ storm-framework/
 
 ## Code Formatting
 
-Storm uses [Spotless](https://github.com/diffplug/spotless) to enforce consistent code formatting across the project. Formatting is checked automatically in CI and can be enforced locally with a git pre-push hook.
+Storm uses [Spotless](https://github.com/diffplug/spotless) to enforce consistent code formatting across the project. Formatting is checked automatically in CI and can be enforced locally with a git pre-commit hook.
 
 - **Kotlin** is formatted with [ktlint](https://github.com/pinterest/ktlint) (Kotlin coding conventions)
-- **Java** is formatted with [Palantir Java Format](https://github.com/palantir/palantir-java-format) (4-space indentation)
+- **Java** is checked for import order, unused imports, trailing whitespace, and a final newline; beyond that, follow the formatting of the surrounding code (4-space indentation)
 
 ### Auto-fix formatting
 
@@ -86,9 +86,9 @@ mvn spotless:apply
 mvn spotless:check
 ```
 
-### Set up the pre-push hook
+### Set up the pre-commit hook
 
-To automatically check formatting before every push:
+To automatically check formatting before every commit:
 
 ```bash
 git config core.hooksPath .githooks

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Docs](https://img.shields.io/badge/docs-orm.st-blue)](https://orm.st)
 [![Kotlin 2.0+](https://img.shields.io/badge/Kotlin-2.0%2B-purple)](https://kotlinlang.org/)
-[![Java 21+](https://img.shields.io/badge/Java-21%2B-blue)](https://openjdk.org/projects/jdk/21/)
+[![Java 21](https://img.shields.io/badge/Java-21-blue)](https://openjdk.org/projects/jdk/21/)
 
-**Storm is the type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21+.** Immutable data-class entities, one-line queries checked at compile time, and none of the machinery you fight in traditional ORMs: no proxies, no N+1, no persistence context.
+**Storm is the type-safe, SQL-first ORM for Kotlin 2.0+ and Java 21.** Immutable data-class entities, one-line queries checked at compile time, and none of the machinery you fight in traditional ORMs: no proxies, no N+1, no persistence context.
 
 ```kotlin
 // An entity is a data class. This is the whole mapping.
@@ -250,9 +250,9 @@ Storm works with any JDBC-compatible database. Dialect packages provide optimize
 ## Requirements
 
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.0%2B-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white)](https://kotlinlang.org/)
-[![Java](https://img.shields.io/badge/Java-21%2B-ED8B00?style=for-the-badge&logo=openjdk&logoColor=white)](https://openjdk.org/)
+[![Java](https://img.shields.io/badge/Java-21-ED8B00?style=for-the-badge&logo=openjdk&logoColor=white)](https://openjdk.org/)
 
-Storm targets Kotlin 2.0+ and Java 21+ as minimum supported versions. These baselines will be maintained for the foreseeable future.
+Storm targets Kotlin 2.0+ as its minimum supported Kotlin version; the Kotlin path runs on JDK 21 or later. The Java API uses String Templates, a preview feature, and preview class files are version-locked: the Java path compiles and runs on JDK 21 exactly until the platform reintroduces string templates as a stable feature. See [String Templates](https://orm.st/docs/string-templates#status) for the full story.
 
 ## Contributing
 

--- a/docs/api-java.md
+++ b/docs/api-java.md
@@ -20,7 +20,7 @@ The main Java API module. It provides the `ORMTemplate` entry point, repository 
 </dependency>
 ```
 
-**String Templates (Preview Feature):** The Java API uses JDK String Templates for SQL construction. String Templates are a preview feature in Java 21+, which means you must compile with `--enable-preview` and run with `--enable-preview`. The preview status means the syntax may change in future JDK releases, and Storm's Java API surface will adapt accordingly. The Kotlin API does not depend on any preview features and is fully stable.
+**String Templates (Preview Feature):** The Java API uses JDK String Templates for SQL construction. String Templates are a preview feature, which means you must compile and run with `--enable-preview`, on JDK 21 exactly: preview class files are version-locked to the JDK that compiled them. The preview status means the syntax may change in future JDK releases, and Storm's Java API surface will adapt accordingly. The Kotlin API does not depend on any preview features and is fully stable.
 
 To enable preview features in Maven:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Get Started
 
-Storm is a modern SQL Template and ORM framework for Kotlin 2.0+ and Java 21+. It uses immutable data classes and records instead of proxied entities, giving you predictable behavior, type-safe queries, and high performance.
+Storm is a modern SQL Template and ORM framework for Kotlin 2.0+ and Java 21. It uses immutable data classes and records instead of proxied entities, giving you predictable behavior, type-safe queries, and high performance.
 
 ## Choose Your Path
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Storm
 
-**Storm** is an ORM for Kotlin 2.0+ and Java 21+, built on a SQL template engine. It aims for simplicity, type safety, and predictable performance, through immutable models and metadata generated at compile time.
+**Storm** is an ORM for Kotlin 2.0+ and Java 21, built on a SQL template engine. It aims for simplicity, type safety, and predictable performance, through immutable models and metadata generated at compile time.
 
 **Key benefits:**
 
@@ -235,7 +235,7 @@ See [Database Dialects](dialects.md) for installation and configuration details.
 
 ## Requirements
 
-- Kotlin 2.0+ or Java 21+
+- Kotlin 2.0+ (JDK 21 or later), or Java on JDK 21 exactly (the Java API uses preview class files, which are version-locked)
 - Maven 3.9+ or Gradle 8+
 
 ## Glossary

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,12 +9,13 @@ This page covers everything you need to add Storm to your project: prerequisites
 
 | Requirement | Version |
 |-------------|---------|
-| JDK | 21 or later |
+| JDK (Kotlin path) | 21 or later |
+| JDK (Java path) | 21 exactly; preview class files are version-locked |
 | Kotlin (if using Kotlin) | 2.0 or later |
 | Build tool | Maven 3.9+ or Gradle 8+ |
 | Database | Any JDBC-compatible database |
 
-Kotlin users do not need any preview flags. Java users must enable `--enable-preview` in their compiler configuration because the Java API uses String Templates (JEP 430).
+Kotlin users do not need any preview flags. Java users must enable `--enable-preview` on compilation, tests, and execution because the Java API uses String Templates (JEP 430), and must build and run on a JDK 21 toolchain: preview class files only load on the JDK that compiled them.
 
 ## Gradle Plugin (Recommended)
 
@@ -83,10 +84,28 @@ Storm provides a Bill of Materials (BOM) for centralized version management. Imp
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
 
+**Gradle (Kotlin DSL):**
+
 ```kotlin
 dependencies {
     implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
 }
+```
+
+**Maven:**
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>st.orm</groupId>
+            <artifactId>storm-bom</artifactId>
+            <version>@@STORM_VERSION@@</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
 ```
 
 </TabItem>
@@ -124,9 +143,12 @@ dependencies {
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
 
+**Gradle (Kotlin DSL):**
+
 ```kotlin
 plugins {
-    id("com.google.devtools.ksp") version "2.0.21-1.0.28"
+    kotlin("jvm") version "2.4.0"
+    id("com.google.devtools.ksp") version "2.3.10"
 }
 
 dependencies {
@@ -135,11 +157,49 @@ dependencies {
     implementation("st.orm:storm-kotlin")
     runtimeOnly("st.orm:storm-core")
     ksp("st.orm:storm-metamodel-ksp")
-    kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
+    kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.4")
 }
 ```
 
-The `storm-metamodel-ksp` dependency generates type-safe metamodel classes (e.g., `User_`, `City_`) at compile time. See [Metamodel](metamodel.md) for details. The `storm-compiler-plugin` automatically wraps string interpolations inside SQL template lambdas, making queries injection-safe by default. The `2.0` suffix matches the Kotlin major.minor version used in your project (e.g., `storm-compiler-plugin-2.1` for Kotlin 2.1.x). See [String Templates](string-templates.md) for details.
+The `storm-metamodel-ksp` dependency generates type-safe metamodel classes (e.g., `User_`, `City_`) at compile time. See [Metamodel](metamodel.md) for details. The `storm-compiler-plugin` automatically wraps string interpolations inside SQL template lambdas, making queries injection-safe by default. The suffix matches the Kotlin major.minor version used in your project: `storm-compiler-plugin-2.4` for Kotlin 2.4.x, `storm-compiler-plugin-2.1` for Kotlin 2.1.x, and so on. See [String Templates](string-templates.md) for details.
+
+**Maven:**
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>st.orm</groupId>
+        <artifactId>storm-kotlin</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>st.orm</groupId>
+        <artifactId>storm-core</artifactId>
+        <scope>runtime</scope>
+    </dependency>
+</dependencies>
+```
+
+Configure the Kotlin compiler with the Storm compiler plugin on its classpath; the plugin registers itself:
+
+```xml
+<plugin>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-maven-plugin</artifactId>
+    <version>${kotlin.version}</version>
+    <configuration>
+        <jvmTarget>21</jvmTarget>
+    </configuration>
+    <dependencies>
+        <dependency>
+            <groupId>st.orm</groupId>
+            <artifactId>storm-compiler-plugin-2.4</artifactId>
+            <version>@@STORM_VERSION@@</version>
+        </dependency>
+    </dependencies>
+</plugin>
+```
+
+As in the Gradle setup, the compiler-plugin suffix follows your Kotlin major.minor version. Metamodel generation runs through KSP, which ships first-party build integration for Gradle only; Maven projects wire KSP through a community extension such as [kotlin-maven-symbol-processing](https://github.com/Dyescape/kotlin-maven-symbol-processing), with `st.orm:storm-metamodel-ksp` as the processor. The KClass-based query API works without generated metamodels.
 
 </TabItem>
 <TabItem value="java" label="Java">
@@ -196,6 +256,18 @@ Enable preview features for String Templates (JEP 430):
         <compilerArgs>
             <arg>--enable-preview</arg>
         </compilerArgs>
+    </configuration>
+</plugin>
+```
+
+Tests run in a forked JVM that needs the flag as well; without it, every test run fails at class load. Add it to surefire (and to failsafe, if you run integration tests):
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <configuration>
+        <argLine>--enable-preview</argLine>
     </configuration>
 </plugin>
 ```

--- a/docs/metamodel.md
+++ b/docs/metamodel.md
@@ -47,11 +47,11 @@ The [Storm Gradle plugin](installation.md#gradle-plugin-recommended) configures 
 
 ```kotlin
 plugins {
-    id("com.google.devtools.ksp") version "2.0.21-1.0.28"
+    id("com.google.devtools.ksp") version "2.3.10"
 }
 
 dependencies {
-    ksp("st.orm:storm-metamodel-processor:@@STORM_VERSION@@")
+    ksp("st.orm:storm-metamodel-ksp:@@STORM_VERSION@@")
 }
 ```
 

--- a/docs/sql-templates.md
+++ b/docs/sql-templates.md
@@ -44,7 +44,7 @@ orm.query(RAW."""
     WHERE \{User_.email} = \{email}""")
 ```
 
-> **Note:** Java string templates are a preview feature. Storm for Java requires Java 21+ with preview mode enabled (`--enable-preview`). Storm will adapt to the final string template specification once it's released.
+> **Note:** Java string templates are a preview feature. Storm for Java requires JDK 21 exactly with preview mode enabled (`--enable-preview`); preview class files are version-locked. Storm's Java API will adapt to whatever shape the platform ultimately gives the feature.
 
 </TabItem>
 </Tabs>

--- a/docs/string-templates.md
+++ b/docs/string-templates.md
@@ -17,7 +17,7 @@ Both Kotlin and Java provide language-level string interpolation that Storm leve
 |---|---|---|
 | **Syntax** | `$variable` or `${expression}` | `\{expression}` |
 | **Mechanism** | Compiler plugin (auto-wraps interpolations) | String Templates (preview feature) |
-| **Status** | Stable (Kotlin 2.0+) | Preview (Java 21+, evolving) |
+| **Status** | Stable (Kotlin 2.0+) | Preview (JDK 21 exactly) |
 | **Module** | `storm-kotlin` | `storm-java21` |
 
 ---
@@ -213,7 +213,7 @@ The `\{expression}` syntax is Java's string template interpolation. The `RAW` pr
 
 Java String Templates are a **preview feature** that is still evolving in the JDK. Storm is a forward-looking framework, and String Templates are the best way to write SQL in Java that is both readable and injection-safe by design.
 
-Rather than wait for the feature to stabilize, Storm ships with String Template support today. The Java API is production-ready from a quality perspective, but its API surface will adapt as String Templates move toward a stable release. Once the redesigned string templates land in the JDK as a stable feature, the Java API moves front and center alongside Kotlin: same first-class status, no preview flags, no version pin.
+Rather than wait for the feature to stabilize, Storm ships with String Template support today. The Java API is production-ready from a quality perspective, but its API surface will adapt to whatever shape the platform ultimately gives the feature. If the JDK reintroduces string templates as a stable feature, the Java API moves front and center alongside Kotlin: same first-class status, no preview flags, no version pin. Until then, the preview pin applies: preview class files are version-locked, so the Java path compiles and runs on JDK 21 exactly.
 
 Only `storm-java21` depends on this preview feature. The core framework and the Kotlin API are unaffected.
 


### PR DESCRIPTION
Fixes #408.

The Java surface stays on String Templates until the platform reintroduces them; the copy now matches that accepted state everywhere it spoke:

- README stated "Java 21+" in the badge, the tagline, and the compatibility section, while preview class files run on JDK 21 exactly; a JDK 25 user following the README fails at runtime. All three now state Java 21, and the compatibility section explains the version lock and links to the String Templates status page. The same correction is applied to the equivalent claims in docs/index.md, docs/getting-started.md, docs/api-java.md, docs/sql-templates.md, and the status table in docs/string-templates.md.
- docs/string-templates.md promised a stable landing for the preview feature; the wording is now conditional on the platform, and states the JDK 21 pin that applies until then.
- docs/installation.md showed `--enable-preview` on the Maven compiler plugin only; without it in the surefire argLine every test run fails at class load. Both are documented now, and the prerequisites table distinguishes the Kotlin path (JDK 21+) from the Java path (JDK 21 exactly).
- docs/installation.md gains a Maven setup for the Kotlin path: BOM import, dependencies, and the kotlin-maven-plugin wiring with the Storm compiler plugin on its classpath, mirroring how this repository builds its own Kotlin modules with Maven. Metamodel generation is stated honestly: KSP ships first-party build integration for Gradle only; Maven projects go through a community KSP extension, and the KClass-based API works without generated metamodels.
- The manual Gradle section pinned `ksp 2.0.21-1.0.28` and `storm-compiler-plugin-2.0` while the plugin section above uses Kotlin 2.4.0 / KSP 2.3.10; the manual sections now match, with the version-suffix rule spelled out. docs/metamodel.md had the same stale KSP pin and additionally wired the wrong artifact (`storm-metamodel-processor`, the javac half) on the `ksp` configuration; it now uses `storm-metamodel-ksp`.
- CONTRIBUTING.md claimed Java is formatted with Palantir Java Format; Spotless only enforces import order, unused imports, and whitespace for Java, which is what the text says now. The hook is `.githooks/pre-commit`; both "pre-push" references are corrected.

Not touched here: the "Java 21+" phrasings in `website/docusaurus.config.ts` (tagline) and `website/scripts/generate-llms-full.sh` (header) — both files are modified by the open #464, so these two lines follow after it merges to avoid a conflict.

Verified with a full local website build (docs are MDX-compiled at build time): passes.