### PR TITLE
ci: job timeouts, concurrency, pinned database images, JDK guard, website and CLI PR coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Watches the dependency surfaces that previously drifted unwatched: the Maven
+# build (Spring Boot, Kotlin, hardcoded tool versions), the workflow actions,
+# and the two npm trees (website, CLI). Monthly cadence keeps the PR noise low.
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+  - package-ecosystem: npm
+    directory: /storm-cli
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,16 @@ on:
 permissions:
   contents: read
 
+# Rapid pushes to a PR queue duplicate runs; supersede them. Runs on main keep
+# going so every merge commit gets its coverage upload.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository
@@ -47,3 +54,20 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
           fail_ci_if_error: true
+
+  # The CLI ships to users via npx but is plain JavaScript with no compile step,
+  # so at minimum its syntax must be checked before merge.
+  cli-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Syntax-check the CLI
+        run: node --check storm-cli/storm.mjs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -119,6 +120,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url || steps.deploy-retry.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
       contents: read   # Checkout only; deploy auth comes from Central/GPG secrets, not GITHUB_TOKEN.
 
@@ -66,6 +67,7 @@ jobs:
 
   publish-npm:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       id-token: write   # Required for npm trusted publishing (OIDC).
       contents: read
@@ -102,6 +104,7 @@ jobs:
 
   publish-gradle-plugin:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: publish            # The plugin references st.orm artifacts of the same version on Central.
     permissions:
       contents: read
@@ -134,6 +137,7 @@ jobs:
 
   version-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: publish
     permissions:
       contents: write
@@ -189,6 +193,7 @@ jobs:
   # version they pin current so "Use this template" always starts on the release.
   sync-example-templates:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: publish-gradle-plugin
     # Pushes go through RELEASE_TOKEN, not the default GITHUB_TOKEN, so this job
     # needs no permissions on its own repository.

--- a/.github/workflows/website-pr.yml
+++ b/.github/workflows/website-pr.yml
@@ -1,0 +1,41 @@
+name: Website PR Build
+
+# docs.yml deploys on push to main only, so a change that breaks the Docusaurus
+# build used to surface after merge. This build-only job catches it on the PR.
+on:
+  pull_request:
+    paths:
+      - 'website/**'
+      - 'docs/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install website dependencies
+        run: npm ci
+        working-directory: website
+
+      # Without the Javadoc/KDoc static trees that docs.yml generates; this job
+      # validates the Docusaurus compile and the link check, not /api content.
+      - name: Build Docusaurus
+        run: npm run build
+        working-directory: website

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,29 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>require-jdk-21</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- storm-java21 compiles with the enable-preview flag, and preview compilation
+                                     only works on the matching JDK release; any other default JDK fails with a
+                                     confusing compiler error instead of this sentence. -->
+                                <requireJavaVersion>
+                                    <version>[21,22)</version>
+                                    <message>Storm builds on JDK 21 exactly: storm-java21 uses preview features, and preview compilation requires the matching JDK release.</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
             </plugin>

--- a/storm-mariadb/docker-compose.yml
+++ b/storm-mariadb/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mariadb:
-    image: mariadb:latest
+    image: mariadb:11.8
     platform: ${DOCKER_PLATFORM:-linux/arm64/v8}
     container_name: mariadb-db
     ports:

--- a/storm-oracle/docker-compose.yml
+++ b/storm-oracle/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   oracle:
-    image: gvenzl/oracle-free:latest
+    image: gvenzl/oracle-free:23
     platform: ${DOCKER_PLATFORM:-linux/arm64/v8}
     container_name: oracle-db
     ports:

--- a/storm-postgresql/docker-compose.yml
+++ b/storm-postgresql/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:17
     platform: ${DOCKER_PLATFORM:-linux/arm64/v8}
     container_name: postgres-db
     ports:


### PR DESCRIPTION
Fixes #413.

- Every job in every workflow now carries `timeout-minutes` (ci build 60, cli-check 5, docs build 45, docs deploy 15, website PR build 30, and the five release jobs at 90/15/45/30/15), so a hung image pull or backend stall no longer burns hours of runner time.
- `ci.yml` gets a `concurrency` group: superseded runs on a PR branch are cancelled, runs on main are never cancelled so every merge commit keeps its coverage upload.
- The dialect databases that floated on `latest` are pinned at the same granularity the already-pinned ones use: `postgres:17`, `mariadb:11.8`, `gvenzl/oracle-free:23` (MySQL was already at 9.2, MSSQL at 2019-latest). An upstream major can no longer break the dialect tests overnight with no repo change.
- The parent pom enforces JDK 21 with an enforcer `requireJavaVersion [21,22)` rule on every module: building on any other default JDK now fails at validate with one clear sentence instead of a confusing preview-flag compiler error. Verified in both directions locally: passes on JDK 21, fails with the message on JDK 17.
- New `website-pr.yml`: a build-only Docusaurus job on pull requests that touch `website/**` or `docs/**`, so a change that breaks the site build is caught before merge instead of on the main deploy. It builds without the Javadoc/KDoc static trees; it validates the Docusaurus compile and link check, not `/api` content.
- New `cli-check` job in `ci.yml`: `node --check storm-cli/storm.mjs` on every run, the first CI coverage the 3,000-line user-executed CLI has.
- New `.github/dependabot.yml` watching the Maven build, the workflow actions, and both npm trees (website, CLI) on a monthly cadence.

Left out deliberately: `project.build.outputTimestamp` for reproducible builds. It interacts with the flatten plugin and the tag-driven release pipeline, so it deserves its own verified change rather than riding along here.