### PR TITLE
fix: Ktor named databases inherit plugin-level configuration, unclaimed named lookups fail fast, and the SQL log binds to application.conf

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,7 @@ storm {
 }
 ```
 
-The Storm Ktor plugin reads these properties and builds a `StormConfig` that is passed to the `ORMTemplate` factory. HOCON supports environment variable substitution with `${?VAR_NAME}` syntax. See [Ktor Integration](ktor-integration.md#configuration) for details.
+The Storm Ktor plugin reads these properties and builds a `StormConfig` that is passed to the `ORMTemplate` factory. A named database reads the same keys under `storm.databases.<name>`, inheriting every key it does not set from the keys above. HOCON supports environment variable substitution with `${?VAR_NAME}` syntax. See [Ktor Integration](ktor-integration.md#configuration) for details.
 
 ---
 

--- a/docs/ktor-integration.md
+++ b/docs/ktor-integration.md
@@ -445,9 +445,11 @@ install(Storm) {
 }
 ```
 
-Each named database gets its own `ORMTemplate`, repositories, schema validation, migration hook, and lifecycle. Provide a `dataSource` in the block, or let the plugin create one from the HOCON configuration under `storm.databases.<name>.datasource`, with the same properties as the primary's `storm.datasource` section. Storm configuration overrides for the database are read from `storm.databases.<name>.*`.
+Each named database gets its own `ORMTemplate`, repositories, schema validation, migration hook, and lifecycle. Provide a `dataSource` in the block, or let the plugin create one from the HOCON configuration under `storm.databases.<name>.datasource`, with the same properties as the primary's `storm.datasource` section.
 
-The packages declared with `repositories(...)` partition the application between the databases: repository interfaces and entity types under those packages belong to that database. They are registered against its template, validated against its schema, and excluded from the primary database's registration and validation. Requesting a claimed repository from the primary fails with an error naming the owning database.
+A named database inherits the plugin-level settings that express policy: the Storm configuration keys (per key, `storm.databases.<name>.*` over `storm.*`), the exception mapper, the query observer, the SQL commenter, and the schema validation mode, each overridable in its block; the plugin-level entity callbacks, which apply in addition to the callbacks declared in the block; and the `autoRegisterRepositories` switch. What identifies a database never inherits: its data source, its migration hook, and its connection and transaction template providers, which define the database's transaction scope and default to fresh per-database instances.
+
+The packages declared with `repositories(...)` partition the application between the databases: repository interfaces and entity types under those packages belong to that database. They are registered against its template, validated against its schema, and excluded from the primary database's registration and validation. Requesting a claimed repository from the primary fails with an error naming the owning database, and requesting a type no database block claims from a named database fails the same way: an undeclared type belongs to the primary, so a named lookup for it is a wiring error, not a request to bind the type to that database.
 
 Access the named database through the name-taking variants of the standard accessors, or through dependency injection:
 
@@ -561,7 +563,7 @@ storm {
 }
 ```
 
-See the [Configuration](configuration.md) guide for a description of each property and the full precedence rules.
+A named database reads the same keys under `storm.databases.<name>`, inheriting every key it does not set from the `storm` section. The per-call [SQL log](sql-logging.md#per-call-summaries) is configured under `storm.sqlLog`. See the [Configuration](configuration.md) guide for a description of each property and the full precedence rules.
 
 ### Environment-Specific Configuration
 
@@ -741,7 +743,7 @@ Physical transactions report as `storm.transaction` observations with their dura
 
 Queries against a named database are tagged `storm.database=<name>`; the primary database is tagged `storm.database=primary`. The tag is always present because meters of one name must share a single set of tag keys; registries such as Prometheus drop series whose tag keys differ. Queries issued during plugin installation, such as schema validation, run before the registry is resolved and are not observed.
 
-For development and per-call diagnosis, `sqlLog = true` in the plugin configuration reports what each call cost the database as one summary (statements, database time against total time, concurrency, and the statement that carried the weight) with thresholds that turn it into a production guardrail. See [SQL Logging](sql-logging.md#per-call-summaries).
+For development and per-call diagnosis, `sqlLog = true` in the plugin configuration (or `storm.sqlLog.enabled = true` in `application.conf`) reports what each call cost the database as one summary (statements, database time against total time, concurrency, and the statement that carried the weight) with thresholds that turn it into a production guardrail. See [SQL Logging](sql-logging.md#per-call-summaries).
 
 For full control, set an explicit observer in the plugin configuration; it takes precedence over the automatic binding. The `queryObserver` slot accepts any `st.orm.core.spi.QueryObserver`, including a hand-configured `MicrometerQueryObserver` from the `storm-micrometer` module (custom `ObservationConvention`, extra key values):
 

--- a/docs/sql-logging.md
+++ b/docs/sql-logging.md
@@ -158,15 +158,21 @@ install(Storm) {
 }
 ```
 
+Every `sqlLog*` option can come from `application.conf` instead, under `storm.sqlLog` (or `storm.sql_log`), so the log can be switched on in production without a redeploy; a plugin setting overrides the configuration file per option.
+
 For production, thresholds turn the scope into a guardrail: only calls that exceed one are reported, at WARN.
 
