### PR TITLE
ci: harden the release workflow: CI gate, job ordering, Central validation, dead credential config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,13 @@ on:
 permissions:
   contents: read
 
-# Rapid pushes to a PR queue duplicate runs; supersede them. Runs on main keep
-# going so every merge commit gets its coverage upload.
+# Rapid pushes to a PR queue duplicate runs; supersede them. Runs on main are
+# keyed by commit instead of sharing a group: a shared group cancels the
+# previously queued run even with cancel-in-progress off, and every main commit
+# needs a completed run — for its coverage upload, and because the release
+# workflow refuses to publish a commit without a successful CI run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,49 @@ on:
       - 'v*'  # Only triggers on version tags like v1.2.0.
 
 jobs:
+  # The deploy below runs -DskipTests: a release ships exactly the bytes CI already
+  # tested, it does not re-test them. That is only sound if the tagged commit in fact
+  # passed CI, and publishing is irreversible, so every publish job is gated on a
+  # successful CI run for this commit. A tag pushed while CI is still running waits
+  # for the verdict instead of failing.
+  verify-ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90   # CI itself may take up to an hour; leave room to wait for it.
+    permissions:
+      contents: read
+      actions: read   # Reading workflow runs requires it.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Require a successful CI run for the tagged commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # For annotated tags GITHUB_SHA is the tag object, not the commit, so
+          # resolve the commit the tag points at.
+          COMMIT=$(git rev-parse HEAD^{commit})
+          RUNS_API="repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs"
+          while true; do
+            SUCCESSFUL=$(gh api "${RUNS_API}?head_sha=${COMMIT}&status=success" --jq '.total_count')
+            if [ "${SUCCESSFUL}" -gt 0 ]; then
+              echo "CI passed for ${COMMIT}."
+              exit 0
+            fi
+            ACTIVE=$(gh api "${RUNS_API}?head_sha=${COMMIT}" --jq '[.workflow_runs[] | select(.status != "completed")] | length')
+            if [ "${ACTIVE}" -gt 0 ]; then
+              echo "CI is still running for ${COMMIT}; checking again in 60s."
+              sleep 60
+              continue
+            fi
+            echo "::error::No successful CI run exists for ${COMMIT}. Re-run CI for this commit (or push it through CI), then re-run this workflow."
+            exit 1
+          done
+
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    needs: verify-ci
     permissions:
       contents: read   # Checkout only; deploy auth comes from Central/GPG secrets, not GITHUB_TOKEN.
 
@@ -16,18 +56,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up Java 21 and Maven Central credentials
-        uses: actions/setup-java@v3
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
-          server-id: 'central'
-          server-username: ${{ secrets.CENTRAL_USERNAME }}
-          server-password: ${{ secrets.CENTRAL_PASSWORD }}
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Import GPG key manually
+      # Signing and Central credentials are configured explicitly in the steps
+      # below rather than through setup-java inputs: the action's server-username/
+      # server-password expect environment variable *names*, and its generated
+      # settings.xml is replaced wholesale here anyway.
+      - name: Import GPG key
         run: |
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --yes --import
           gpg --list-keys
@@ -51,8 +90,6 @@ jobs:
             </servers>
           </settings>
           EOF
-        env:
-          CENTRAL_USER_TOKEN: ${{ secrets.CENTRAL_USER_TOKEN }}
 
       - name: Extract version from tag
         id: version
@@ -68,6 +105,10 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # npm versions cannot be reused after an unpublish, so the CLI must only go out
+    # once the Central deploy has succeeded; otherwise a failed deploy burns the npm
+    # version number on a release whose artifacts do not exist.
+    needs: publish
     permissions:
       id-token: write   # Required for npm trusted publishing (OIDC).
       contents: read
@@ -108,7 +149,10 @@ jobs:
   publish-gradle-plugin:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: publish            # The plugin references st.orm artifacts of the same version on Central.
+    # The plugin references st.orm artifacts of the same version on Central. The
+    # publish job blocks until Central has validated and published them (the pom
+    # sets waitUntil=published), so they are resolvable when this job starts.
+    needs: publish
     permissions:
       contents: read
     steps:
