### PR TITLE
chore: mark Kotlin test classes internal so editors stop applying explicit API mode to tests

### DIFF
--- a/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/DataStormTestSliceTest.kt
+++ b/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/DataStormTestSliceTest.kt
@@ -19,7 +19,7 @@ import st.orm.spring.boot.test.DataStormTest
  */
 @TestMethodOrder(OrderAnnotation::class)
 @DataStormTest
-class DataStormTestSliceTest(
+internal class DataStormTestSliceTest(
     @Autowired private val visitRepository: VisitRepository,
     @Autowired private val applicationContext: ApplicationContext,
 ) {

--- a/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/SliceTestApplication.kt
+++ b/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/SliceTestApplication.kt
@@ -3,4 +3,4 @@ package st.orm.spring.boot.autoconfigure
 import org.springframework.boot.autoconfigure.SpringBootApplication
 
 @SpringBootApplication
-open class SliceTestApplication
+internal open class SliceTestApplication

--- a/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.kt
+++ b/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/StormAutoConfigurationTest.kt
@@ -47,7 +47,7 @@ import st.orm.template.ORMTemplate
 import javax.sql.DataSource
 
 @ExtendWith(OutputCaptureExtension::class)
-class StormAutoConfigurationTest {
+internal class StormAutoConfigurationTest {
 
     private val contextRunner = ApplicationContextRunner()
         .withConfiguration(

--- a/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/slice/Visit.kt
+++ b/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/slice/Visit.kt
@@ -4,7 +4,7 @@ import st.orm.Entity
 import st.orm.PK
 
 @JvmRecord
-data class Visit(
+internal data class Visit(
     @PK val id: Int = 0,
     val description: String? = null,
 ) : Entity<Int>

--- a/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/slice/VisitRepository.kt
+++ b/storm-kotlin-spring-boot-starter/src/test/kotlin/st/orm/spring/boot/autoconfigure/slice/VisitRepository.kt
@@ -2,4 +2,4 @@ package st.orm.spring.boot.autoconfigure.slice
 
 import st.orm.repository.EntityRepository
 
-interface VisitRepository : EntityRepository<Visit, Int>
+internal interface VisitRepository : EntityRepository<Visit, Int>

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/AdditionalTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/AdditionalTest.kt
@@ -51,7 +51,7 @@ import st.orm.template.transactionBlocking
 @ContextConfiguration(classes = [SpringIntegrationConfig::class])
 @SpringBootTest
 @Sql("/data.sql")
-open class AdditionalTest(
+internal open class AdditionalTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/DualContextIsolationTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/DualContextIsolationTest.kt
@@ -28,7 +28,7 @@ import javax.sql.DataSource
  * JVM-global static state that the second context overwrote, so transactions could bind to the wrong manager and
  * standalone templates were silently hijacked by whichever Spring context refreshed last.
  */
-class DualContextIsolationTest {
+internal class DualContextIsolationTest {
 
     private val contexts = mutableListOf<AnnotationConfigApplicationContext>()
 

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/EnableStormRepositoriesTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/EnableStormRepositoriesTest.kt
@@ -17,7 +17,7 @@ import javax.sql.DataSource
  * Verifies that [EnableStormRepositories] binds repositories through the Kotlin adapter when
  * storm-kotlin-spring is on the classpath.
  */
-class EnableStormRepositoriesTest {
+internal class EnableStormRepositoriesTest {
 
     @Configuration
     open class DatabaseConfiguration {

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/IntegrationConfig.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/IntegrationConfig.kt
@@ -10,7 +10,7 @@ import javax.sql.DataSource
 
 @Configuration
 @EnableTransactionManagement
-open class IntegrationConfig {
+internal open class IntegrationConfig {
 
     @Bean
     open fun dataSource(): DataSource = DataSourceBuilder.create()

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/NullBeanNameRepositoryTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/NullBeanNameRepositoryTest.kt
@@ -23,7 +23,7 @@ import st.orm.spring.repository.VisitRepository
 @TestConstructor(autowireMode = ALL)
 @SpringBootTest
 @Sql("/data.sql")
-class NullBeanNameRepositoryTest(
+internal class NullBeanNameRepositoryTest(
     val visitRepository: VisitRepository,
 ) {
 

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryAdvancedTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryAdvancedTest.kt
@@ -41,7 +41,7 @@ import java.time.LocalDate
 @TestConstructor(autowireMode = ALL)
 @SpringBootTest
 @Sql("/data.sql")
-class RepositoryAdvancedTest(
+internal class RepositoryAdvancedTest(
     val visitRepository: VisitRepository,
     val orm: ORMTemplate,
 ) {

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryAutowireCandidateResolverTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryAutowireCandidateResolverTest.kt
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.support.AutowireCandidateResolver
  * Unit tests for [AbstractRepositoryBeanFactoryPostProcessor.RepositoryAutowireCandidateResolver]
  * delegation methods that are not exercised through integration tests.
  */
-class RepositoryAutowireCandidateResolverTest {
+internal class RepositoryAutowireCandidateResolverTest {
 
     private val delegate = mock(AutowireCandidateResolver::class.java)
     private val resolver = AbstractRepositoryBeanFactoryPostProcessor.RepositoryAutowireCandidateResolver(delegate)

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryBeanFactoryPostProcessorTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryBeanFactoryPostProcessorTest.kt
@@ -23,7 +23,7 @@ import st.orm.spring.kotlin.RepositoryBeanFactoryPostProcessor
 @TestConstructor(autowireMode = ALL)
 @SpringBootTest
 @Sql("/data.sql")
-class RepositoryBeanFactoryPostProcessorTest(
+internal class RepositoryBeanFactoryPostProcessorTest(
     val applicationContext: ApplicationContext,
 ) {
 

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryProxyTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryProxyTest.kt
@@ -35,7 +35,7 @@ import st.orm.template.ORMTemplate
 @TestConstructor(autowireMode = ALL)
 @SpringBootTest
 @Sql("/data.sql")
-class RepositoryProxyTest(
+internal class RepositoryProxyTest(
     val visitRepository: VisitRepository,
     val applicationContext: ApplicationContext,
 ) {

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryQualifierTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryQualifierTest.kt
@@ -28,7 +28,7 @@ import st.orm.spring.repository.VisitRepository
 @TestConstructor(autowireMode = ALL)
 @SpringBootTest
 @Sql("/data.sql")
-class RepositoryQualifierTest(
+internal class RepositoryQualifierTest(
     val applicationContext: ApplicationContext,
     @Qualifier("prefixed_") val prefixedVisitRepository: VisitRepository,
 ) {

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/RepositoryTest.kt
@@ -19,7 +19,7 @@ import st.orm.spring.repository.VisitRepository
 @TestConstructor(autowireMode = ALL)
 @SpringBootTest
 @Sql("/data.sql")
-class RepositoryTest(
+internal class RepositoryTest(
     val visitRepository: VisitRepository,
     val ownerRepositoryTest: OwnerRepository?,
     val applicationContext: ApplicationContext,

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/SpringIntegrationConfig.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/SpringIntegrationConfig.kt
@@ -13,7 +13,7 @@ import javax.sql.DataSource
  * [IntegrationConfig], whose template falls back to the platform-neutral providers.
  */
 @Configuration
-open class SpringIntegrationConfig : IntegrationConfig() {
+internal open class SpringIntegrationConfig : IntegrationConfig() {
 
     @Bean
     override fun ormTemplate(dataSource: DataSource): ORMTemplate = springOrmTemplate(dataSource) { listOf(transactionManager(dataSource)) }

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/SpringManagedTransactionTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/SpringManagedTransactionTest.kt
@@ -24,7 +24,7 @@ import st.orm.template.*
 @ContextConfiguration(classes = [SpringIntegrationConfig::class])
 @SpringBootTest
 @Sql("/data.sql")
-open class SpringManagedTransactionTest(
+internal open class SpringManagedTransactionTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/SpringTransactionContextTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/SpringTransactionContextTest.kt
@@ -30,7 +30,7 @@ import st.orm.template.*
 @ContextConfiguration(classes = [SpringIntegrationConfig::class])
 @SpringBootTest
 @Sql("/data.sql")
-open class SpringTransactionContextTest(
+internal open class SpringTransactionContextTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/TestRepositoryBeanFactoryPostProcessor.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/TestRepositoryBeanFactoryPostProcessor.kt
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration
 import st.orm.spring.kotlin.RepositoryBeanFactoryPostProcessor
 
 @Configuration
-open class TestRepositoryBeanFactoryPostProcessor : RepositoryBeanFactoryPostProcessor() {
+internal open class TestRepositoryBeanFactoryPostProcessor : RepositoryBeanFactoryPostProcessor() {
     override fun getOrmTemplateBeanName(): String = "ormTemplate"
 
     // Make platform wide repositories available as well in the context of the dataORMTemplate.

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/TransactionPropagationTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/TransactionPropagationTest.kt
@@ -29,7 +29,7 @@ import st.orm.template.*
 @ContextConfiguration(classes = [SpringIntegrationConfig::class])
 @SpringBootTest
 @Sql("/data.sql")
-open class TransactionPropagationTest(
+internal open class TransactionPropagationTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/TransactionTest.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/TransactionTest.kt
@@ -27,7 +27,7 @@ import kotlin.test.assertFalse
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @SpringBootTest
 @Sql("/data.sql")
-open class TransactionTest(
+internal open class TransactionTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Address.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Address.kt
@@ -6,7 +6,7 @@ import st.orm.FK
  * Simple business object representing an address.
  */
 @JvmRecord
-data class Address(
+internal data class Address(
     val address: String? = null,
     @FK val city: City? = null,
 )

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/City.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/City.kt
@@ -8,7 +8,7 @@ import st.orm.PK
  *
  */
 @JvmRecord
-data class City(
+internal data class City(
     @PK val id: Int = 0,
     val name: String,
 ) : Entity<Int>

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Owner.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Owner.kt
@@ -9,7 +9,7 @@ import st.orm.Version
  *
  */
 @JvmRecord
-data class Owner(
+internal data class Owner(
     @PK val id: Int = 0,
     override val firstName: String,
     override val lastName: String,

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Person.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Person.kt
@@ -3,7 +3,7 @@ package st.orm.spring.model
 /**
  * Simple domain object representing a person.
  */
-interface Person {
+internal interface Person {
     val name: String
         get() = "$firstName $lastName"
 

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Pet.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Pet.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
  * Simple business object representing a pet.
  */
 @JvmRecord
-data class Pet(
+internal data class Pet(
     @PK val id: Int = 0,
     val name: String,
     @Persist(updatable = false) val birthDate: LocalDate,

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/PetType.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/PetType.kt
@@ -8,7 +8,7 @@ import st.orm.PK
  * Can be Cat, Dog, Hamster...
  */
 @JvmRecord
-data class PetType(
+internal data class PetType(
     @PK(generation = GenerationStrategy.NONE) val id: Int = 0,
     val name: String,
 ) : Entity<Int>

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Vet.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Vet.kt
@@ -7,7 +7,7 @@ import st.orm.PK
  * Simple domain object representing a veterinarian.
  */
 @JvmRecord
-data class Vet(
+internal data class Vet(
     @PK val id: Int = 0,
     override val firstName: String,
     override val lastName: String,

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Visit.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/model/Visit.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
  * Simple domain object representing a visit.
  */
 @JvmRecord
-data class Visit(
+internal data class Visit(
     @PK val id: Int = 0,
     val visitDate: LocalDate,
     val description: String? = null,

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/repository/OwnerRepository.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/repository/OwnerRepository.kt
@@ -5,4 +5,4 @@ import st.orm.repository.EntityRepository
 import st.orm.spring.model.Owner
 
 @NoRepositoryBean
-interface OwnerRepository : EntityRepository<Owner, Int>
+internal interface OwnerRepository : EntityRepository<Owner, Int>

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/repository/PetMetamodel.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/repository/PetMetamodel.kt
@@ -5,5 +5,8 @@ import st.orm.Metamodel
 /**
  * Simulates a generated metamodel interface in the same package as repositories.
  * This should NOT be picked up by [st.orm.spring.RepositoryBeanFactoryPostProcessor].
+ *
+ * Deliberately has no code references: it is exercised through classpath scanning, and
+ * `RepositoryTest` asserts by bean name that no bean was registered for it.
  */
 internal interface PetMetamodel : Metamodel<st.orm.spring.model.Pet, st.orm.spring.model.Pet>

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/repository/PetMetamodel.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/repository/PetMetamodel.kt
@@ -6,4 +6,4 @@ import st.orm.Metamodel
  * Simulates a generated metamodel interface in the same package as repositories.
  * This should NOT be picked up by [st.orm.spring.RepositoryBeanFactoryPostProcessor].
  */
-interface PetMetamodel : Metamodel<st.orm.spring.model.Pet, st.orm.spring.model.Pet>
+internal interface PetMetamodel : Metamodel<st.orm.spring.model.Pet, st.orm.spring.model.Pet>

--- a/storm-kotlin-spring/src/test/kotlin/st/orm/spring/repository/VisitRepository.kt
+++ b/storm-kotlin-spring/src/test/kotlin/st/orm/spring/repository/VisitRepository.kt
@@ -3,4 +3,4 @@ package st.orm.spring.repository
 import st.orm.repository.EntityRepository
 import st.orm.spring.model.Visit
 
-interface VisitRepository : EntityRepository<Visit, Int>
+internal interface VisitRepository : EntityRepository<Visit, Int>

--- a/storm-kotlin/src/test/kotlin/com/example/scope/CallSitePlumbingTest.kt
+++ b/storm-kotlin/src/test/kotlin/com/example/scope/CallSitePlumbingTest.kt
@@ -29,7 +29,7 @@ import st.orm.template.recordSqlLog
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class CallSitePlumbingTest(
+internal open class CallSitePlumbingTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/com/example/scope/Plumbing.kt
+++ b/storm-kotlin/src/test/kotlin/com/example/scope/Plumbing.kt
@@ -19,6 +19,6 @@ suspend inline fun <T> throughDbLayer(crossinline block: suspend () -> T): T = p
  * A fan-out the way an application's database layer writes one: the work runs on another dispatcher, whose
  * stack starts at the dispatcher and goes straight into this file, with the caller nowhere on it.
  */
-suspend fun fetchAllOnDispatcher(orm: ORMTemplate): List<PetOwnerRef> = withContext(Dispatchers.Default + sqlLogContext()) {
+internal suspend fun fetchAllOnDispatcher(orm: ORMTemplate): List<PetOwnerRef> = withContext(Dispatchers.Default + sqlLogContext()) {
     orm.entity(PetOwnerRef::class).select().resultList
 }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/CompilerPluginTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/CompilerPluginTest.kt
@@ -31,7 +31,7 @@ import st.orm.template.model.Owner
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class CompilerPluginTest(
+internal open class CompilerPluginTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/ConnectionProviderTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/ConnectionProviderTest.kt
@@ -28,7 +28,7 @@ import javax.sql.DataSource
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class ConnectionProviderTest(
+internal open class ConnectionProviderTest(
     @Autowired val orm: ORMTemplate,
     @Autowired val dataSource: DataSource,
 ) {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/CustomRepositoryTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/CustomRepositoryTest.kt
@@ -26,7 +26,7 @@ import st.orm.template.model.OwnerView
  * `ORMReflectionImpl.execute()`, which in turn calls `findKotlinDefault()` and `scanMethods()`
  * to locate and invoke the static helper in `DefaultImpls`.
  */
-interface CityCustomRepo : EntityRepository<City, Int> {
+internal interface CityCustomRepo : EntityRepository<City, Int> {
 
     /**
      * Default method that delegates to [count].
@@ -52,7 +52,7 @@ interface CityCustomRepo : EntityRepository<City, Int> {
 /**
  * Custom ProjectionRepository with a Kotlin default method.
  */
-interface OwnerViewCustomRepo : ProjectionRepository<OwnerView, Int> {
+internal interface OwnerViewCustomRepo : ProjectionRepository<OwnerView, Int> {
 
     /**
      * Default method that delegates to [count].
@@ -78,7 +78,7 @@ interface OwnerViewCustomRepo : ProjectionRepository<OwnerView, Int> {
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class CustomRepositoryTest(
+internal open class CustomRepositoryTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/EntityCallbackObservedEntityTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/EntityCallbackObservedEntityTest.kt
@@ -19,7 +19,7 @@ import st.orm.template.model.Owner
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class EntityCallbackObservedEntityTest(
+internal open class EntityCallbackObservedEntityTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/EntityRepositoryTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/EntityRepositoryTest.kt
@@ -23,7 +23,7 @@ import st.orm.template.model.*
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class EntityRepositoryTest(
+internal open class EntityRepositoryTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/FlowTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/FlowTest.kt
@@ -15,7 +15,7 @@ import st.orm.template.model.Visit
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class FlowTest(
+internal open class FlowTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/FlowUtilsTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/FlowUtilsTest.kt
@@ -13,7 +13,7 @@ import st.orm.repository.impl.chunked
 import st.orm.repository.impl.flatMapConcat
 import st.orm.repository.impl.flattenConcat
 
-class FlowUtilsTest {
+internal class FlowUtilsTest {
 
     // chunked() tests
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/IntegrationConfig.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/IntegrationConfig.kt
@@ -9,7 +9,7 @@ import javax.sql.DataSource
 
 @Configuration
 @EnableTransactionManagement
-open class IntegrationConfig {
+internal open class IntegrationConfig {
 
     @Bean
     open fun dataSource(): DataSource = DataSourceBuilder.create()

--- a/storm-kotlin/src/test/kotlin/st/orm/template/InterpolationSafetyTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/InterpolationSafetyTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
  * execute without the [TemplateContext.autoInterpolation] marker: they model templates compiled without the plugin.
  * Lambdas declared in this module are transformed by the plugin during test compilation and carry the marker.
  */
-class InterpolationSafetyTest {
+internal class InterpolationSafetyTest {
 
     @Test
     fun `fail mode throws for a template without the plugin marker`() {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/JdbcTransactionContextTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/JdbcTransactionContextTest.kt
@@ -31,7 +31,7 @@ import st.orm.template.model.Visit
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class JdbcTransactionContextTest(
+internal open class JdbcTransactionContextTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/ModelTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/ModelTest.kt
@@ -18,7 +18,7 @@ import st.orm.template.model.*
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class ModelTest(
+internal open class ModelTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/ORMReflectionImplTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/ORMReflectionImplTest.kt
@@ -26,40 +26,40 @@ import java.lang.reflect.Proxy
 
 // Test interfaces with self-contained Kotlin default methods for scanMethods tests.
 
-interface ScanTestNoArgs {
+internal interface ScanTestNoArgs {
     fun greeting(): String = "hello"
 }
 
-interface ScanTestPrimitiveArgs {
+internal interface ScanTestPrimitiveArgs {
     fun add(a: Int, b: Int): Int = a + b
 }
 
-interface ScanTestNullableArgs {
+internal interface ScanTestNullableArgs {
     fun withDefault(name: String?): String = name ?: "default"
 }
 
-interface ScanTestCollectionArgs {
+internal interface ScanTestCollectionArgs {
     fun listSize(items: List<String>): Int = items.size
 }
 
-interface ScanTestReturnsUnit {
+internal interface ScanTestReturnsUnit {
     fun doNothing() {}
 }
 
-interface ScanTestOverloaded {
+internal interface ScanTestOverloaded {
     fun compute(a: Int): Int = a * 2
     fun compute(a: Int, b: Int): Int = a + b
 }
 
-interface ScanTestAbstractOnly {
+internal interface ScanTestAbstractOnly {
     fun abstractMethod(): String
 }
 
-interface ScanTestParent {
+internal interface ScanTestParent {
     fun value(): String = "parent"
 }
 
-interface ScanTestChild : ScanTestParent {
+internal interface ScanTestChild : ScanTestParent {
     override fun value(): String = "child"
 }
 
@@ -70,7 +70,7 @@ interface ScanTestChild : ScanTestParent {
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class ORMReflectionImplTest(
+internal open class ORMReflectionImplTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/ORMTemplateFactoryTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/ORMTemplateFactoryTest.kt
@@ -25,7 +25,7 @@ import javax.sql.DataSource
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class ORMTemplateFactoryTest(
+internal open class ORMTemplateFactoryTest(
     @Autowired val orm: ORMTemplate,
     @Autowired val dataSource: DataSource,
 ) {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/ORMTemplateTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/ORMTemplateTest.kt
@@ -24,7 +24,7 @@ import javax.sql.DataSource
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class ORMTemplateTest(
+internal open class ORMTemplateTest(
     @Autowired val orm: ORMTemplate,
     @Autowired val dataSource: DataSource,
 ) {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/PolymorphicTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/PolymorphicTest.kt
@@ -21,7 +21,7 @@ import st.orm.template.model.*
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class PolymorphicTest(
+internal open class PolymorphicTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/ProjectionRepositoryTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/ProjectionRepositoryTest.kt
@@ -27,7 +27,7 @@ import st.orm.template.model.*
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class ProjectionRepositoryTest(
+internal open class ProjectionRepositoryTest(
     @Autowired val orm: ORMTemplate,
 ) {
     @Suppress("UNCHECKED_CAST")

--- a/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
@@ -34,7 +34,7 @@ import kotlin.reflect.KClass
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class QueryBuilderTest(
+internal open class QueryBuilderTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/RecordValidationTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/RecordValidationTest.kt
@@ -16,7 +16,7 @@ import st.orm.repository.entity
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class RecordValidationTest(
+internal open class RecordValidationTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/RefFetchTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/RefFetchTest.kt
@@ -27,7 +27,7 @@ import st.orm.template.model.PetType
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class RefFetchTest(
+internal open class RefFetchTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/RefGraphTraversalTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/RefGraphTraversalTest.kt
@@ -90,7 +90,7 @@ private class AnimalRefMetamodel_generated<T : st.orm.Data>(
 }
 
 /** A self-referential entity. Its `parent` reference points back at the table that declares it. */
-data class SelfNode(
+internal data class SelfNode(
     @PK val id: Int = 0,
     @FK val parent: Ref<SelfNode>? = null,
 ) : Entity<Int>
@@ -164,7 +164,7 @@ private class SelfNodeRefMetamodel_generated<T : st.orm.Data>(
     }
 }
 
-class RefGraphTraversalTest {
+internal class RefGraphTraversalTest {
 
     @Test
     fun `self-referential reference metamodel constructs without recursing`() {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/RefsAndKeysTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/RefsAndKeysTest.kt
@@ -20,7 +20,7 @@ import st.orm.template.model.*
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class RefsAndKeysTest(
+internal open class RefsAndKeysTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/RepositoryTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/RepositoryTest.kt
@@ -27,7 +27,7 @@ import st.orm.template.model.*
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class RepositoryTest(
+internal open class RepositoryTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/SchemaValidationTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/SchemaValidationTest.kt
@@ -19,7 +19,7 @@ import javax.sql.DataSource
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class SchemaValidationTest(
+internal open class SchemaValidationTest(
     @Autowired val orm: ORMTemplate,
     @Autowired val dataSource: DataSource,
 ) {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/SqlDslTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/SqlDslTest.kt
@@ -27,7 +27,7 @@ import st.orm.template.model.Visit
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class SqlDslTest(
+internal open class SqlDslTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/SqlLogTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/SqlLogTest.kt
@@ -37,7 +37,7 @@ import st.orm.core.template.SqlLog as CoreSqlLog
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class SqlLogTest(
+internal open class SqlLogTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/StormTestExtensionTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/StormTestExtensionTest.kt
@@ -25,7 +25,7 @@ import st.orm.test.StormTest
 import javax.sql.DataSource
 
 @StormTest(scripts = ["/data.sql"])
-class StormTestExtensionTest {
+internal class StormTestExtensionTest {
 
     @Test
     fun `data source should be injected`(dataSource: DataSource) {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/TemplateStringTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/TemplateStringTest.kt
@@ -15,7 +15,7 @@ import st.orm.template.model.*
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class TemplateStringTest(
+internal open class TemplateStringTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/TemplatesTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/TemplatesTest.kt
@@ -25,7 +25,7 @@ import javax.sql.DataSource
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class TemplatesTest(
+internal open class TemplatesTest(
     @Autowired val orm: ORMTemplate,
     @Autowired val dataSource: DataSource,
 ) {
@@ -941,4 +941,4 @@ open class TemplatesTest(
 /**
  * Custom repository interface for testing ORMTemplateImpl proxy creation.
  */
-interface CityRepository : st.orm.repository.EntityRepository<City, Int>
+internal interface CityRepository : st.orm.repository.EntityRepository<City, Int>

--- a/storm-kotlin/src/test/kotlin/st/orm/template/TransactionCallbackTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/TransactionCallbackTest.kt
@@ -21,7 +21,7 @@ import st.orm.template.model.Visit
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class TransactionCallbackTest(
+internal open class TransactionCallbackTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/TransactionDispatchersTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/TransactionDispatchersTest.kt
@@ -16,7 +16,7 @@ import st.orm.template.impl.VirtualThreadDispatcher
  * - System property handling
  * - shutdown()
  */
-class TransactionDispatchersTest {
+internal class TransactionDispatchersTest {
 
     @AfterEach
     fun restoreDefault() {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/TransactionTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/TransactionTest.kt
@@ -26,7 +26,7 @@ import kotlin.test.assertFalse
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class TransactionTest(
+internal open class TransactionTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/WriteSetTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/WriteSetTest.kt
@@ -31,7 +31,7 @@ import java.time.LocalDateTime
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @Sql("/data.sql")
-open class WriteSetTest(
+internal open class WriteSetTest(
     @Autowired val orm: ORMTemplate,
 ) {
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/impl/VirtualThreadDispatcherTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/impl/VirtualThreadDispatcherTest.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.EmptyCoroutineContext
 
-class VirtualThreadDispatcherTest {
+internal class VirtualThreadDispatcherTest {
 
     @Test
     fun `constructor with default thread name prefix should create dispatcher`() {

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Address.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Address.kt
@@ -5,7 +5,7 @@ import st.orm.FK
 /**
  * Simple business object representing an address.
  */
-data class Address(
+internal data class Address(
     val address: String? = null,
     @FK val city: City? = null,
 )

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Animal.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Animal.kt
@@ -9,25 +9,25 @@ import st.orm.Ref
 
 @Discriminator
 @DbTable("animal")
-sealed interface Animal : Entity<Int> {
+internal sealed interface Animal : Entity<Int> {
     val id: Int
     val name: String
 }
 
-data class Cat(
+internal data class Cat(
     @PK override val id: Int = 0,
     override val name: String,
     val indoor: Boolean,
 ) : Animal
 
-data class Dog(
+internal data class Dog(
     @PK override val id: Int = 0,
     override val name: String,
     val weight: Int,
 ) : Animal
 
 @DbTable("adoption")
-data class Adoption(
+internal data class Adoption(
     @PK val id: Int = 0,
     @FK val animal: Ref<Animal>,
 ) : Entity<Int>

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Appointment.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Appointment.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
  * Entity whose `scheduled_at` column is declared with second precision, so a database round-trip drops any
  * sub-second part of the in-memory value and the two representations are not structurally equal.
  */
-data class Appointment(
+internal data class Appointment(
     @PK val id: Int = 0,
     val description: String,
     val scheduledAt: LocalDateTime,

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/AppointmentReport.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/AppointmentReport.kt
@@ -10,7 +10,7 @@ import st.orm.PK
  * carries a column that does not round-trip bit-exact, operations on this entity must correlate by the key column
  * rather than by structural equality of the key entity.
  */
-data class AppointmentReport(
+internal data class AppointmentReport(
     @PK(generation = NONE) @FK("appointment_id") val appointment: Appointment,
     val report: String,
 ) : Entity<Appointment>

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/CharDiscAnimal.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/CharDiscAnimal.kt
@@ -8,17 +8,17 @@ import st.orm.PK
 
 @Discriminator(type = CHAR)
 @DbTable("char_disc_animal")
-sealed interface CharDiscAnimal : Entity<Int>
+internal sealed interface CharDiscAnimal : Entity<Int>
 
 @Discriminator("C")
-data class CharDiscCat(
+internal data class CharDiscCat(
     @PK val id: Int = 0,
     val name: String,
     val indoor: Boolean,
 ) : CharDiscAnimal
 
 @Discriminator("D")
-data class CharDiscDog(
+internal data class CharDiscDog(
     @PK val id: Int = 0,
     val name: String,
     val weight: Int,

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/City.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/City.kt
@@ -22,7 +22,7 @@ import st.orm.PK
  * Simple domain object representing an owner.
  *
  */
-data class City(
+internal data class City(
     @PK val id: Int = 0,
     val name: String,
 ) : Entity<Int>

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Commentable.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Commentable.kt
@@ -7,24 +7,24 @@ import st.orm.FK
 import st.orm.PK
 import st.orm.Ref
 
-sealed interface Commentable : Data
+internal sealed interface Commentable : Data
 
 @DbTable("post")
-data class Post(
+internal data class Post(
     @PK val id: Int = 0,
     val title: String,
 ) : Commentable,
     Entity<Int>
 
 @DbTable("photo")
-data class Photo(
+internal data class Photo(
     @PK val id: Int = 0,
     val url: String,
 ) : Commentable,
     Entity<Int>
 
 @DbTable("comment")
-data class Comment(
+internal data class Comment(
     @PK val id: Int = 0,
     val text: String,
     @FK val target: Ref<Commentable>,

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/IntDiscAnimal.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/IntDiscAnimal.kt
@@ -8,17 +8,17 @@ import st.orm.PK
 
 @Discriminator(type = INTEGER)
 @DbTable("int_disc_animal")
-sealed interface IntDiscAnimal : Entity<Int>
+internal sealed interface IntDiscAnimal : Entity<Int>
 
 @Discriminator("1")
-data class IntDiscCat(
+internal data class IntDiscCat(
     @PK val id: Int = 0,
     val name: String,
     val indoor: Boolean,
 ) : IntDiscAnimal
 
 @Discriminator("2")
-data class IntDiscDog(
+internal data class IntDiscDog(
     @PK val id: Int = 0,
     val name: String,
     val weight: Int,

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/JoinedAnimal.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/JoinedAnimal.kt
@@ -12,24 +12,24 @@ import st.orm.Ref
 @Discriminator
 @Polymorphic(JOINED)
 @DbTable("joined_animal")
-sealed interface JoinedAnimal : Entity<Int>
+internal sealed interface JoinedAnimal : Entity<Int>
 
 @DbTable("joined_cat")
-data class JoinedCat(
+internal data class JoinedCat(
     @PK val id: Int = 0,
     val name: String,
     val indoor: Boolean,
 ) : JoinedAnimal
 
 @DbTable("joined_dog")
-data class JoinedDog(
+internal data class JoinedDog(
     @PK val id: Int = 0,
     val name: String,
     val weight: Int,
 ) : JoinedAnimal
 
 @DbTable("joined_adoption")
-data class JoinedAdoption(
+internal data class JoinedAdoption(
     @PK val id: Int = 0,
     @FK val animal: Ref<JoinedAnimal>,
 ) : Entity<Int>

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/NodscAnimal.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/NodscAnimal.kt
@@ -8,27 +8,27 @@ import st.orm.Polymorphic.Strategy.JOINED
 
 @Polymorphic(JOINED)
 @DbTable("nodsc_animal")
-sealed interface NodscAnimal : Entity<Int> {
+internal sealed interface NodscAnimal : Entity<Int> {
     val id: Int
     val name: String
 }
 
 @DbTable("nodsc_cat")
-data class NodscCat(
+internal data class NodscCat(
     @PK override val id: Int = 0,
     override val name: String,
     val indoor: Boolean,
 ) : NodscAnimal
 
 @DbTable("nodsc_dog")
-data class NodscDog(
+internal data class NodscDog(
     @PK override val id: Int = 0,
     override val name: String,
     val weight: Int,
 ) : NodscAnimal
 
 @DbTable("nodsc_bird")
-data class NodscBird(
+internal data class NodscBird(
     @PK override val id: Int = 0,
     override val name: String,
 ) : NodscAnimal

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Owner.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Owner.kt
@@ -23,7 +23,7 @@ import st.orm.Version
  * Simple domain object representing an owner.
  *
  */
-data class Owner(
+internal data class Owner(
     @PK val id: Int = 0,
     override val firstName: String,
     override val lastName: String,

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/OwnerView.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/OwnerView.kt
@@ -6,7 +6,7 @@ import st.orm.Projection
 import st.orm.Version
 
 @DbTable("owner_view")
-data class OwnerView(
+internal data class OwnerView(
     @PK val id: Int = 0,
     val firstName: String,
     val lastName: String,

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Person.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Person.kt
@@ -18,7 +18,7 @@ package st.orm.template.model
 /**
  * Simple domain object representing a person.
  */
-interface Person {
+internal interface Person {
     val name: String
         get() = "$firstName $lastName"
 

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Pet.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Pet.kt
@@ -24,7 +24,7 @@ import java.time.LocalDate
 /**
  * Simple business object representing a pet.
  */
-data class Pet(
+internal data class Pet(
     @PK val id: Int = 0,
     val name: String,
     @Persist(updatable = false) val birthDate: LocalDate,

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/PetOwnerRef.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/PetOwnerRef.kt
@@ -15,7 +15,7 @@ import java.time.LocalDate
  * entity-graph baseline to compare a resolved reference against.
  */
 @DbTable("pet")
-data class PetOwnerRef(
+internal data class PetOwnerRef(
     @PK val id: Int = 0,
     val name: String,
     @Persist(updatable = false) val birthDate: LocalDate,

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/PetType.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/PetType.kt
@@ -22,7 +22,7 @@ import st.orm.PK
 /**
  * Can be Cat, Dog, Hamster...
  */
-data class PetType(
+internal data class PetType(
     @PK(generation = GenerationStrategy.NONE) val id: Int = 0,
     val name: String,
 ) : Entity<Int>

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Vet.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Vet.kt
@@ -21,7 +21,7 @@ import st.orm.PK
 /**
  * Simple domain object representing a veterinarian.
  */
-data class Vet(
+internal data class Vet(
     @PK val id: Int = 0,
     override val firstName: String,
     override val lastName: String,

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/Visit.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/Visit.kt
@@ -25,7 +25,7 @@ import java.time.LocalDate
 /**
  * Simple domain object representing a visit.
  */
-data class Visit(
+internal data class Visit(
     @PK val id: Int = 0,
     val visitDate: LocalDate,
     val description: String? = null,

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/IntegrationConfig.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/IntegrationConfig.kt
@@ -11,4 +11,4 @@ import org.springframework.transaction.annotation.EnableTransactionManagement
 @ComponentScan("st.orm.serialization")
 @EnableJpaRepositories
 @EnableTransactionManagement
-open class IntegrationConfig
+internal open class IntegrationConfig

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonIntegrationTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonIntegrationTest.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.json.Json as JsonMapper
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @DataJpaTest(showSql = false)
-open class JsonIntegrationTest(
+internal open class JsonIntegrationTest(
     @Autowired val dataSource: DataSource,
 ) {
 

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterAdditionalTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterAdditionalTest.kt
@@ -41,7 +41,7 @@ import javax.sql.DataSource
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @DataJpaTest(showSql = false)
-open class JsonORMConverterAdditionalTest(
+internal open class JsonORMConverterAdditionalTest(
     @Autowired val dataSource: DataSource,
 ) {
 

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterIntegrationTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterIntegrationTest.kt
@@ -32,7 +32,7 @@ import kotlin.test.assertEquals
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @DataJpaTest(showSql = false)
-open class JsonORMConverterIntegrationTest(@Autowired val dataSource: DataSource) {
+internal open class JsonORMConverterIntegrationTest(@Autowired val dataSource: DataSource) {
 
     @Test
     fun `select owners should return all 10 distinct owners from test data`() {

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterProviderGapTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterProviderGapTest.kt
@@ -28,7 +28,7 @@ import javax.sql.DataSource
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @DataJpaTest(showSql = false)
-open class JsonORMConverterProviderGapTest(
+internal open class JsonORMConverterProviderGapTest(
     @Autowired val dataSource: DataSource,
 ) {
 

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterProviderTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterProviderTest.kt
@@ -23,7 +23,7 @@ import javax.sql.DataSource
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @DataJpaTest(showSql = false)
-open class JsonORMConverterProviderTest(
+internal open class JsonORMConverterProviderTest(
     @Autowired val dataSource: DataSource,
 ) {
 

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/JsonORMConverterTest.kt
@@ -35,7 +35,7 @@ import javax.sql.DataSource
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
 @DataJpaTest(showSql = false)
-open class JsonORMConverterTest(
+internal open class JsonORMConverterTest(
     @Autowired val dataSource: DataSource,
 ) {
 

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/RefSerializerAdditionalTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/RefSerializerAdditionalTest.kt
@@ -22,7 +22,7 @@ import st.orm.Ref
  * round-trip serialization, mixed loaded/unloaded refs, and edge cases not covered by
  * the primary [RefSerializerTest].
  */
-class RefSerializerAdditionalTest {
+internal class RefSerializerAdditionalTest {
 
     @Serializable
     data class SimpleEntity(

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/RefSerializerTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/RefSerializerTest.kt
@@ -27,7 +27,7 @@ import st.orm.serialization.model.VetSpecialtyPK
  * Unit tests for [RefSerializer] and [StormSerializersModule] covering edge cases
  * and error paths not exercised by the integration tests.
  */
-class RefSerializerTest {
+internal class RefSerializerTest {
 
     @Serializable
     data class SimpleEntity(

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/ResolveTargetClassStrategyTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/ResolveTargetClassStrategyTest.kt
@@ -28,7 +28,7 @@ import st.orm.Ref
  * generated `$$serializer` or `$$$serializer` patterns, which happens when a type
  * uses `@Serializable(with = CustomSerializer::class)`.
  */
-class ResolveTargetClassStrategyTest {
+internal class ResolveTargetClassStrategyTest {
 
     /**
      * Entity that uses a custom serializer (not the generated one).
@@ -99,7 +99,7 @@ class ResolveTargetClassStrategyTest {
  * The descriptor's serialName is set to the fully qualified class name of the target type,
  * including nested class notation with dots.
  */
-class CustomEntityDataSerializer : KSerializer<ResolveTargetClassStrategyTest.CustomEntity> {
+internal class CustomEntityDataSerializer : KSerializer<ResolveTargetClassStrategyTest.CustomEntity> {
     override val descriptor: SerialDescriptor = buildClassSerialDescriptor(
         // Use the serialName that includes dots for nested class reference.
         // resolveClassFromSerialName will try to resolve this, first as-is (fails),

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/StormSerializersModuleGapTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/StormSerializersModuleGapTest.kt
@@ -28,7 +28,7 @@ import st.orm.Ref
  * - Line 121: RefSerializer non-JSON format assertion
  * - Lines 316-327: resolveTargetClass Strategy 1 patterns
  */
-class StormSerializersModuleGapTest {
+internal class StormSerializersModuleGapTest {
 
     @Serializable
     data class SimpleEntity(

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/StormSerializersModuleHelperTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/StormSerializersModuleHelperTest.kt
@@ -23,7 +23,7 @@ import st.orm.Ref
  * - resolveClassFromSerialName (via serialName-based resolution)
  * - serializerOrNull (via PK type resolution fallback)
  */
-class StormSerializersModuleHelperTest {
+internal class StormSerializersModuleHelperTest {
 
     // Standard entity types that exercise the generated serializer naming patterns
 

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/StormSerializersModuleTest.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/StormSerializersModuleTest.kt
@@ -25,7 +25,7 @@ import st.orm.Ref
  * - createRef with null id returning null
  * - Map of refs exercising Ref in various collection positions
  */
-class StormSerializersModuleTest {
+internal class StormSerializersModuleTest {
 
     @Serializable
     data class SimpleEntity(

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Address.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Address.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
  * Simple business object representing an address.
  */
 @Serializable
-data class Address(
+internal data class Address(
     val address: String? = null,
     val city: String? = null,
 )

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/City.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/City.kt
@@ -6,7 +6,7 @@ import st.orm.PK
 /**
  * Simple domain object representing an owner.
  */
-data class City(
+internal data class City(
     @PK val id: Int = 0,
     val name: String,
 ) : Entity<Int>

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Owner.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Owner.kt
@@ -7,7 +7,7 @@ import st.orm.PK
 /**
  * Simple domain object representing an owner.
  */
-data class Owner(
+internal data class Owner(
     @PK val id: Int = 0,
     override val firstName: String,
     override val lastName: String,

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Person.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Person.kt
@@ -3,7 +3,7 @@ package st.orm.serialization.model
 /**
  * Simple domain object representing a person.
  */
-interface Person {
+internal interface Person {
     val name: String
         get() = "$firstName $lastName"
 

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Pet.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Pet.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 /**
  * Simple business object representing a pet.
  */
-data class Pet(
+internal data class Pet(
     @PK val id: Int = 0,
     val name: String,
     @Persist(updatable = false) val birthDate: LocalDate,

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/PetType.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/PetType.kt
@@ -7,7 +7,7 @@ import st.orm.PK
 /**
  * Can be Cat, Dog, Hamster...
  */
-data class PetType(
+internal data class PetType(
     @PK(generation = GenerationStrategy.NONE) val id: Int = 0,
     val name: String,
 ) : Entity<Int>

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Specialty.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Specialty.kt
@@ -20,7 +20,7 @@ import st.orm.Data
 import st.orm.PK
 
 @Serializable
-data class Specialty(
+internal data class Specialty(
     @PK val id: Int,
     val name: String,
 ) : Data

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Vet.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Vet.kt
@@ -8,7 +8,7 @@ import st.orm.PK
  * Simple domain object representing a veterinarian.
  */
 @Serializable
-data class Vet(
+internal data class Vet(
     @PK val id: Int = 0,
     override val firstName: String,
     override val lastName: String,

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/VetSpecialty.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/VetSpecialty.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import st.orm.*
 
 @Serializable
-data class VetSpecialty(
+internal data class VetSpecialty(
     @PK(generation = GenerationStrategy.NONE) val id: VetSpecialtyPK, // Implicitly @Inlined
     @FK @Persist(insertable = false) val vet: Vet,
     @FK @Persist(insertable = false) val specialty: Specialty,

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/VetSpecialtyPK.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/VetSpecialtyPK.kt
@@ -3,7 +3,7 @@ package st.orm.serialization.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class VetSpecialtyPK(
+internal data class VetSpecialtyPK(
     val vetId: Int,
     val specialtyId: Int,
 )

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Visit.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/model/Visit.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 /**
  * Simple domain object representing a visit.
  */
-data class Visit(
+internal data class Visit(
     @PK val id: Int = 0,
     val visitDate: LocalDate,
     val description: String? = null,

--- a/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/testsupport/TestSpringConnectionProvider.kt
+++ b/storm-kotlinx-serialization/src/test/kotlin/st/orm/serialization/testsupport/TestSpringConnectionProvider.kt
@@ -28,7 +28,7 @@ import javax.sql.DataSource
  * transaction-per-test isolation applies to statements executed by Storm templates.
  */
 @BeforeAny
-class TestSpringConnectionProvider : ConnectionProvider {
+internal class TestSpringConnectionProvider : ConnectionProvider {
 
     override fun getConnection(dataSource: DataSource, context: TransactionContext?): Connection {
         try {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/RepositoryTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/RepositoryTest.kt
@@ -11,7 +11,7 @@ import st.orm.ktor.model.Pet
 import st.orm.ktor.model.PetRepository
 import st.orm.ktor.model.PetView
 
-class RepositoryTest {
+internal class RepositoryTest {
 
     private fun createTestDataSource(): HikariDataSource {
         val config = HikariConfig().apply {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormConfigReaderTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormConfigReaderTest.kt
@@ -11,7 +11,7 @@ import st.orm.StormConfig.ENTITY_CACHE_RETENTION
 import st.orm.StormConfig.UPDATE_DEFAULT_MODE
 import st.orm.StormConfig.UPDATE_DIRTY_CHECK
 
-class StormConfigReaderTest {
+internal class StormConfigReaderTest {
 
     @Test
     fun `reads camelCase storm config from HOCON`() {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormDataSourceTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormDataSourceTest.kt
@@ -7,7 +7,7 @@ import io.ktor.server.testing.testApplication
 import org.junit.jupiter.api.Test
 import java.sql.DriverManager
 
-class StormDataSourceTest {
+internal class StormDataSourceTest {
 
     @Test
     fun `creates DataSource from HOCON config`() = testApplication {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormDependencyInjectionTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormDependencyInjectionTest.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.full.starProjectedType
  * Verifies that the Storm plugin exposes the [ORMTemplate] and the registered repositories through Ktor's
  * dependency injection (`ktor-server-di`), and that the exposure can be disabled.
  */
-class StormDependencyInjectionTest {
+internal class StormDependencyInjectionTest {
 
     private fun createTestDataSource(): HikariDataSource {
         val config = HikariConfig().apply {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormMultipleDatabasesTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormMultipleDatabasesTest.kt
@@ -25,7 +25,7 @@ import st.orm.template.ORMTemplate
  * The scenario follows the pet clinic domain: the clinic's own database holds the pets, while the vet registry
  * lives in a separate, named database.
  */
-class StormMultipleDatabasesTest {
+internal class StormMultipleDatabasesTest {
 
     private fun createTestDataSource(name: String, schemaResource: String): HikariDataSource {
         val config = HikariConfig().apply {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormObservabilityTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormObservabilityTest.kt
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * named databases are tagged with `storm.database`, an explicit `queryObserver` wins over the automatic
  * binding, and without a registry queries run unobserved.
  */
-class StormObservabilityTest {
+internal class StormObservabilityTest {
 
     private fun createTestDataSource(name: String, schemaResource: String): HikariDataSource {
         val config = HikariConfig().apply {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormPluginTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormPluginTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test
 import st.orm.ktor.model.PetType
 import st.orm.template.ORMTemplate
 
-class StormPluginTest {
+internal class StormPluginTest {
 
     private fun createTestDataSource(): HikariDataSource {
         val config = HikariConfig().apply {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/TransactionTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/TransactionTest.kt
@@ -9,7 +9,7 @@ import st.orm.ktor.model.PetType
 import st.orm.template.ORMTemplate
 import st.orm.template.transaction
 
-class TransactionTest {
+internal class TransactionTest {
 
     private fun createTestDataSource(): HikariDataSource {
         val config = HikariConfig().apply {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/TransactionalRouteTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/TransactionalRouteTest.kt
@@ -29,7 +29,7 @@ import java.sql.SQLException
  * joining the outer transaction. Also verifies the StatusPages recipes documented in the Ktor integration
  * guide, exactly as written there.
  */
-class TransactionalRouteTest {
+internal class TransactionalRouteTest {
 
     private fun createTestDataSource(): HikariDataSource {
         val config = HikariConfig().apply {

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/model/Pet.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/model/Pet.kt
@@ -4,7 +4,7 @@ import st.orm.Entity
 import st.orm.FK
 import st.orm.PK
 
-data class Pet(
+internal data class Pet(
     @PK val id: Int = 0,
     val name: String,
     @FK val type: PetType,

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetRepository.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetRepository.kt
@@ -2,4 +2,4 @@ package st.orm.ktor.model
 
 import st.orm.repository.EntityRepository
 
-interface PetRepository : EntityRepository<Pet, Int>
+internal interface PetRepository : EntityRepository<Pet, Int>

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetType.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetType.kt
@@ -4,7 +4,7 @@ import st.orm.Entity
 import st.orm.GenerationStrategy
 import st.orm.PK
 
-data class PetType(
+internal data class PetType(
     @PK(generation = GenerationStrategy.NONE) val id: Int = 0,
     val name: String,
 ) : Entity<Int>

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetView.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/model/PetView.kt
@@ -5,7 +5,7 @@ import st.orm.PK
 import st.orm.Projection
 
 @DbTable("pet")
-data class PetView(
+internal data class PetView(
     @PK val id: Int = 0,
     val name: String,
 ) : Projection<Int>

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/vet/Vet.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/vet/Vet.kt
@@ -3,7 +3,7 @@ package st.orm.ktor.vet
 import st.orm.Entity
 import st.orm.PK
 
-data class Vet(
+internal data class Vet(
     @PK val id: Int = 0,
     val firstName: String,
     val lastName: String,

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/vet/VetRepository.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/vet/VetRepository.kt
@@ -2,4 +2,4 @@ package st.orm.ktor.vet
 
 import st.orm.repository.EntityRepository
 
-interface VetRepository : EntityRepository<Vet, Int>
+internal interface VetRepository : EntityRepository<Vet, Int>


### PR DESCRIPTION
Fixes #430.

The Kotlin modules enable `-Xexplicit-api=strict` on the main-sources compile execution only, but IDEs import the compiler args module-wide and flag every public test declaration. Explicit API checks apply only to effectively public declarations, so one `internal` keyword per top-level test type silences the diagnostics for all members and states the truth: tests are not API.

Mechanical sweep over the test sources of storm-kotlin, storm-kotlin-spring, storm-kotlin-spring-boot-starter, storm-kotlinx-serialization, and storm-ktor: every top-level type declaration (classes, interfaces, objects, including the test entity models and repository interfaces) without an explicit visibility modifier is now `internal`. 125 files, one keyword each. One top-level function (`Plumbing.kt`'s `fetchAllOnDispatcher`) had to follow along, since it returns a now-internal entity type.

JUnit, Spring, and Storm's reflection are unaffected: `internal` classes compile to public bytecode and keep their member names.

All five modules' suites pass after the change (1725 + 196 + 23 + 253 + 60 tests). One pre-existing local hiccup surfaced during verification and is unrelated: the starter's `schema validation unknown mode fails context startup` fails when `~/.m2` holds a storm-spring jar predating #461; it passes against freshly installed modules, on this branch and on main alike.

Note: `storm-ktor`'s `StormPluginTest.kt` is also modified by the open #463, in a different region of the file; the hunks merge cleanly.