-```kotlin
-install(Storm) {
-    sqlLog = true
-    sqlLogStatementThreshold = 50
-    sqlLogDurationThreshold = 500.milliseconds
+```hocon
+storm.sqlLog {
+    enabled = true
+    threshold {
+        statements = 50
+        duration = 500ms
+    }
 }
 ```
+
+The same thresholds in the plugin configuration are `sqlLogStatementThreshold = 50` and `sqlLogDurationThreshold = 500.milliseconds`.
 
 </TabItem>
 </Tabs>

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/RepositoryRegistry.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/RepositoryRegistry.kt
@@ -38,6 +38,19 @@ public class RepositoryRegistry internal constructor(
     private val repositories = ConcurrentHashMap<KClass<*>, Any>()
 
     /**
+     * The named database this registry belongs to, or `null` for the primary database's registry. A named
+     * database's registry serves only the types under [ownedPackages]; the primary serves everything no named
+     * database claims.
+     */
+    internal var databaseName: String? = null
+
+    /**
+     * The packages the registry's database declared with `repositories(...)`, empty for the primary database's
+     * registry.
+     */
+    internal var ownedPackages: List<String> = emptyList()
+
+    /**
      * Packages claimed by other, named databases (package name to database name). Types under these packages must
      * not be created against this registry's template; lookups fail fast pointing to the owning database.
      */
@@ -48,12 +61,33 @@ public class RepositoryRegistry internal constructor(
         return claimedPackages.entries.firstOrNull { (packageName, _) -> typeName.startsWith("$packageName.") }?.value
     }
 
-    private fun requireUnclaimed(type: KClass<*>) {
+    /**
+     * Verifies that this registry's database serves [type]: not a type claimed by another database, and for a
+     * named database's registry, a type under its declared packages. An unclaimed type belongs to the primary
+     * database, so a named lookup for one is a wiring error that fails fast naming the fix, rather than
+     * silently binding the type to the named database.
+     */
+    private fun requireServed(type: KClass<*>) {
         val owner = ownerOf(type)
         if (owner != null) {
             throw IllegalStateException(
                 "Repository ${type.simpleName} belongs to database '$owner'. " +
                     "Use repository<${type.simpleName}>(\"$owner\") or orm(\"$owner\") to access it.",
+            )
+        }
+        val name = databaseName ?: return
+        if (ownedPackages.none { type.java.name.startsWith("$it.") }) {
+            val declared = if (ownedPackages.isEmpty()) {
+                "declares no repository packages"
+            } else {
+                "declares the packages ${ownedPackages.joinToString(", ") { "'$it'" }}"
+            }
+            throw IllegalStateException(
+                "Repository ${type.simpleName} does not belong to database '$name', which $declared. " +
+                    "A type belongs to a named database through the packages declared with repositories(...) in " +
+                    "its database block; undeclared types belong to the primary database. " +
+                    "Use repository<${type.simpleName}>() for the primary database, or declare the type's " +
+                    "package inside database(\"$name\") { repositories(\"${type.java.packageName}\") }.",
             )
         }
     }
@@ -65,7 +99,7 @@ public class RepositoryRegistry internal constructor(
      * @return the created repository instance.
      */
     public fun <T : Repository> register(type: KClass<T>): T {
-        requireUnclaimed(type)
+        requireServed(type)
         val repository = ormTemplate.repository(type)
         repositories[type] = repository
         return repository
@@ -90,8 +124,9 @@ public class RepositoryRegistry internal constructor(
             val typeName = type.name
             if (packages.isNotEmpty() && packages.none { typeName.startsWith("$it.") }) continue
             // Skip types that belong to another, named database; they are registered against that database's
-            // template instead.
+            // template instead. A named database's registry additionally serves only its own packages.
             if (claimedPackages.keys.any { typeName.startsWith("$it.") }) continue
+            if (databaseName != null && ownedPackages.none { typeName.startsWith("$it.") }) continue
             val kotlinType = type.kotlin as KClass<out Repository>
             if (!repositories.containsKey(kotlinType)) {
                 val repository = ormTemplate.repository(kotlinType)
@@ -132,8 +167,9 @@ public class RepositoryRegistry internal constructor(
      * Retrieves a repository, creating and caching it on first access if it has not been registered.
      *
      * Repositories registered at startup (automatically from the compile-time type index, or explicitly via
-     * [register]) are returned from the cache. Unknown types are created lazily and cached for subsequent
-     * calls. Thread-safe.
+     * [register]) are returned from the cache. Unknown types the registry's database serves are created lazily
+     * and cached for subsequent calls; a type belonging to a different database fails fast naming the owning
+     * database. Thread-safe.
      *
      * @param type the repository interface to retrieve or create.
      * @return the cached or newly created repository instance.
@@ -141,7 +177,7 @@ public class RepositoryRegistry internal constructor(
      */
     @Suppress("UNCHECKED_CAST")
     public fun <T : Repository> getOrCreate(type: KClass<T>): T = repositories.computeIfAbsent(type) {
-        requireUnclaimed(type)
+        requireServed(type)
         ormTemplate.repository(type)
     } as T
 }

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/SqlLogSettings.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/SqlLogSettings.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.ktor
+
+import io.ktor.server.application.Application
+import st.orm.core.template.SqlLog.HydrationShapes
+import kotlin.time.Duration
+
+/**
+ * The per-call SQL log configuration the plugin runs with, resolved per option: an explicit
+ * [StormPluginConfig] setting wins, otherwise the HOCON configuration under `storm.sqlLog`
+ * (or `storm.sql_log`) applies, otherwise the option's default. The HOCON path is what makes the
+ * log switchable through `application.conf` without a code change, mirroring the Spring starter's
+ * `storm.sql-log.*` properties.
+ *
+ * [lineWidth] and [hydration] are `null` when neither the DSL nor the configuration sets them, so
+ * installation leaves the JVM-wide display settings (the `storm.sql_log.*` system properties, or
+ * another application's configuration in the same JVM) untouched.
+ */
+internal class SqlLogSettings(
+    val enabled: Boolean,
+    val limit: Int,
+    val statementThreshold: Int?,
+    val durationThreshold: Duration?,
+    val callSites: Boolean,
+    val callSiteSkip: List<String>,
+    val lineWidth: Int?,
+    val hydration: HydrationShapes?,
+)
+
+/**
+ * Resolves the effective per-call SQL log settings from the plugin configuration and the application's HOCON
+ * configuration. An invalid configuration value aborts installation with an error naming the key, so a typo
+ * cannot silently misconfigure the log.
+ */
+internal fun resolveSqlLogSettings(application: Application, pluginConfig: StormPluginConfig): SqlLogSettings = SqlLogSettings(
+    enabled = pluginConfig.sqlLog ?: booleanProperty(application, "enabled") ?: false,
+    limit = pluginConfig.sqlLogLimit ?: intProperty(application, "limit") ?: 200,
+    statementThreshold = pluginConfig.sqlLogStatementThreshold
+        ?: intProperty(application, "threshold.statements"),
+    durationThreshold = pluginConfig.sqlLogDurationThreshold
+        ?: durationProperty(application, "threshold.duration"),
+    callSites = pluginConfig.sqlLogCallSites ?: booleanProperty(application, "callSites") ?: false,
+    callSiteSkip = pluginConfig.sqlLogCallSiteSkip
+        ?: listProperty(application, "callSiteSkip")
+        ?: emptyList(),
+    lineWidth = pluginConfig.sqlLogLineWidth ?: intProperty(application, "lineWidth"),
+    hydration = pluginConfig.sqlLogHydration ?: hydrationProperty(application, "hydration"),
+)
+
+/**
+ * Reads a SQL log property, trying the camelCase key under `storm.sqlLog` first (HOCON convention), then the
+ * snake_case key under `storm.sql_log` (Storm convention).
+ */
+private fun stringProperty(application: Application, relativeKey: String): Pair<String, String>? {
+    val config = application.environment.config
+    val camelKey = "storm.sqlLog.$relativeKey"
+    val snakeKey = "storm.sql_log." + camelToSnake(relativeKey)
+    config.propertyOrNull(camelKey)?.let { return camelKey to it.getString() }
+    config.propertyOrNull(snakeKey)?.let { return snakeKey to it.getString() }
+    return null
+}
+
+private fun booleanProperty(application: Application, relativeKey: String): Boolean? {
+    val (key, value) = stringProperty(application, relativeKey) ?: return null
+    return value.toBooleanStrictOrNull()
+        ?: throw IllegalStateException("Invalid value '$value' for $key. Valid values are: true, false.")
+}
+
+private fun intProperty(application: Application, relativeKey: String): Int? {
+    val (key, value) = stringProperty(application, relativeKey) ?: return null
+    return value.toIntOrNull()
+        ?: throw IllegalStateException("Invalid value '$value' for $key. The value must be an integer.")
+}
+
+private fun durationProperty(application: Application, relativeKey: String): Duration? {
+    val (key, value) = stringProperty(application, relativeKey) ?: return null
+    return Duration.parseOrNull(value)
+        ?: throw IllegalStateException(
+            "Invalid value '$value' for $key. The value must be a duration such as 500ms, 2s, or PT0.5S.",
+        )
+}
+
+private fun hydrationProperty(application: Application, relativeKey: String): HydrationShapes? {
+    val (key, value) = stringProperty(application, relativeKey) ?: return null
+    return HydrationShapes.entries.firstOrNull { it.name.equals(value.trim(), ignoreCase = true) }
+        ?: throw IllegalStateException("Invalid value '$value' for $key. Valid values are: off, short, full.")
+}
+
+/**
+ * Reads a list-valued SQL log property: a HOCON list, or a single comma-separated string.
+ */
+private fun listProperty(application: Application, relativeKey: String): List<String>? {
+    val config = application.environment.config
+    val camelKey = "storm.sqlLog.$relativeKey"
+    val snakeKey = "storm.sql_log." + camelToSnake(relativeKey)
+    val property = config.propertyOrNull(camelKey) ?: config.propertyOrNull(snakeKey) ?: return null
+    val values = runCatching { property.getList() }.getOrElse { property.getString().split(',') }
+    return values.map { it.trim() }.filter { it.isNotEmpty() }
+}
+
+/**
+ * Converts a dotted camelCase key segment to snake_case: `callSiteSkip` becomes `call_site_skip`.
+ */
+private fun camelToSnake(key: String): String = key.split('.').joinToString(".") { segment ->
+    segment.replace(Regex("([A-Z])")) { "_" + it.groupValues[1].lowercase() }
+}

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/Storm.kt
@@ -93,7 +93,8 @@ import kotlin.reflect.typeOf
  * Additional databases declared with `database("name") { }` get their own template, repositories, schema
  * validation, and lifecycle, exposed under their name: `orm("name")`, `repository<T>("name")`, and named
  * dependency injection. The packages declared inside a database block partition repositories and schema
- * validation between the databases.
+ * validation between the databases. A named database inherits the plugin-level policy settings, per option,
+ * unless its block overrides them; see [StormDatabaseConfig] for the inheritance rule.
  *
  * @since 1.11
  */
@@ -167,6 +168,11 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
 
     // ---- Named databases ----
 
+    // A named database inherits the plugin-level policy settings, per option, unless its block overrides them:
+    // the Storm configuration (per key), the exception mapper, query observer, SQL commenter, entity callbacks,
+    // schema validation mode, and the auto-registration switch. The connection and transaction template
+    // providers never inherit: a provider instance defines a database's transaction scope, so each database
+    // gets its own unless its block sets one.
     val namedTemplates = LinkedHashMap<String, ORMTemplate>()
     val namedDataSources = LinkedHashMap<String, DataSource>()
     val namedRegistries = LinkedHashMap<String, RepositoryRegistry>()
@@ -176,7 +182,7 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
             ?: createDataSourceFromConfig(application, "storm.databases.$name.datasource")
                 .also { ownedDataSources += it }
         val databaseStormConfig = databaseConfig.config
-            ?: readStormConfig(application, "storm.databases.$name")
+            ?: readStormConfig(application, "storm.databases.$name", fallback = stormConfig)
         databaseConfig.migration?.invoke(databaseDataSource)
         val databaseBuilder = ORMTemplate.builder(databaseDataSource)
             .config(databaseStormConfig)
@@ -184,18 +190,22 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
             .transactionTemplateProvider(
                 databaseConfig.transactionTemplateProvider ?: JdbcTransactionTemplateProviderImpl(),
             )
-        databaseConfig.exceptionMapper?.let { databaseBuilder.exceptionMapper(it) }
+        (databaseConfig.exceptionMapper ?: pluginConfig.exceptionMapper)?.let { databaseBuilder.exceptionMapper(it) }
         (databaseConfig.sqlCommenter ?: pluginConfig.sqlCommenter)?.let { databaseBuilder.sqlCommenter(it) }
         databaseBuilder.queryObserver(
-            databaseConfig.queryObserver ?: DelegatingQueryObserver().also { delegatingObservers[name] = it },
+            databaseConfig.queryObserver ?: pluginConfig.queryObserver
+                ?: DelegatingQueryObserver().also { delegatingObservers[name] = it },
         )
         var databaseTemplate = databaseBuilder.build()
-        if (databaseConfig.entityCallbacks.isNotEmpty()) {
-            databaseTemplate = databaseTemplate.withEntityCallbacks(databaseConfig.entityCallbacks)
+        val databaseCallbacks = pluginConfig.entityCallbacks + databaseConfig.entityCallbacks
+        if (databaseCallbacks.isNotEmpty()) {
+            databaseTemplate = databaseTemplate.withEntityCallbacks(databaseCallbacks)
         }
         val databaseRegistry = RepositoryRegistry(databaseTemplate, application)
+        databaseRegistry.databaseName = name
+        databaseRegistry.ownedPackages = databaseConfig.repositoryPackages.toList()
         databaseRegistry.claimedPackages = claimedPackages.filterValues { it != name }
-        if (databaseConfig.repositoryPackages.isNotEmpty()) {
+        if (pluginConfig.autoRegisterRepositories && databaseConfig.repositoryPackages.isNotEmpty()) {
             databaseRegistry.register(*databaseConfig.repositoryPackages.toTypedArray())
         }
         namedTemplates[name] = databaseTemplate
@@ -262,9 +272,14 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
         val name = databaseConfig.name
         application.runSchemaValidation(
             template = namedTemplates.getValue(name),
+            // Per-database settings before inherited ones: the database's block, then its configuration keys,
+            // then the plugin-level mode the primary uses.
             configuredMode = databaseConfig.schemaValidation
                 ?: application.environment.config.propertyOrNull("storm.databases.$name.validation.schemaMode")?.getString()
                 ?: application.environment.config.propertyOrNull("storm.databases.$name.validation.schema_mode")?.getString()
+                ?: pluginConfig.schemaValidation
+                ?: application.environment.config.propertyOrNull("storm.validation.schemaMode")?.getString()
+                ?: application.environment.config.propertyOrNull("storm.validation.schema_mode")?.getString()
                 ?: "fail",
             property = "storm.databases.$name.validation.schemaMode",
             description = "database '$name'",
@@ -284,16 +299,21 @@ public val Storm: ApplicationPlugin<StormPluginConfig> = createApplicationPlugin
 
     // ---- Per-call SQL log ----
 
-    if (pluginConfig.sqlLog) {
-        val limit = pluginConfig.sqlLogLimit
-        val callSites = pluginConfig.sqlLogCallSites
-        if (pluginConfig.sqlLogCallSiteSkip.isNotEmpty()) {
-            CallSiteCapture.ignoreCallSites(*pluginConfig.sqlLogCallSiteSkip.toTypedArray())
+    // Each option resolves from the plugin configuration first, then the application configuration under
+    // storm.sqlLog, so the log can be switched on through the configuration file alone. The display settings
+    // (call-site skip, line width, hydration shapes) are JVM-wide by design and are only applied when actually
+    // configured, leaving the system-property defaults, or another application's settings, in effect otherwise.
+    val sqlLogSettings = resolveSqlLogSettings(application, pluginConfig)
+    if (sqlLogSettings.enabled) {
+        val limit = sqlLogSettings.limit
+        val callSites = sqlLogSettings.callSites
+        if (sqlLogSettings.callSiteSkip.isNotEmpty()) {
+            CallSiteCapture.ignoreCallSites(*sqlLogSettings.callSiteSkip.toTypedArray())
         }
-        pluginConfig.sqlLogLineWidth?.let { SqlLogRenderer.lineWidth(it) }
-        SqlLogRenderer.hydrationShapes(pluginConfig.sqlLogHydration)
-        val statementThreshold = pluginConfig.sqlLogStatementThreshold
-        val durationThreshold = pluginConfig.sqlLogDurationThreshold
+        sqlLogSettings.lineWidth?.let { SqlLogRenderer.lineWidth(it) }
+        sqlLogSettings.hydration?.let { SqlLogRenderer.hydrationShapes(it) }
+        val statementThreshold = sqlLogSettings.statementThreshold
+        val durationThreshold = sqlLogSettings.durationThreshold
         val thresholded = statementThreshold != null || durationThreshold != null
         val logger = LoggerFactory.getLogger("st.orm.sql.perf")
         // Intercepting surrounds the rest of the pipeline, so the scope covers everything the call does rather

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormConfigReader.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormConfigReader.kt
@@ -57,8 +57,12 @@ import st.orm.StormConfig.VALIDATION_STRICT
  *     }
  * }
  * ```
