### PR TITLE
chore: core internals sweep: comparator naming, join-derivation context, publication invariant, silent close

### DIFF
--- a/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
+++ b/storm-core/src/main/java/st/orm/core/repository/impl/EntityRepositoryImpl.java
@@ -2310,7 +2310,9 @@ public class EntityRepositoryImpl<E extends Entity<ID>, ID>
         queries.forEach(query -> {
             try {
                 query.close();
-            } catch (Exception ignore) {}
+            } catch (Exception e) {
+                LOGGER.debug("Failed to close prepared query.", e);
+            }
         });
     }
 

--- a/storm-core/src/main/java/st/orm/core/template/impl/EqualitySupport.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/EqualitySupport.java
@@ -32,14 +32,14 @@ public final class EqualitySupport {
     private EqualitySupport() {}
 
     /**
-     * Compiles an {@link Same} implementation for the given field getter.
+     * Compiles a {@link ValueComparator} implementation for the given field getter.
      *
      * <p>The handle is expected to behave like {@code (receiverType) -> returnType}. If your handle has a different
      * shape, adapt it before calling this method.</p>
      *
      * <p>No boxing is performed for primitive return types.</p>
      */
-    public static <T> Same<T> compileIsSame(MethodHandle handle) {
+    public static <T> ValueComparator<T> compileIsSame(MethodHandle handle) {
         requireNonNull(handle, "handle");
         Class<?> r = handle.type().returnType();
         if (r == int.class) {
@@ -115,14 +115,14 @@ public final class EqualitySupport {
     }
 
     /**
-     * Compiles an {@link Identical} implementation for the given field getter.
+     * Compiles an {@link IdentityComparator} implementation for the given field getter.
      *
      * <p>Identity comparison is only defined for reference-typed fields. For primitive return types this method wraps
      * the isSame implementation.
      *
      * <p>No boxing is performed.</p>
      */
-    public static <T> Identical<T> compileIsIdentical(MethodHandle handle) {
+    public static <T> IdentityComparator<T> compileIsIdentical(MethodHandle handle) {
         requireNonNull(handle, "handle");
         Class<?> r = handle.type().returnType();
         if (r.isPrimitive()) {

--- a/storm-core/src/main/java/st/orm/core/template/impl/IdentityComparator.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/IdentityComparator.java
@@ -17,17 +17,18 @@ package st.orm.core.template.impl;
 
 
 /**
- * Value comparison on an extracted field value.
+ * Identity comparison on an extracted field value.
  *
- * <p>Implementations must not perform boxing or coercion for primitive-typed fields.</p>
+ * <p>Implementations must not perform boxing or coercion for primitive-typed fields. For primitive-typed fields,
+ * identity comparison is not defined and must be rejected at construction time.</p>
  *
  * @since 1.7
  */
 @FunctionalInterface
-public interface Same<T> {
+public interface IdentityComparator<T> {
 
     /**
-     * Returns {@code true} if and only if the value extracted from {@code a} and {@code b} is equal by value.
+     * Returns {@code true} if and only if the value extracted from {@code a} and {@code b} is the same object instance.
      */
-    boolean isSame(T a, T b) throws Throwable;
+    boolean isIdentical(T a, T b) throws Throwable;
 }

--- a/storm-core/src/main/java/st/orm/core/template/impl/MetamodelFactory.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/MetamodelFactory.java
@@ -88,7 +88,7 @@ public final class MetamodelFactory {
      * Creates a new metamodel for the given record type.
      */
     private static <T extends Data> Metamodel<T, T> getRootModel(Class<T> table) {
-        Same<T> wrapped = null;
+        ValueComparator<T> wrapped = null;
         if (Data.class.isAssignableFrom(table)) {
             var pkField = findPkField(table).orElse(null);
             if (pkField != null) {
@@ -97,7 +97,7 @@ public final class MetamodelFactory {
                 wrapped = s::isSame;
             }
         }
-        Same<T> same = wrapped == null ? Objects::equals : wrapped;
+        ValueComparator<T> same = wrapped == null ? Objects::equals : wrapped;
         return new AbstractMetamodel<>(table) {
             @Override
             public T getValue(T record) {
@@ -682,8 +682,8 @@ public final class MetamodelFactory {
         private final Class<T> root;
         private final Metamodel<T, ? extends Data> table;
         private final MethodHandle handle;
-        private final Identical<T> identical;
-        private final Same<T> same;
+        private final IdentityComparator<T> identical;
+        private final ValueComparator<T> same;
 
         SimpleKeyMetamodel(Class<T> root,
                            String path,
@@ -699,7 +699,7 @@ public final class MetamodelFactory {
             this.table = table;
             this.handle = handle;
             this.identical = EqualitySupport.compileIsIdentical(handle);
-            Same<T> wrapped = null;
+            ValueComparator<T> wrapped = null;
             if (Data.class.isAssignableFrom(fieldType)) {
                 var pkField = findPkField(fieldType).orElse(null);
                 if (pkField != null) {
@@ -786,8 +786,8 @@ public final class MetamodelFactory {
         private final Class<T> root;
         private final Metamodel<T, ? extends Data> table;
         private final MethodHandle handle;
-        private final Identical<T> identical;
-        private final Same<T> same;
+        private final IdentityComparator<T> identical;
+        private final ValueComparator<T> same;
 
         SimpleMetamodel(Class<T> root,
                         String path,
@@ -802,7 +802,7 @@ public final class MetamodelFactory {
             this.table = table;
             this.handle = handle;
             this.identical = EqualitySupport.compileIsIdentical(handle);
-            Same<T> wrapped = null;
+            ValueComparator<T> wrapped = null;
             if (Data.class.isAssignableFrom(fieldType)) {
                 var pkField = findPkField(fieldType).orElse(null);
                 if (pkField != null) {

--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlInterceptorManager.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlInterceptorManager.java
@@ -35,7 +35,6 @@ import st.orm.core.template.StatementOrigin;
  *
  * @since 1.1
  */
-@SuppressWarnings("ALL")
 public final class SqlInterceptorManager {
 
     /** Shared identity customizer; lets callers recognize operators that do not customize the template. */

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplatePreparation.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplatePreparation.java
@@ -812,7 +812,8 @@ class TemplatePreparation {
         // When demandOnly is set, only referenced foreign keys are joined (the hydrated graph is not expanded), so
         // the recursion starts already beyond the eager region.
         if (!isSealedEntity(table)) {
-            addAutoJoins(getRecordType(table), table, rootTable, List.of(), aliasMapper, tableMapper, joins, null, false, referenced, demandOnly);
+            var context = new AutoJoinContext(rootTable, aliasMapper, tableMapper, joins, referenced);
+            deriveAutoJoins(getRecordType(table), table, List.of(), null, false, demandOnly, context);
         } else if (!demandOnly && isJoinedEntity(table)) {
             // For JOINED inheritance, add LEFT JOIN for each extension table (permitted subclass with
             // @DbTable) using PK=PK ON conditions.
@@ -882,6 +883,19 @@ class TemplatePreparation {
     }
 
     /**
+     * The arguments of an auto-join derivation that stay fixed across the recursion: the root the mappings are
+     * registered against, the mappers that receive them, the output join list, and the query's referenced paths.
+     * Bundling them leaves the genuinely varying traversal state visible in the recursive signature.
+     */
+    private record AutoJoinContext(
+            Class<? extends Data> rootTable,
+            AliasMapper aliasMapper,
+            TableMapper tableMapper,
+            List<Join> joins,
+            ReferencedPaths referenced) {
+    }
+
+    /**
      * Recursively derives joins and alias mappings for a record type graph.
      *
      * <p>{@link FK} fields trigger join generation. {@link Ref} foreign keys do not generate a join, but they register
@@ -890,28 +904,27 @@ class TemplatePreparation {
      *
      * @param type        the current record type.
      * @param table       the current table type.
-     * @param rootTable   the root table for mapping purposes.
      * @param path        the current record field path.
-     * @param aliasMapper alias mapper used for alias lookup and generation.
-     * @param tableMapper table mapper used for mapping foreign keys.
-     * @param joins       output list that receives derived joins.
      * @param fkName      the alias to use as the join source for nested traversal, or {@code null}.
      * @param outerJoin   whether joins in this subtree must be outer joins due to a nullable ancestor.
+     * @param beyondRef   whether the traversal is below a reference boundary, where joins are demand-driven.
+     * @param context     the arguments that stay fixed across the recursion.
      * @throws SqlTemplateException if derivation fails.
      */
-    private void addAutoJoins(
+    private void deriveAutoJoins(
             RecordType type,
             Class<? extends Data> table,
-            Class<? extends Data> rootTable,
             List<RecordField> path,
-            AliasMapper aliasMapper,
-            TableMapper tableMapper,
-            List<Join> joins,
             @Nullable String fkName,
             boolean outerJoin,
-            ReferencedPaths referenced,
-            boolean beyondRef
+            boolean beyondRef,
+            AutoJoinContext context
     ) throws SqlTemplateException {
+        var rootTable = context.rootTable();
+        var aliasMapper = context.aliasMapper();
+        var tableMapper = context.tableMapper();
+        var joins = context.joins();
+        var referenced = context.referenced();
         for (var field : type.fields()) {
             var list = new ArrayList<>(path);
             String fkPath = toPathString(path);
@@ -943,9 +956,8 @@ class TemplatePreparation {
                             boolean effectiveOuterJoin = outerJoin || field.nullable();
                             String alias = addForeignKeyJoin(table, rootTable, field, fieldType, fromAlias, fkPath,
                                     pkPath, effectiveOuterJoin, aliasMapper, tableMapper, joins);
-                            addAutoJoins(fieldType, fieldType.requireDataType(), rootTable, copy, aliasMapper,
-                                    tableMapper, joins, alias, effectiveOuterJoin, referenced,
-                                    !referenced.hydrated().contains(pkPath));
+                            deriveAutoJoins(fieldType, fieldType.requireDataType(), copy, alias,
+                                    effectiveOuterJoin, !referenced.hydrated().contains(pkPath), context);
                         }
                     }
                     continue;
@@ -982,7 +994,8 @@ class TemplatePreparation {
                 boolean effectiveOuterJoin = outerJoin || field.nullable();
                 String alias = addForeignKeyJoin(table, rootTable, field, fieldType, fromAlias, fkPath,
                         pkPath, effectiveOuterJoin, aliasMapper, tableMapper, joins);
-                addAutoJoins(fieldType, fieldType.requireDataType(), rootTable, copy, aliasMapper, tableMapper, joins, alias, effectiveOuterJoin, referenced, beyondRef && !referenced.hydrated().contains(pkPath));
+                deriveAutoJoins(fieldType, fieldType.requireDataType(), copy, alias, effectiveOuterJoin,
+                        beyondRef && !referenced.hydrated().contains(pkPath), context);
             } else if (isRecord(field.type())) {
                 if (field.isAnnotationPresent(PK.class) || getORMConverter(field).isPresent()) {
                     continue;
@@ -1005,7 +1018,7 @@ class TemplatePreparation {
                 } else {
                     fromAlias = fkName;
                 }
-                addAutoJoins(getRecordType(field.type()), table, rootTable, copy, aliasMapper, tableMapper, joins, fromAlias, outerJoin, referenced, beyondRef);
+                deriveAutoJoins(getRecordType(field.type()), table, copy, fromAlias, outerJoin, beyondRef, context);
             }
         }
     }

--- a/storm-core/src/main/java/st/orm/core/template/impl/TemplateProcessor.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/TemplateProcessor.java
@@ -65,7 +65,11 @@ import st.orm.core.template.impl.TemplatePreparation.PreparedTemplate;
  * consuming the previously recorded bind hints in the same order they were produced during compilation.</p>
  *
  * <p>The processor instance is safe to cache and reuse across threads. All mutable binding state is kept inside
- * {@link BindingSession}. Compile-time state is produced once and treated as immutable after compilation completes.</p>
+ * {@link BindingSession}. Compile-time state is produced once and treated as immutable after compilation completes.
+ * The compile-time fields are neither volatile nor final, so their cross-thread visibility rests entirely on the
+ * publication through {@link SegmentedLruCache}{@code .putIfAbsent}: its synchronized segments supply the
+ * happens-before edge between the compiling thread and every later reader. Publishing a processor to other threads
+ * through any channel without such an edge is unsafe.</p>
  *
  * @since 1.8
  */

--- a/storm-core/src/main/java/st/orm/core/template/impl/ValueComparator.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/ValueComparator.java
@@ -17,18 +17,17 @@ package st.orm.core.template.impl;
 
 
 /**
- * Identity comparison on an extracted field value.
+ * Value comparison on an extracted field value.
  *
- * <p>Implementations must not perform boxing or coercion for primitive-typed fields. For primitive-typed fields,
- * identity comparison is not defined and must be rejected at construction time.</p>
+ * <p>Implementations must not perform boxing or coercion for primitive-typed fields.</p>
  *
  * @since 1.7
  */
 @FunctionalInterface
-public interface Identical<T> {
+public interface ValueComparator<T> {
 
     /**
-     * Returns {@code true} if and only if the value extracted from {@code a} and {@code b} is the same object instance.
+     * Returns {@code true} if and only if the value extracted from {@code a} and {@code b} is equal by value.
      */
-    boolean isIdentical(T a, T b) throws Throwable;
+    boolean isSame(T a, T b) throws Throwable;
 }


### PR DESCRIPTION
Fixes #417.

Grouped internal-quality items in storm-core, none user-visible:

- `Identical` performed identity comparison and `Same` performed value comparison, the two most safety-critical predicates in dirty checking with names that read as each other's job. They are now `IdentityComparator` and `ValueComparator`. The `isIdentical`/`isSame` method names stay: they mirror the public metamodel methods they implement, and the issue's confusion sat in the type names.
- `TemplatePreparation`'s recursive join derivation took 11 parameters, five of which never change across the recursion. Those five (root table, alias mapper, table mapper, output joins, referenced paths) now travel in an `AutoJoinContext` record, and the recursive overload is renamed `deriveAutoJoins` so the entry point and the recursion no longer share a name at different arities. The recursive signature now shows only the genuinely varying traversal state (type, table, path, source alias, outer-join flag, beyond-ref flag); the body is unchanged.
- The cached `TemplateProcessor`'s class comment now states the publication invariant: its compile-time fields are neither volatile nor final, and cross-thread visibility rests on `SegmentedLruCache.putIfAbsent`, whose synchronized segments supply the happens-before edge. The invariant was correct but unstated, and is close to untestable if broken.
- `EntityRepositoryImpl.closeQuietly` swallowed close failures silently, the only silent catch in the module; it logs at debug now.
- `@SuppressWarnings("ALL")` on `SqlInterceptorManager` is removed rather than narrowed: a clean compile of the module produces no warning for the class, so there is nothing left to suppress; if an IDE inspection resurfaces something real, it can be suppressed at that specific site.

Full storm-core suite passes: 2624 tests.