@@ -174,15 +218,22 @@ jobs:
       # so its install snippets carry a literal version. Sync it to the release
       # here, in the same commit as the docs snapshot, so it is never bumped by
       # hand. Targets the Gradle plugin version and the storm-bom coordinate in
-      # both the Gradle and Maven examples.
+      # both the Gradle and Maven examples; the Maven <version> substitution is
+      # anchored to the line after the storm-bom <artifactId> so that any other
+      # XML snippet the README picks up is left alone.
       - name: Sync README version
         run: |
           V="${{ steps.version.outputs.VERSION }}"
           sed -i -E \
             -e "s/(id\(\"st\.orm\"\) version \")[0-9]+\.[0-9]+\.[0-9]+/\1${V}/g" \
             -e "s/(storm-bom:)[0-9]+\.[0-9]+\.[0-9]+/\1${V}/g" \
-            -e "s#(<version>)[0-9]+\.[0-9]+\.[0-9]+(</version>)#\1${V}\2#g" \
+            -e "/<artifactId>storm-bom<\/artifactId>/{n;s#(<version>)[0-9]+\.[0-9]+\.[0-9]+(</version>)#\1${V}\2#;}" \
             README.md
+          # Without these guards, a README edit that drifts away from the patterns
+          # above would silently ship snippets pinning the previous release.
+          grep -q "id(\"st.orm\") version \"${V}\"" README.md
+          grep -q "storm-bom:${V}" README.md
+          grep -q "<version>${V}</version>" README.md
 
       - name: Commit and push
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,11 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>uploaded</waitUntil>
+                            <!-- The release workflow starts jobs that resolve these artifacts from
+                                 Central (the Gradle Plugin Portal build) as soon as the deploy
+                                 returns, so the deploy must block until Central has validated and
+                                 published the bundle, not merely received it. -->
+                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Fixes #382

The tag-driven release deploys with `-DskipTests` and publishes irreversibly, so every latent ordering and validation gap in `release.yml` is one incident away. This closes them all:

- **CI gate.** A new `verify-ci` job requires a successful CI run for the tagged commit before anything publishes. It dereferences annotated tags to the underlying commit and polls while CI is still running, so a tag pushed right after a merge waits for the verdict instead of failing. `publish` now `needs: verify-ci`; everything else is gated transitively.
- **Job ordering.** `publish-npm` now has `needs: publish`. Previously a failed Central deploy still published `@storm-orm/cli` pointing at artifacts that do not exist, and npm versions cannot be reused after an unpublish.
- **Central validation.** The `central-publishing-maven-plugin` now uses `waitUntil: published` instead of `uploaded`, so the deploy blocks until Central has validated and published the bundle. `publish-gradle-plugin` resolves those artifacts from Central and could previously start before validation completed.
- **Dead credential config.** `setup-java` bumped v3 → v4 and stripped to distribution/java-version. Its `server-username`/`server-password` inputs were fed secret values where environment variable *names* are expected, its generated `settings.xml` is overwritten wholesale by the hand-written one (which stays as the single credential mechanism), its GPG inputs duplicated the explicit import step, and the `CENTRAL_USER_TOKEN` env var was never read. All deleted.
- **README version sync.** The Maven `<version>` substitution in `version-docs` previously rewrote every `<version>x.y.z</version>` in the README; it is now anchored to the line after the storm-bom `<artifactId>`, with `grep -q` postconditions that fail the job if any of the three snippets drift away from the sed patterns. Dry-ran against the current README with a decoy XML dependency appended: the storm-bom version updates, the decoy is untouched.

One additional fix surfaced while verifying the gate against real data: even with `cancel-in-progress: false`, a concurrency group holds at most one *pending* run, so during this morning's merge burst the queued main runs for `968482cd` and `05ae3da7` were displaced and finished as `cancelled`. That silently defeats the per-merge coverage upload and would make the new gate reject good commits. The CI concurrency group is now keyed by commit SHA on main (every push gets a completed run) while PR branches keep their superseding behavior.

Verified live against the repo: the gate's success query returns the green run for `77df55e9`, the cancelled runs for `968482cd`/`05ae3da7` are correctly not counted, and the in-flight run for `00884d6a` exercises the wait branch. Both workflow files parse, both embedded scripts pass `bash -n`.