+ *
+ * A named database reads the same keys relative to its own prefix (`storm.databases.<name>`) and inherits the
+ * rest through [fallback], the primary database's effective configuration: a key set under the named prefix
+ * overrides, every other key resolves to what the primary uses.
  */
-internal fun readStormConfig(application: Application, prefix: String = "storm"): StormConfig {
+internal fun readStormConfig(application: Application, prefix: String = "storm", fallback: StormConfig? = null): StormConfig {
     val config = application.environment.config
     val properties = mutableMapOf<String, String>()
     val keys = listOf(
@@ -78,9 +82,11 @@ internal fun readStormConfig(application: Application, prefix: String = "storm")
         // own prefix, e.g. "storm.databases.analytics.update.default_mode". The prefix itself (which may contain
         // a user-chosen database name) is looked up verbatim; only the relative key gets the camelCase variant.
         val relativeKey = key.removePrefix("storm")
-        // Try camelCase (HOCON convention) first, then snake_case (Storm convention).
+        // Try camelCase (HOCON convention) first, then snake_case (Storm convention), then the fallback
+        // configuration a named database inherits from.
         val value = config.propertyOrNull(prefix + snakeToCamel(relativeKey))?.getString()
             ?: config.propertyOrNull(prefix + relativeKey)?.getString()
+            ?: fallback?.getProperty(key)
             ?: continue
         properties[key] = value
     }

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormDatabaseConfig.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormDatabaseConfig.kt
@@ -26,6 +26,14 @@ import javax.sql.DataSource
  * configuration on [StormPluginConfig]. The database's template and repositories are exposed under the given name:
  * `orm("name")`, `repository<T>("name")`, and named dependency injection (`@Named("name")`).
  *
+ * A named database inherits the plugin-level settings that express policy: the Storm configuration keys
+ * (per key, `storm.databases.<name>.*` over `storm.*`), [exceptionMapper], [queryObserver], [sqlCommenter],
+ * and [schemaValidation], each overridable in this block; the plugin-level entity callbacks, which apply in
+ * addition to the callbacks declared here; and the [StormPluginConfig.autoRegisterRepositories] switch.
+ * What identifies a database never inherits: its [dataSource], its [migration] hook, and its
+ * [connectionProvider] and [transactionTemplateProvider], which define the database's transaction scope and
+ * default to fresh per-database instances.
+ *
  * The packages declared with [repositories] partition the application: repository interfaces and entity types under
  * these packages belong to this database. They are registered against this database's template, excluded from the
  * primary database's registration and schema validation, and validated against this database's schema instead.
@@ -41,31 +49,38 @@ public class StormDatabaseConfig internal constructor(internal val name: String)
     public var dataSource: DataSource? = null
 
     /**
-     * Optional [StormConfig] override for this database. If not provided, configuration is read from the HOCON
-     * configuration under `storm.databases.<name>`, falling back to defaults.
+     * Optional [StormConfig] override for this database, replacing the inherited configuration entirely. If not
+     * provided, each configuration key is read from the HOCON configuration under `storm.databases.<name>`,
+     * inheriting keys it does not set from the primary database's effective configuration (the plugin-level
+     * [StormPluginConfig.config], or the HOCON configuration under `storm`).
      */
     public var config: StormConfig? = null
 
     /**
      * Optional [st.orm.core.spi.ConnectionProvider] override. When not set, this database uses its own
-     * coroutine-aware provider instance.
+     * coroutine-aware provider instance; a plugin-level provider is never inherited, because a provider
+     * instance scopes connection binding to one database.
      */
     public var connectionProvider: st.orm.core.spi.ConnectionProvider? = null
 
     /**
      * Optional [st.orm.core.spi.TransactionTemplateProvider] override. When not set, this database uses its own
-     * JDBC transaction provider instance. Each database has its own transaction provider, so a `transaction { }`
-     * block binds to one database; blocks cannot atomically span databases.
+     * JDBC transaction provider instance; a plugin-level provider is never inherited. Each database has its own
+     * transaction provider, so a `transaction { }` block binds to one database; blocks cannot atomically span
+     * databases.
      */
     public var transactionTemplateProvider: st.orm.core.spi.TransactionTemplateProvider? = null
 
     /**
-     * Optional [st.orm.core.spi.ExceptionMapper] for this database's template.
+     * Optional [st.orm.core.spi.ExceptionMapper] for this database's template; inherits the plugin-level
+     * mapper when unset.
      */
     public var exceptionMapper: st.orm.core.spi.ExceptionMapper? = null
 
     /**
-     * Optional [st.orm.core.spi.QueryObserver] for this database's template.
+     * Optional [st.orm.core.spi.QueryObserver] for this database's template; inherits the plugin-level
+     * observer when unset. Without either, query observations bind to the `ObservationRegistry` from the
+     * dependency container once the application has started.
      */
     public var queryObserver: st.orm.core.spi.QueryObserver? = null
 
@@ -82,8 +97,10 @@ public class StormDatabaseConfig internal constructor(internal val name: String)
      * installation.
      *
      * When not set, the mode is read from the HOCON configuration under
-     * `storm.databases.<name>.validation.schemaMode` (or `schema_mode`), defaulting to `"fail"`. Validation covers
-     * the entity and projection types under the packages declared with [repositories].
+     * `storm.databases.<name>.validation.schemaMode` (or `schema_mode`), inheriting the primary database's mode
+     * ([StormPluginConfig.schemaValidation], or `storm.validation.schemaMode`) when that is not set either,
+     * defaulting to `"fail"`. Validation covers the entity and projection types under the packages declared
+     * with [repositories].
      */
     public var schemaValidation: String? = null
 
@@ -100,7 +117,8 @@ public class StormDatabaseConfig internal constructor(internal val name: String)
     internal val entityCallbacks = mutableListOf<EntityCallback<*>>()
 
     /**
-     * Registers an entity callback on this database's template.
+     * Registers an entity callback on this database's template, in addition to the plugin-level callbacks,
+     * which apply to every database.
      */
     public fun entityCallback(callback: EntityCallback<*>) {
         entityCallbacks += callback

--- a/storm-ktor/src/main/kotlin/st/orm/ktor/StormPluginConfig.kt
+++ b/storm-ktor/src/main/kotlin/st/orm/ktor/StormPluginConfig.kt
@@ -66,7 +66,7 @@ public class StormPluginConfig {
 
     /**
      * Optional [st.orm.core.spi.ExceptionMapper] that maps failures raised during query execution to the runtime
-     * exception thrown to the caller.
+     * exception thrown to the caller. Applies to every database unless a database block sets its own.
      *
      * @since 1.13
      */
@@ -74,7 +74,7 @@ public class StormPluginConfig {
 
     /**
      * Optional [st.orm.core.spi.QueryObserver] that is notified of query executions, for metrics and tracing
-     * bindings.
+     * bindings. Applies to every database unless a database block sets its own.
      *
      * @since 1.13
      */
@@ -83,7 +83,8 @@ public class StormPluginConfig {
     /**
      * Optional [st.orm.core.spi.SqlCommenter] that appends per-execution comment content to statements, such
      * as the current trace context ([st.orm.micrometer.TraceContextSqlCommenter]). Note that per-execution
-     * content defeats prepared statement caching; enable selectively.
+     * content defeats prepared statement caching; enable selectively. Applies to every database unless a
+     * database block sets its own.
      *
      * @since 1.13
      */
@@ -103,32 +104,48 @@ public class StormPluginConfig {
      * The summary logs under `st.orm.sql.perf` at INFO. Statements are recorded only while that logger is
      * enabled, so leaving this on costs nothing once the logger is turned down. Disabled by default.
      *
+     * Every `sqlLog*` option can come from the application configuration instead, under `storm.sqlLog`
+     * (or `storm.sql_log`), so the log can be switched on in production without a redeploy. A setting here
+     * overrides the configuration file; when neither sets an option, its default applies.
+     *
+     * ```
+     * storm.sqlLog {
+     *     enabled = true
+     *     threshold {
+     *         statements = 50
+     *         duration = 500ms
+     *     }
+     * }
+     * ```
+     *
      * For a narrower boundary than a request, open a scope directly with
      * [st.orm.template.sqlLog].
      *
      * @since 1.13
      */
-    public var sqlLog: Boolean = false
+    public var sqlLog: Boolean? = null
 
     /**
      * Number of statements a per-request scope records; the summary counts the rest regardless. Bounds what a
-     * single runaway call can retain and print.
+     * single runaway call can retain and print. Configuration key `storm.sqlLog.limit`; defaults to 200.
      *
      * @since 1.13
      */
-    public var sqlLogLimit: Int = 200
+    public var sqlLogLimit: Int? = null
 
     /**
      * Number of statements above which a call's summary is reported, at WARN. With any threshold set, only
      * calls that exceed one are reported, which is the guardrail form suited to production; without thresholds
-     * every call that touches the database is reported at INFO.
+     * every call that touches the database is reported at INFO. Configuration key
+     * `storm.sqlLog.threshold.statements`.
      *
      * @since 1.13
      */
     public var sqlLogStatementThreshold: Int? = null
 
     /**
-     * Call duration above which a call's summary is reported, at WARN.
+     * Call duration above which a call's summary is reported, at WARN. Configuration key
+     * `storm.sqlLog.threshold.duration`, as a duration such as `500ms`.
      *
      * @since 1.13
      */
@@ -137,24 +154,28 @@ public class StormPluginConfig {
     /**
      * Whether each execution is attributed to the application frame that caused it, shown per row as
      * `@ File.ext:line`. Costs a stack walk per execution while a scope records; suited to development.
-     * Defaults to false.
+     * Configuration key `storm.sqlLog.callSites`; defaults to false.
      *
      * @since 1.13
      */
-    public var sqlLogCallSites: Boolean = false
+    public var sqlLogCallSites: Boolean? = null
 
     /**
      * Packages whose frames are skipped when attributing an execution to a call site, so rows name the code
-     * that asked for the work rather than the application's own database plumbing.
+     * that asked for the work rather than the application's own database plumbing. Configuration key
+     * `storm.sqlLog.callSiteSkip`, a list or comma-separated string. Applied JVM-wide at installation, like
+     * the `storm.sql_log.call_site_skip` system property it complements; when unset, the system property's
+     * setting stays in effect.
      *
      * @since 1.13
      */
-    public var sqlLogCallSiteSkip: List<String> = emptyList()
+    public var sqlLogCallSiteSkip: List<String>? = null
 
     /**
      * Width a summary row aims for, such as 120 for narrow viewers or 240 for wide ones; the statement text
-     * elides to what the row's other columns leave. A display property of the deployment, applied once at
-     * installation.
+     * elides to what the row's other columns leave. A display property of the deployment, applied JVM-wide at
+     * installation. Configuration key `storm.sqlLog.lineWidth`; when unset, the `storm.sql_log.line_width`
+     * system property's setting stays in effect.
      *
      * @since 1.13
      */
@@ -164,11 +185,13 @@ public class StormPluginConfig {
      * How a read's summary row renders the declared hydration shape of its type: [HydrationShapes.OFF] (the
      * default), [HydrationShapes.SHORT] for the numeric form (`j2 c12 d3`: joins, columns, graph depth; flat
      * types show none), or [HydrationShapes.FULL] to name the joined-entity graph on every mapped read. Writes
-     * carry no shape.
+     * carry no shape. A display property of the deployment, applied JVM-wide at installation. Configuration
+     * key `storm.sqlLog.hydration`; when unset, the `storm.sql_log.hydration` system property's setting stays
+     * in effect.
      *
      * @since 1.13
      */
-    public var sqlLogHydration: HydrationShapes = HydrationShapes.OFF
+    public var sqlLogHydration: HydrationShapes? = null
 
     /**
      * Whether to expose the [st.orm.template.ORMTemplate] and the registered repositories through Ktor's
@@ -220,7 +243,8 @@ public class StormPluginConfig {
     }
 
     /**
-     * Entity callbacks for lifecycle hooks on insert, update, and delete operations.
+     * Entity callbacks for lifecycle hooks on insert, update, and delete operations. Applied to every
+     * database; callbacks declared in a database block apply to that database in addition.
      */
     public val entityCallbacks: MutableList<EntityCallback<*>> = mutableListOf()
 
@@ -237,8 +261,9 @@ public class StormPluginConfig {
      *
      * Auto-registration creates the repository proxies eagerly, so an invalid repository definition fails at
      * startup rather than at first request. Use [repositories] to narrow registration to specific packages, or
-     * set this to `false` to skip auto-registration entirely; repositories are then created lazily on first
-     * [repository] access, or explicitly via [stormRepositories].
+     * set this to `false` to skip auto-registration entirely, for the primary and named databases alike;
+     * repositories are then created lazily on first [repository] access, or explicitly via
+     * [stormRepositories]. The packages declared in a database block keep partitioning either way.
      *
      * @since 1.12
      */

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/SqlLogConfigTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/SqlLogConfigTest.kt
@@ -1,0 +1,173 @@
+package st.orm.ktor
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import st.orm.core.template.SqlLog.HydrationShapes
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Verifies the per-option resolution of the SQL log settings: an explicit plugin setting wins, otherwise the
+ * HOCON configuration under `storm.sqlLog` (or `storm.sql_log`) applies, otherwise the option's default.
+ */
+internal class SqlLogConfigTest {
+
+    @Test
+    fun `defaults apply when neither the plugin nor the configuration sets an option`() {
+        val settings = resolve()
+        settings.enabled shouldBe false
+        settings.limit shouldBe 200
+        settings.statementThreshold shouldBe null
+        settings.durationThreshold shouldBe null
+        settings.callSites shouldBe false
+        settings.callSiteSkip shouldBe emptyList()
+        settings.lineWidth shouldBe null
+        settings.hydration shouldBe null
+    }
+
+    @Test
+    fun `every option reads from camelCase configuration keys`() {
+        val settings = resolve(
+            "storm.sqlLog.enabled" to "true",
+            "storm.sqlLog.limit" to "50",
+            "storm.sqlLog.threshold.statements" to "10",
+            "storm.sqlLog.threshold.duration" to "250ms",
+            "storm.sqlLog.callSites" to "true",
+            "storm.sqlLog.callSiteSkip" to "com.myapp.data, com.myapp.plumbing",
+            "storm.sqlLog.lineWidth" to "120",
+            "storm.sqlLog.hydration" to "short",
+        )
+        settings.enabled shouldBe true
+        settings.limit shouldBe 50
+        settings.statementThreshold shouldBe 10
+        settings.durationThreshold shouldBe 250.milliseconds
+        settings.callSites shouldBe true
+        settings.callSiteSkip shouldBe listOf("com.myapp.data", "com.myapp.plumbing")
+        settings.lineWidth shouldBe 120
+        settings.hydration shouldBe HydrationShapes.SHORT
+    }
+
+    @Test
+    fun `every option reads from snake_case configuration keys`() {
+        val settings = resolve(
+            "storm.sql_log.enabled" to "true",
+            "storm.sql_log.limit" to "25",
+            "storm.sql_log.threshold.statements" to "5",
+            "storm.sql_log.threshold.duration" to "2s",
+            "storm.sql_log.call_sites" to "true",
+            "storm.sql_log.call_site_skip" to "com.myapp.data",
+            "storm.sql_log.line_width" to "240",
+            "storm.sql_log.hydration" to "FULL",
+        )
+        settings.enabled shouldBe true
+        settings.limit shouldBe 25
+        settings.statementThreshold shouldBe 5
+        settings.durationThreshold shouldBe 2.seconds
+        settings.callSites shouldBe true
+        settings.callSiteSkip shouldBe listOf("com.myapp.data")
+        settings.lineWidth shouldBe 240
+        settings.hydration shouldBe HydrationShapes.FULL
+    }
+
+    @Test
+    fun `callSiteSkip reads a configuration list`() {
+        val applicationConfig = MapApplicationConfig()
+        applicationConfig.put("storm.sqlLog.callSiteSkip", listOf("com.myapp.data", "com.myapp.web"))
+        val settings = resolve(applicationConfig)
+        settings.callSiteSkip shouldBe listOf("com.myapp.data", "com.myapp.web")
+    }
+
+    @Test
+    fun `a plugin setting overrides the configuration file`() {
+        val pluginConfig = StormPluginConfig().apply {
+            sqlLog = false
+            sqlLogLimit = 5
+        }
+        val settings = resolve(
+            "storm.sqlLog.enabled" to "true",
+            "storm.sqlLog.limit" to "99",
+            pluginConfig = pluginConfig,
+        )
+        settings.enabled shouldBe false
+        settings.limit shouldBe 5
+    }
+
+    @Test
+    fun `camelCase takes precedence over snake_case`() {
+        val settings = resolve(
+            "storm.sqlLog.limit" to "10",
+            "storm.sql_log.limit" to "20",
+        )
+        settings.limit shouldBe 10
+    }
+
+    @Test
+    fun `an invalid boolean aborts installation naming the key`() {
+        val exception = shouldThrow<IllegalStateException> {
+            resolve("storm.sqlLog.enabled" to "yes")
+        }
+        exception.message!! shouldContain "storm.sqlLog.enabled"
+        exception.message!! shouldContain "'yes'"
+    }
+
+    @Test
+    fun `an invalid integer aborts installation naming the key`() {
+        val exception = shouldThrow<IllegalStateException> {
+            resolve("storm.sql_log.limit" to "many")
+        }
+        exception.message!! shouldContain "storm.sql_log.limit"
+    }
+
+    @Test
+    fun `an invalid duration aborts installation naming the key`() {
+        val exception = shouldThrow<IllegalStateException> {
+            resolve("storm.sqlLog.threshold.duration" to "fast")
+        }
+        exception.message!! shouldContain "storm.sqlLog.threshold.duration"
+    }
+
+    @Test
+    fun `an invalid hydration mode aborts installation naming the valid values`() {
+        val exception = shouldThrow<IllegalStateException> {
+            resolve("storm.sqlLog.hydration" to "verbose")
+        }
+        exception.message!! shouldContain "storm.sqlLog.hydration"
+        exception.message!! shouldContain "off, short, full"
+    }
+
+    private fun resolve(
+        vararg pairs: Pair<String, String>,
+        pluginConfig: StormPluginConfig = StormPluginConfig(),
+    ): SqlLogSettings = resolve(MapApplicationConfig(*pairs), pluginConfig)
+
+    private fun resolve(
+        applicationConfig: MapApplicationConfig,
+        pluginConfig: StormPluginConfig = StormPluginConfig(),
+    ): SqlLogSettings {
+        var result: SqlLogSettings? = null
+        var failure: Throwable? = null
+        runBlocking {
+            testApplication {
+                environment {
+                    config = applicationConfig
+                }
+                application {
+                    // Resolution failures are rethrown outside the application block: testApplication wraps
+                    // an exception thrown during a module into its own startup failure.
+                    try {
+                        result = resolveSqlLogSettings(this, pluginConfig)
+                    } catch (e: Throwable) {
+                        failure = e
+                    }
+                }
+            }
+        }
+        failure?.let { throw it }
+        return result!!
+    }
+}

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormConfigReaderTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormConfigReaderTest.kt
@@ -51,6 +51,37 @@ internal class StormConfigReaderTest {
     }
 
     @Test
+    fun `named database reads keys under its own prefix`() {
+        val config = readNamedConfigFromMap(
+            "storm.databases.analytics.update.defaultMode" to "FIELD",
+        )
+        config.getProperty(UPDATE_DEFAULT_MODE) shouldBe "FIELD"
+    }
+
+    @Test
+    fun `named database inherits keys its own prefix does not set`() {
+        val config = readNamedConfigFromMap(
+            "storm.update.defaultMode" to "FIELD",
+            "storm.entityCache.retention" to "light",
+            "storm.databases.analytics.entityCache.retention" to "default",
+        )
+        // Unset under the named prefix: inherited from the root.
+        config.getProperty(UPDATE_DEFAULT_MODE) shouldBe "FIELD"
+        // Set under the named prefix: overrides the root.
+        config.getProperty(ENTITY_CACHE_RETENTION) shouldBe "default"
+    }
+
+    @Test
+    fun `named database inherits from an explicit fallback config`() {
+        val config = readNamedConfigFromMap(
+            "storm.databases.analytics.entityCache.retention" to "light",
+            fallback = StormConfig.of(mapOf(UPDATE_DEFAULT_MODE to "ENTITY")),
+        )
+        config.getProperty(UPDATE_DEFAULT_MODE) shouldBe "ENTITY"
+        config.getProperty(ENTITY_CACHE_RETENTION) shouldBe "light"
+    }
+
+    @Test
     fun `plugin reads config from HOCON environment`() = testApplication {
         environment {
             config = MapApplicationConfig(
@@ -81,6 +112,26 @@ internal class StormConfigReaderTest {
                 }
                 application {
                     result = st.orm.ktor.readStormConfig(this)
+                }
+            }
+        }
+        return result!!
+    }
+
+    /**
+     * Helper that reads the configuration of the named database `analytics` the way the plugin does: the keys
+     * under its own prefix, inheriting the rest from the fallback, which defaults to the root configuration.
+     */
+    private fun readNamedConfigFromMap(vararg pairs: Pair<String, String>, fallback: StormConfig? = null): StormConfig {
+        var result: StormConfig? = null
+        kotlinx.coroutines.runBlocking {
+            io.ktor.server.testing.testApplication {
+                environment {
+                    config = MapApplicationConfig(*pairs)
+                }
+                application {
+                    val primary = fallback ?: st.orm.ktor.readStormConfig(this)
+                    result = st.orm.ktor.readStormConfig(this, "storm.databases.analytics", fallback = primary)
                 }
             }
         }

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormMultipleDatabasesTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormMultipleDatabasesTest.kt
@@ -4,19 +4,27 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.di.dependencies
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import st.orm.EntityCallback
+import st.orm.core.spi.ExceptionMapper
+import st.orm.core.spi.QueryContext
+import st.orm.core.spi.QueryObserver
 import st.orm.ktor.model.PetRepository
 import st.orm.ktor.vet.Vet
 import st.orm.ktor.vet.VetRepository
 import st.orm.template.ORMTemplate
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Verifies the named-database support of the [Storm] plugin: per-database templates and repositories, package
@@ -27,7 +35,7 @@ import st.orm.template.ORMTemplate
  */
 internal class StormMultipleDatabasesTest {
 
-    private fun createTestDataSource(name: String, schemaResource: String): HikariDataSource {
+    private fun createTestDataSource(name: String, schemaResource: String? = null): HikariDataSource {
         val config = HikariConfig().apply {
             jdbcUrl = "jdbc:h2:mem:$name-${System.nanoTime()};DB_CLOSE_DELAY=-1"
             driverClassName = "org.h2.Driver"
@@ -36,13 +44,15 @@ internal class StormMultipleDatabasesTest {
             maximumPoolSize = 2
         }
         val dataSource = HikariDataSource(config)
-        dataSource.connection.use { connection ->
-            connection.createStatement().use { statement ->
-                val sql = this::class.java.getResourceAsStream(schemaResource)!!.bufferedReader().readText()
-                for (line in sql.split(";")) {
-                    val trimmed = line.trim()
-                    if (trimmed.isNotEmpty()) {
-                        statement.execute(trimmed)
+        if (schemaResource != null) {
+            dataSource.connection.use { connection ->
+                connection.createStatement().use { statement ->
+                    val sql = this::class.java.getResourceAsStream(schemaResource)!!.bufferedReader().readText()
+                    for (line in sql.split(";")) {
+                        val trimmed = line.trim()
+                        if (trimmed.isNotEmpty()) {
+                            statement.execute(trimmed)
+                        }
                     }
                 }
             }
@@ -50,7 +60,13 @@ internal class StormMultipleDatabasesTest {
         return dataSource
     }
 
-    private fun withClinicAndVetsDatabases(block: io.ktor.server.application.Application.() -> Unit) {
+    private fun withClinicAndVetsDatabases(block: Application.() -> Unit) = withClinicAndVetsDatabases(configure = {}) { block() }
+
+    private fun withClinicAndVetsDatabases(
+        configure: StormPluginConfig.() -> Unit,
+        configureVets: StormDatabaseConfig.() -> Unit = {},
+        block: Application.(vetsDataSource: HikariDataSource) -> Unit,
+    ) {
         val clinicDataSource = createTestDataSource("storm-multi-clinic", "/schema.sql")
         val vetsDataSource = createTestDataSource("storm-multi-vets", "/schema-vets.sql")
         try {
@@ -58,14 +74,16 @@ internal class StormMultipleDatabasesTest {
                 application {
                     install(Storm) {
                         dataSource = clinicDataSource
+                        configure()
                         // The primary must not see the vet package; partitioning also keeps schema
                         // validation (mode "fail" by default) green for both databases.
                         database("vets") {
                             dataSource = vetsDataSource
                             repositories("st.orm.ktor.vet")
+                            configureVets()
                         }
                     }
-                    block()
+                    block(vetsDataSource)
                 }
             }
         } finally {
@@ -124,4 +142,133 @@ internal class StormMultipleDatabasesTest {
         exception.message!! shouldContain "No database named 'specialties'"
         exception.message!! shouldContain "vets"
     }
+
+    @Test
+    fun `an unclaimed repository type is not served by a named database`() = withClinicAndVetsDatabases {
+        val exception = shouldThrow<IllegalStateException> {
+            repository<PetRepository>("vets")
+        }
+        exception.message!! shouldContain "does not belong to database 'vets'"
+        exception.message!! shouldContain "'st.orm.ktor.vet'"
+        exception.message!! shouldContain "repository<PetRepository>()"
+        exception.message!! shouldContain "repositories(\"st.orm.ktor.model\")"
+    }
+
+    @Test
+    fun `autoRegisterRepositories false covers named databases`() {
+        withClinicAndVetsDatabases(configure = { autoRegisterRepositories = false }) {
+            val vetsRegistry = attributes[NamedRepositoryRegistriesKey].getValue("vets")
+            shouldThrow<IllegalStateException> {
+                vetsRegistry.get(VetRepository::class)
+            }.message!! shouldContain "not registered"
+            // The claimed type is still created lazily on first access.
+            repository<VetRepository>("vets").findAll().size shouldBe 2
+        }
+    }
+
+    @Test
+    fun `plugin-level entity callbacks apply to named databases`() {
+        val pluginCallback = RecordingVetCallback()
+        val databaseCallback = RecordingVetCallback()
+        withClinicAndVetsDatabases(
+            configure = { entityCallback(pluginCallback) },
+            configureVets = { entityCallback(databaseCallback) },
+        ) {
+            repository<VetRepository>("vets").insert(Vet(firstName = "Sharon", lastName = "Jenkins"))
+            // The database's own callbacks apply in addition to the inherited plugin-level ones.
+            pluginCallback.inserted.size shouldBe 1
+            databaseCallback.inserted.size shouldBe 1
+        }
+    }
+
+    @Test
+    fun `plugin-level query observer applies to named databases`() {
+        val pluginObserver = RecordingQueryObserver()
+        withClinicAndVetsDatabases(configure = { queryObserver = pluginObserver }) {
+            val before = pluginObserver.executions.get()
+            repository<VetRepository>("vets").findAll()
+            pluginObserver.executions.get() shouldBeGreaterThan before
+        }
+    }
+
+    @Test
+    fun `database-level query observer overrides the inherited one`() {
+        val pluginObserver = RecordingQueryObserver()
+        val databaseObserver = RecordingQueryObserver()
+        withClinicAndVetsDatabases(
+            configure = { queryObserver = pluginObserver },
+            configureVets = { queryObserver = databaseObserver },
+        ) {
+            val before = pluginObserver.executions.get()
+            repository<VetRepository>("vets").findAll()
+            databaseObserver.executions.get() shouldBeGreaterThan 0
+            pluginObserver.executions.get() shouldBe before
+        }
+    }
+
+    @Test
+    fun `plugin-level exception mapper applies to named databases`() {
+        withClinicAndVetsDatabases(
+            configure = { exceptionMapper = ExceptionMapper { cause, _ -> MarkedException(cause) } },
+        ) { vetsDataSource ->
+            vetsDataSource.connection.use { connection ->
+                connection.createStatement().use { it.execute("DROP TABLE vet") }
+            }
+            shouldThrow<MarkedException> {
+                repository<VetRepository>("vets").findAll()
+            }
+        }
+    }
+
+    @Test
+    fun `named databases inherit the plugin-level schema validation mode`() {
+        val clinicDataSource = createTestDataSource("storm-multi-clinic", "/schema.sql")
+        // No schema at all: with the inherited "warn" mode the mismatches log instead of aborting
+        // installation, which the previously hardwired "fail" default would have done.
+        val emptyVetsDataSource = createTestDataSource("storm-multi-vets-empty")
+        try {
+            testApplication {
+                application {
+                    install(Storm) {
+                        dataSource = clinicDataSource
+                        schemaValidation = "warn"
+                        database("vets") {
+                            dataSource = emptyVetsDataSource
+                            repositories("st.orm.ktor.vet")
+                        }
+                    }
+                    orm("vets") shouldNotBe null
+                }
+            }
+        } finally {
+            clinicDataSource.close()
+            emptyVetsDataSource.close()
+        }
+    }
 }
+
+/**
+ * Entity callback that records the vets it saw, for asserting which database's template it was applied to.
+ */
+private class RecordingVetCallback : EntityCallback<Vet> {
+    val inserted = CopyOnWriteArrayList<Vet>()
+
+    override fun beforeInsert(entity: Vet): Vet {
+        inserted += entity
+        return entity
+    }
+}
+
+/**
+ * Query observer that counts executions, for asserting which database's template it was installed on.
+ */
+private class RecordingQueryObserver : QueryObserver {
+    val executions = AtomicInteger()
+
+    override fun onExecute(context: QueryContext): QueryObserver.Observation {
+        executions.incrementAndGet()
+        return QueryObserver.noop().onExecute(context)
+    }
+}
+
+private class MarkedException(cause: Throwable) : RuntimeException(cause)

--- a/storm-ktor/src/test/kotlin/st/orm/ktor/StormSqlLogTest.kt
+++ b/storm-ktor/src/test/kotlin/st/orm/ktor/StormSqlLogTest.kt
@@ -1,0 +1,122 @@
+package st.orm.ktor
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import st.orm.ktor.model.PetRepository
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+/**
+ * Verifies the per-call SQL log end to end: the summary reports through the `st.orm.sql.perf` logger, which the
+ * test classpath's slf4j-simple binding writes to `System.err`, captured around the whole test application so
+ * the assertion runs after every pipeline has unwound.
+ */
+internal class StormSqlLogTest {
+
+    private fun createTestDataSource(): HikariDataSource {
+        val config = HikariConfig().apply {
+            jdbcUrl = "jdbc:h2:mem:storm-sqllog-test-${System.nanoTime()};DB_CLOSE_DELAY=-1"
+            driverClassName = "org.h2.Driver"
+            username = "sa"
+            password = ""
+            maximumPoolSize = 2
+        }
+        val dataSource = HikariDataSource(config)
+        dataSource.connection.use { connection ->
+            connection.createStatement().use { statement ->
+                val sql = this::class.java.getResourceAsStream("/schema.sql")!!.bufferedReader().readText()
+                for (line in sql.split(";")) {
+                    val trimmed = line.trim()
+                    if (trimmed.isNotEmpty()) {
+                        statement.execute(trimmed)
+                    }
+                }
+            }
+        }
+        return dataSource
+    }
+
+    private fun captureStdErr(block: () -> Unit): String {
+        val original = System.err
+        val buffer = ByteArrayOutputStream()
+        System.setErr(PrintStream(buffer, true))
+        try {
+            block()
+        } finally {
+            System.setErr(original)
+        }
+        return buffer.toString()
+    }
+
+    private fun requestPets(vararg configPairs: Pair<String, String>, configure: StormPluginConfig.() -> Unit = {}): String {
+        val dataSource = createTestDataSource()
+        try {
+            return captureStdErr {
+                testApplication {
+                    environment {
+                        config = MapApplicationConfig(*configPairs)
+                    }
+                    application {
+                        install(Storm) {
+                            this.dataSource = dataSource
+                            configure()
+                        }
+                        routing {
+                            get("/pets") {
+                                call.respondText(repository<PetRepository>().findAll().size.toString())
+                            }
+                        }
+                    }
+                    client.get("/pets").status shouldBe HttpStatusCode.OK
+                }
+            }
+        } finally {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `the per-call summary is enabled from the configuration file alone`() {
+        val output = requestPets("storm.sqlLog.enabled" to "true")
+        output shouldContain "SQL (GET /pets)"
+    }
+
+    @Test
+    fun `a plugin setting overrides the configuration file`() {
+        val output = requestPets("storm.sqlLog.enabled" to "true") {
+            sqlLog = false
+        }
+        output shouldNotContain "SQL (GET /pets)"
+    }
+
+    @Test
+    fun `an unexceeded threshold from the configuration file suppresses the summary`() {
+        val output = requestPets(
+            "storm.sqlLog.enabled" to "true",
+            "storm.sqlLog.threshold.statements" to "999",
+        )
+        output shouldNotContain "SQL (GET /pets)"
+    }
+
+    @Test
+    fun `an exceeded threshold from the configuration file reports at WARN`() {
+        val output = requestPets(
+            "storm.sql_log.enabled" to "true",
+            "storm.sql_log.threshold.statements" to "1",
+        )
+        output shouldContain "SQL (GET /pets)"
+        output shouldContain "WARN"
+    }
+}


### PR DESCRIPTION
Fixes #399.

## Named databases inherit plugin-level configuration

A named database inherits the plugin-level settings that express policy, per option:

- Storm configuration keys resolve per key: `storm.databases.<name>.*` first, then the primary database's effective configuration (the plugin-level `config`, or `storm.*`). A root-level `storm.update.defaultMode` now applies to named databases.
- `exceptionMapper`, `queryObserver`, and `sqlCommenter` inherit the plugin-level instance unless the database block sets its own.
- The schema validation mode resolves database block, then `storm.databases.<name>.validation.schemaMode`, then plugin-level `schemaValidation`, then `storm.validation.schemaMode`, then `fail`.
- Plugin-level entity callbacks apply to every database; callbacks declared in a database block apply in addition.
- `autoRegisterRepositories = false` now covers named databases as well; the packages declared in a database block keep partitioning registration and schema validation either way.

What identifies a database never inherits: its data source, its migration hook, and its connection and transaction template providers, which define the database's transaction scope and default to fresh per-database instances. The rule is documented on `StormDatabaseConfig`, in the plugin KDoc, and on the docs site (Ktor integration, configuration).

## Unclaimed named lookups fail fast

`repository<T>("name")` for a type no database block claims used to silently bind the type to the named database. A named database's registry now serves only the types under its declared packages: an unclaimed lookup throws an error naming the database's declared packages, the primary alternative (`repository<T>()`), and the `repositories(...)` declaration that would claim the type. Types claimed by another database keep the existing error naming the owner.

## SQL log configurable from application.conf

All eight `sqlLog*` options resolve per option: plugin configuration first, then `storm.sqlLog.*` (or `storm.sql_log.*`), then the default, mirroring the Spring starter's `storm.sql-log.*` properties, so the log can be switched on in production without a redeploy. Invalid configuration values abort installation with an error naming the key.

The JVM-wide display settings (`callSiteSkip`, `lineWidth`, `hydration`) are applied only when actually configured: installation no longer resets `SqlLogRenderer.hydrationShapes` to `OFF` unconditionally, so a `storm.sql_log.hydration` system property, or another application's configuration in the same JVM, stays in effect unless this application configures its own.

The plugin options `sqlLog`, `sqlLogLimit`, `sqlLogCallSites`, `sqlLogCallSiteSkip`, and `sqlLogHydration` became nullable, with null meaning unset (fall through to the configuration file, then the default). Assignments in existing plugin blocks compile unchanged.

## Tests

- `SqlLogConfigTest`: per-option resolution (camelCase, snake_case, plugin precedence, list and comma-separated forms, invalid values).
- `StormSqlLogTest`: end-to-end summaries through `st.orm.sql.perf` from configuration alone, plugin override, and threshold gating in both directions.
- `StormConfigReaderTest`: per-key inheritance for named prefixes, including an explicit fallback config.
- `StormMultipleDatabasesTest`: callback, observer, and exception mapper inheritance and override, schema validation mode inheritance, `autoRegisterRepositories` gating of named databases, and the fail-fast unclaimed lookup.