### PR TITLE
fix: SqlCapture follows Kotlin coroutines, the Ktor test scope captures for real, and Kotlin gains a blocking SQL log scope

### DIFF
--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -250,7 +250,7 @@ The `SqlCapture` class from `storm-test` records all SQL statements generated du
 
 ```java
 var capture = new SqlCapture();
-capture.run(() -> {
+capture.record(() -> {
     userRepository.findAll();
 });
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -364,6 +364,7 @@ The Spring Boot starters include `storm-micrometer`; Ktor applications add it ex
 | Module | Provides |
 |--------|----------|
 | `storm-test` | `@StormTest` JUnit 5 extension and `SqlCapture`, framework-free |
+| `storm-kotlin-test` | The suspending `recording` extension, carrying `SqlCapture` across coroutines (test scope) |
 | `storm-spring-boot-test-autoconfigure` | The `@DataStormTest` Spring Boot test slice (test scope) |
 
 See [Testing](testing.md) and [Testing with @DataStormTest](spring-integration.md#testing-with-datastormtest).
@@ -394,6 +395,7 @@ storm-foundation (base interfaces)
     │   └── storm-kotlin-spring-boot-starter / storm-spring-boot-starter
     ├── storm-ktor (Ktor)
     │   └── storm-ktor-test (testing support)
+    ├── storm-kotlin-test (coroutine-aware SqlCapture, testing support)
     ├── dialect modules (postgresql, mysql, mariadb, oracle, mssqlserver, sqlite, h2)
     └── JSON modules (jackson2, jackson3, kotlinx-serialization)
 ```

--- a/docs/ktor-integration.md
+++ b/docs/ktor-integration.md
@@ -788,11 +788,13 @@ The `StormTestScope` provides three properties:
 |----------|------|-------------|
 | `stormDataSource` | `DataSource` | The H2 in-memory DataSource, pre-loaded with your SQL scripts |
 | `stormOrm` | `ORMTemplate` | A pre-configured ORM template backed by the test DataSource |
-| `stormSqlCapture` | `SqlCapture` | A capture instance for recording and inspecting generated SQL |
+| `stormSqlCapture` | `SqlCapture` | A capture recording the SQL the application executes while handling calls |
 
 ### SqlCapture
 
-Use `SqlCapture` to verify the SQL that Storm generates during a request. This is valuable for catching unintended query changes during refactoring and for ensuring complex operations produce the expected number of statements:
+Use `SqlCapture` to verify the SQL that Storm generates during a request. This is valuable for catching unintended query changes during refactoring and for ensuring complex operations produce the expected number of statements.
+
+The scope's capture is installed around every call the application handles, so a request's statements are captured wherever its handler runs, with no wrapping at the call site:
 
 ```kotlin
 @Test
@@ -804,15 +806,15 @@ fun `POST users generates single INSERT`() = testStormApplication(
         routing { userRoutes() }
     }
 
-    scope.stormSqlCapture.run {
-        client.post("/users") {
-            contentType(ContentType.Application.Json)
-            setBody("""{"email":"alice@test.com","name":"Alice"}""")
-        }
+    client.post("/users") {
+        contentType(ContentType.Application.Json)
+        setBody("""{"email":"alice@test.com","name":"Alice"}""")
     }
     assertEquals(1, scope.stormSqlCapture.count(Operation.INSERT))
 }
 ```
+
+Statements accumulate across requests; call `scope.stormSqlCapture.clear()` between requests to assert on one request at a time. Statements the test body executes directly against `scope.stormOrm`, such as seeding data, stay outside the capture, so they never distort a request's counts. To capture direct ORM work as well, wrap it in the suspending `recording` extension from `storm-kotlin-test`: `scope.stormSqlCapture.recording { ... }`.
 
 ### Combining with @StormTest
 

--- a/docs/sql-logging.md
+++ b/docs/sql-logging.md
@@ -196,6 +196,14 @@ val owners = sqlLog("importOwners") {
 
 The scope follows the coroutine, so it keeps recording across a suspension that resumes on another thread, and every coroutine launched inside it is covered. A scope opened by one coroutine is never observed by another.
 
+Kotlin code that runs outside coroutines, such as a Spring MVC controller, opens the same scope with `sqlLogBlocking`, mirroring how transactions ship as the `transaction` and `transactionBlocking` pair:
+
+```kotlin
+fun loadOwners(): List<OwnerView> = sqlLogBlocking("loadOwners") {
+    ownerService.loadAll()
+}
+```
+
 Code that builds its own coroutine from blocking code passes the scope along explicitly:
 
 ```kotlin

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -315,7 +315,7 @@ When testing database code, knowing _what_ SQL is executed is often as important
 
 ### Basic Usage
 
-Wrap any Storm operation in a `run`, `execute`, or `executeThrowing` call to capture the SQL statements it generates:
+Wrap any Storm operation in a `record`, `execute`, or `executeThrowing` call to capture the SQL statements it generates:
 
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
@@ -323,7 +323,7 @@ Wrap any Storm operation in a `run`, `execute`, or `executeThrowing` call to cap
 ```kotlin
 val capture = SqlCapture()
 
-capture.run { orm.entity<User>().findAll() }
+capture.record { orm.entity<User>().findAll() }
 
 capture.count(Operation.SELECT) shouldBe 1
 ```
@@ -334,7 +334,7 @@ capture.count(Operation.SELECT) shouldBe 1
 ```java
 var capture = new SqlCapture();
 
-capture.run(() -> orm.entity(User.class).findAll());
+capture.record(() -> orm.entity(User.class).findAll());
 
 assertEquals(1, capture.count(Operation.SELECT));
 ```
@@ -375,11 +375,35 @@ assertEquals(1, capture.count(Operation.SELECT));
 
 | Method              | Description                                                             |
 |---------------------|-------------------------------------------------------------------------|
-| `run(Runnable)`     | Captures SQL during the action. Returns nothing.                        |
+| `record(Runnable)`  | Captures SQL during the action. Returns nothing.                        |
 | `execute(Supplier)` | Captures SQL during the action. Returns the action's result.            |
 | `executeThrowing(Callable)` | Same as `execute`, but allows checked exceptions.               |
+| `attach()`          | Attaches until the returned handle is closed, for brackets a callable cannot wrap, such as a test lifecycle. |
 
-All three methods are scoped: only SQL statements generated within the block are recorded. Code running before or after the block, or on other threads, is not affected.
+These methods are scoped: only SQL statements generated within the block are recorded. Code running before or after the block is not affected. The capture binds to the thread that runs the action and to the contexts Storm carries it into, such as a `transaction { }` block; work handed to another thread outside those contexts falls outside the capture.
+
+### Capturing Across Coroutines (Kotlin)
+
+A capture opened by one of the blocking entry points stops recording at the first suspension that resumes on another thread. Kotlin coroutine code records through the suspending `recording` extension of the `storm-kotlin-test` module, which follows the coroutine across the threads it resumes on, and covers the coroutines launched within the block:
+
+```kotlin
+capture.recording {
+    users.insert(User(email = "alice@example.com"))
+    withContext(Dispatchers.IO) { users.findAll() }
+}
+capture.count(Operation.SELECT) shouldBe 1
+```
+
+```xml
+<dependency>
+    <groupId>st.orm</groupId>
+    <artifactId>storm-kotlin-test</artifactId>
+    <version>@@STORM_VERSION@@</version>
+    <scope>test</scope>
+</dependency>
+```
+
+The suspending entry point carries its own name: Kotlin resolves a call against a member on the lambda's shape alone, so a member named `record` would win the call and reject a suspending block rather than let it reach the extension. A suspending block inside `record { }` therefore fails to compile, pointing at `recording { }`; neither can silently resolve to the `kotlin.run` scope function the way the pre-1.14 `run` entry point could.
 
 ### Inspecting Captured Statements
 
@@ -434,11 +458,11 @@ Operation op = stmt.operation();         // SELECT, INSERT, UPDATE, DELETE, or U
 
 ### Accumulation and Clearing
 
-Statements accumulate across multiple `run`/`execute` calls on the same `SqlCapture` instance. This is useful when you want to measure the total SQL activity of a sequence of operations. Use `clear()` to reset between captures when you need to measure operations independently:
+Statements accumulate across multiple `record`/`execute` calls on the same `SqlCapture` instance. This is useful when you want to measure the total SQL activity of a sequence of operations. Use `clear()` to reset between captures when you need to measure operations independently:
 
 ```java
-capture.run(() -> orm.entity(User.class).findAll());
-capture.run(() -> orm.entity(User.class).findAll());
+capture.record(() -> orm.entity(User.class).findAll());
+capture.record(() -> orm.entity(User.class).findAll());
 assertEquals(2, capture.count(Operation.SELECT));
 
 capture.clear();
@@ -456,7 +480,7 @@ A count assertion is the simplest and most common use of `SqlCapture`. It protec
 @Test
 fun `bulk insert should use single statement`(orm: ORMTemplate, capture: SqlCapture) {
     val items = listOf(Item(name = "A"), Item(name = "B"), Item(name = "C"))
-    capture.run { orm.entity<Item>().insertAll(items) }
+    capture.record { orm.entity<Item>().insertAll(items) }
 
     capture.count(Operation.INSERT) shouldBe 1
 }
@@ -469,7 +493,7 @@ fun `bulk insert should use single statement`(orm: ORMTemplate, capture: SqlCapt
 @Test
 void bulkInsertShouldUseSingleStatement(ORMTemplate orm, SqlCapture capture) {
     var items = List.of(new Item(0, "A"), new Item(0, "B"), new Item(0, "C"));
-    capture.run(() -> orm.entity(Item.class).insertAll(items));
+    capture.record(() -> orm.entity(Item.class).insertAll(items));
 
     assertEquals(1, capture.count(Operation.INSERT));
 }
@@ -485,7 +509,7 @@ For finer-grained assertions, inspect the SQL text and bound parameters of indiv
 ```java
 @Test
 void findByIdShouldUseWhereClause(ORMTemplate orm, SqlCapture capture) {
-    capture.run(() -> orm.entity(User.class).findById(42));
+    capture.record(() -> orm.entity(User.class).findById(42));
 
     var stmts = capture.statements(Operation.SELECT);
     assertEquals(1, stmts.size());
@@ -501,7 +525,7 @@ When a service method should only read data, you can verify that no write operat
 ```java
 @Test
 void reportGenerationShouldBeReadOnly(ORMTemplate orm, SqlCapture capture) {
-    capture.run(() -> generateReport(orm));
+    capture.record(() -> generateReport(orm));
 
     assertEquals(0, capture.count(Operation.INSERT));
     assertEquals(0, capture.count(Operation.UPDATE));
@@ -521,7 +545,7 @@ class QueryCountTest {
 
     @Test
     void insertShouldGenerateOneStatement(ORMTemplate orm, SqlCapture capture) {
-        capture.run(() -> orm.entity(Item.class).insert(new Item(0, "Test")));
+        capture.record(() -> orm.entity(Item.class).insert(new Item(0, "Test")));
         assertEquals(1, capture.count(Operation.INSERT));
     }
 
@@ -537,7 +561,7 @@ class QueryCountTest {
 
 ## Ktor Testing
 
-The `storm-ktor-test` module provides a `testStormApplication` function that combines Storm's H2 setup with Ktor's `testApplication` builder. It creates an in-memory database, executes SQL scripts, and exposes a `StormTestScope` with `stormDataSource`, `stormOrm`, and `stormSqlCapture`.
+The `storm-ktor-test` module provides a `testStormApplication` function that combines Storm's H2 setup with Ktor's `testApplication` builder. It creates an in-memory database, executes SQL scripts, and exposes a `StormTestScope` with `stormDataSource`, `stormOrm`, and `stormSqlCapture`. The scope's capture is installed around every call the application handles, so a request's statements are captured wherever its handler runs, with no wrapping at the call site.
 
 ```kotlin
 @Test
@@ -584,5 +608,5 @@ See [Ktor Integration](ktor-integration.md#testing) for more details.
 2. **Use `SqlCapture` to verify query counts.** Asserting the number of statements an operation produces is an effective way to catch unintended query changes during refactoring.
 3. **Clear between captures** when a single test method needs to measure multiple operations independently.
 4. **Prefer `@StormTest` over manual setup.** It eliminates boilerplate and ensures consistent database lifecycle management across test classes.
-5. **`SqlCapture` binds to the calling thread and the contexts Storm carries it into.** Statements executed inside a `transaction { }` block or a coroutine given `sqlLogContext()` are captured wherever they run; work handed to a thread or coroutine without that context falls outside the capture. Recording itself is safe from any thread the work reaches.
+5. **`SqlCapture` binds to the thread that runs the action and the contexts Storm carries it into.** Statements executed inside a `transaction { }` block or a coroutine given `sqlLogContext()` are captured wherever they run; work handed to a thread or coroutine without that context falls outside the capture. Coroutine code records through the suspending `recording` extension of `storm-kotlin-test`, which follows the coroutine itself. Recording is safe from any thread the work reaches.
 6. **A resolution served from cache issues no statement.** Inside a transaction the entity cache answers repeat resolutions of the same record, so `count(FETCH)` counts distinct cache misses rather than `fetch()` call sites.

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <module>storm-spring-boot-test-autoconfigure</module>
         <module>storm-ktor</module>
         <module>storm-ktor-test</module>
+        <module>storm-kotlin-test</module>
     </modules>
     <dependencyManagement>
         <dependencies>

--- a/storm-bom/pom.xml
+++ b/storm-bom/pom.xml
@@ -211,6 +211,11 @@
                 <artifactId>storm-ktor-test</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>st.orm</groupId>
+                <artifactId>storm-kotlin-test</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/storm-core/src/main/java/st/orm/core/template/impl/SqlInterceptorManager.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/SqlInterceptorManager.java
@@ -281,31 +281,29 @@ public final class SqlInterceptorManager {
     }
 
     /**
-     * Create a new scoped interceptor that applies an operator to SQL statements processed by the current thread and
-     * any child threads.
+     * Creates a scoped interceptor that applies an operator to the SQL statements the carrier's action processes.
      *
-     * <p>This interceptor is scoped to the current thread context and propagates only to its child threads.
-     * It is isolated from sibling threads, meaning changes made to the interceptor set will not affect other threads
-     * that share the same parent scope.</p>
+     * <p>The scope covers the thread that runs the action, and only that thread: work handed to another thread does
+     * not pass through it unless an integration carries the scope there via {@link #holder()}. Scopes on different
+     * threads are isolated from one another.</p>
      *
      * @param operator the operator to apply to each SQL statement.
-     * @return a {@link Carrier} that binds the interceptor to the current thread's scoped context.
+     * @return a {@link Carrier} that binds the interceptor to the thread running its action.
      */
     public static Carrier intercept(UnaryOperator<Sql> operator) {
         return new CarrierImpl(new Operator(operator));
     }
 
     /**
-     * Create a new scoped interceptor that applies an operator to SQL statements processed by the current thread and
-     * any child threads.
+     * Creates a scoped interceptor that applies an operator to the SQL statements the carrier's action processes.
      *
-     * <p>This interceptor is scoped to the current thread context and propagates only to its child threads.
-     * It is isolated from sibling threads, meaning changes made to the interceptor set will not affect other threads
-     * that share the same parent scope.</p>
+     * <p>The scope covers the thread that runs the action, and only that thread: work handed to another thread does
+     * not pass through it unless an integration carries the scope there via {@link #holder()}. Scopes on different
+     * threads are isolated from one another.</p>
      *
      * @param customizer a function to customize the SQL template before use.
      * @param operator the operator to apply to each SQL statement.
-     * @return a {@link Carrier} that binds the interceptor to the current thread's scoped context.
+     * @return a {@link Carrier} that binds the interceptor to the thread running its action.
      * @since 1.3
      */
     public static Carrier intercept(UnaryOperator<SqlTemplate> customizer, UnaryOperator<Sql> operator) {
@@ -313,22 +311,14 @@ public final class SqlInterceptorManager {
     }
 
     /**
-     * Create a new scoped interceptor that applies an operator to SQL statements processed by the current thread and
-     * any child threads.
-     *
-     * <p>This interceptor is scoped to the current thread context and propagates only to its child threads.
-     * It is isolated from sibling threads, meaning changes made to the interceptor set will not affect other threads
-     * that share the same parent scope.</p>
-     *
-     * @param observer the observer to invoke with each SQL statement.
-     * @return a {@link Carrier} that binds the interceptor to the current thread's scoped context.
-     */
-    /**
      * Creates a scoped carrier for a listener notified around each statement execution, which is what a scope
      * needs: a statement carries no duration until it runs.
      *
+     * <p>The scope covers the thread that runs the action, and only that thread: work handed to another thread does
+     * not pass through it unless an integration carries the scope there via {@link #holder()}.</p>
+     *
      * @param listener the listener to notify around each execution.
-     * @return a {@link Carrier} that binds the listener to the current thread's scope.
+     * @return a {@link Carrier} that binds the listener to the thread running its action.
      * @since 1.13
      */
     public static Carrier listen(StatementListener listener) {
@@ -409,15 +399,15 @@ public final class SqlInterceptorManager {
     }
 
     /**
-     * Create a new scoped interceptor that applies an operator to SQL statements processed by the current thread and
-     * any child threads.
+     * Creates a scoped interceptor that invokes an observer with the SQL statements the carrier's action processes.
      *
-     * <p>This interceptor is scoped to the current thread context and propagates only to its child threads.
-     * It is isolated from sibling threads, meaning changes made to the interceptor set will not affect other threads
-     * that share the same parent scope.</p>
+     * <p>The scope covers the thread that runs the action, and only that thread: work handed to another thread does
+     * not pass through it unless an integration carries the scope there via {@link #holder()}. Scopes on different
+     * threads are isolated from one another.</p>
      *
+     * @param customizer a function to customize the SQL template before use.
      * @param observer the observer to invoke with each SQL statement.
-     * @return a {@link Carrier} that binds the interceptor to the current thread's scoped context.
+     * @return a {@link Carrier} that binds the interceptor to the thread running its action.
      * @since 1.3
      */
     public static Carrier intercept(UnaryOperator<SqlTemplate> customizer, Consumer<Sql> observer) {

--- a/storm-kotlin-test/pom.xml
+++ b/storm-kotlin-test/pom.xml
@@ -9,9 +9,9 @@
         <version>${revision}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <artifactId>storm-ktor-test</artifactId>
-    <name>Storm Ktor Test</name>
-    <description>Testing support for Storm with Ktor.</description>
+    <artifactId>storm-kotlin-test</artifactId>
+    <name>Storm Kotlin Test</name>
+    <description>Kotlin testing support for Storm, carrying SQL statement capture across coroutines.</description>
     <url>https://github.com/storm-orm/storm-framework</url>
     <licenses>
         <license>
@@ -30,11 +30,6 @@
         <developerConnection>scm:git:ssh://github.com/storm-orm/storm-framework.git</developerConnection>
         <url>https://github.com/storm-orm/storm-framework/</url>
     </scm>
-    <!-- Matches storm-ktor's toolchain (Ktor 3.4 / Kotlin 2.3 / coroutines 1.10); see storm-ktor/pom.xml. -->
-    <properties>
-        <kotlin.version>2.3.10</kotlin.version>
-        <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
-    </properties>
     <build>
         <plugins>
             <plugin>
@@ -45,10 +40,7 @@
                     <argLine>
                         @{argLine}
                         --add-opens java.base/java.lang=ALL-UNNAMED
-                        -Dstorm.ansi_escaping=true
                     </argLine>
-                    <forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
             <plugin>
@@ -74,6 +66,11 @@
                             <sourceDirs>
                                 <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
                             </sourceDirs>
+                            <!-- Main sources only: a missing visibility modifier or return type on the public
+                                 API fails the build, so nothing ships public by accident. -->
+                            <args combine.children="append">
+                                <arg>-Xexplicit-api=strict</arg>
+                            </args>
                         </configuration>
                     </execution>
                     <execution>
@@ -157,42 +154,10 @@
             </plugin>
         </plugins>
     </build>
-    <!-- Pin every transitive Kotlin artifact to this module's 2.3 version so the 2.3 stdlib required by
-         kotlinx-coroutines 1.10 (via Ktor 3.4) wins over the 2.0 stdlib pulled in by storm-kotlin. See
-         storm-ktor/pom.xml for the full rationale. -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-bom</artifactId>
-                <version>${kotlin.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- Align every transitive Ktor artifact to this module's Ktor version; see storm-ktor/pom.xml. -->
-            <dependency>
-                <groupId>io.ktor</groupId>
-                <artifactId>ktor-bom</artifactId>
-                <version>${ktor.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>st.orm</groupId>
             <artifactId>storm-kotlin</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
-            <version>${kotlin.coroutines.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>st.orm</groupId>
-            <artifactId>storm-ktor</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -201,24 +166,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>st.orm</groupId>
-            <artifactId>storm-kotlin-test</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>st.orm</groupId>
-            <artifactId>storm-core</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.ktor</groupId>
-            <artifactId>ktor-server-test-host-jvm</artifactId>
-            <version>${ktor.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
+            <version>${kotlin.coroutines.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>
@@ -232,15 +182,13 @@
         </dependency>
         <!-- Test -->
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
-            <version>${kotlin.version}</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/storm-kotlin-test/src/main/kotlin/st/orm/test/kotlin/SqlCaptures.kt
+++ b/storm-kotlin-test/src/main/kotlin/st/orm/test/kotlin/SqlCaptures.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.test.kotlin
+
+import kotlinx.coroutines.ThreadContextElement
+import kotlinx.coroutines.withContext
+import st.orm.test.SqlCapture
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Executes [block] while capturing all SQL statements it generates.
+ *
+ * The capture follows the coroutine rather than the thread it happens to run on: it keeps recording across a
+ * suspension that resumes elsewhere, and coroutines launched within the block inherit it, whichever dispatcher
+ * they land on. Work launched on a context built from scratch, such as an external scope, falls outside the
+ * capture, and a capture recording one coroutine is never observed by another:
+ *
+ * ```
+ * capture.recording {
+ *     users.insert(User(email = "alice@example.com"))
+ *     withContext(Dispatchers.IO) { users.findAll() }
+ * }
+ * capture.count(Operation.SELECT) shouldBe 1
+ * ```
+ *
+ * Blocking code records through the [SqlCapture.record] and [SqlCapture.execute] members. The suspending entry
+ * point carries its own name because Kotlin resolves a call against the member on the lambda's shape alone: a
+ * member named `record` would win the call and reject the suspending block, rather than let it reach this
+ * extension.
+ *
+ * @param block the work to record.
+ * @return the block's result.
+ * @since 1.14
+ */
+public suspend fun <T> SqlCapture.recording(block: suspend () -> T): T = withContext(SqlCaptureElement(this)) { block() }
+
+/**
+ * Binds a capture to the coroutine by attaching it to whichever thread the coroutine resumes on, and detaching
+ * it again on suspension, so the capture is only ever observable from the coroutine that opened it.
+ */
+private class SqlCaptureElement(
+    private val capture: SqlCapture,
+) : ThreadContextElement<AutoCloseable> {
+
+    /** A key per element, so nested captures stack on the thread the way the blocking entry points nest. */
+    private val instanceKey = object : CoroutineContext.Key<SqlCaptureElement> {}
+
+    override val key: CoroutineContext.Key<*> get() = instanceKey
+
+    override fun updateThreadContext(context: CoroutineContext): AutoCloseable = capture.attach()
+
+    override fun restoreThreadContext(context: CoroutineContext, oldState: AutoCloseable) {
+        oldState.close()
+    }
+}

--- a/storm-kotlin-test/src/test/kotlin/st/orm/test/kotlin/SqlCaptureRecordTest.kt
+++ b/storm-kotlin-test/src/test/kotlin/st/orm/test/kotlin/SqlCaptureRecordTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.test.kotlin
+
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Test
+import st.orm.template.ORMTemplate
+import st.orm.test.CapturedSql.Operation
+import st.orm.test.SqlCapture
+import st.orm.test.StormTest
+import st.orm.test.kotlin.model.City
+
+/**
+ * Verifies that a capture follows the coroutine rather than the thread: it keeps recording across a suspension
+ * that resumes on another thread, which is the case a thread-bound capture loses.
+ */
+@StormTest(scripts = ["/data.sql"])
+internal class SqlCaptureRecordTest {
+
+    @Test
+    fun `the suspending capture returns the block's result`(orm: ORMTemplate, capture: SqlCapture): Unit = runBlocking {
+        val cities = capture.recording {
+            orm.entity(City::class).findAll()
+        }
+        cities.shouldNotBeEmpty()
+        capture.count(Operation.SELECT) shouldBe 1
+    }
+
+    @Test
+    fun `a capture survives a suspension that resumes on another thread`(orm: ORMTemplate, capture: SqlCapture): Unit = runBlocking {
+        val threads = mutableSetOf<String>()
+        capture.recording {
+            threads += Thread.currentThread().name
+            orm.entity(City::class).findAll()
+            // Hop dispatchers: a thread-bound capture stops recording from here on.
+            withContext(Dispatchers.IO) {
+                threads += Thread.currentThread().name
+                orm.entity(City::class).findAll()
+            }
+            yield()
+            threads += Thread.currentThread().name
+            orm.entity(City::class).findAll()
+        }
+        threads.size shouldBeGreaterThan 1
+        capture.count(Operation.SELECT) shouldBe 3
+    }
+
+    @Test
+    fun `a coroutine launched inside the block records into the capture`(orm: ORMTemplate, capture: SqlCapture): Unit = runBlocking {
+        capture.recording {
+            coroutineScope {
+                async(Dispatchers.Default) {
+                    orm.entity(City::class).findAll()
+                }.await()
+            }
+        }
+        capture.count(Operation.SELECT) shouldBe 1
+    }
+
+    @Test
+    fun `statements executed after the block are not captured`(orm: ORMTemplate, capture: SqlCapture): Unit = runBlocking {
+        capture.recording {
+            orm.entity(City::class).findAll()
+        }
+        orm.entity(City::class).findAll()
+        capture.count(Operation.SELECT) shouldBe 1
+    }
+
+    @Test
+    fun `a blocking block resolves to the member and still records`(orm: ORMTemplate, capture: SqlCapture) {
+        capture.record { orm.entity(City::class).findAll() }
+        capture.count(Operation.SELECT) shouldBe 1
+    }
+}

--- a/storm-kotlin-test/src/test/kotlin/st/orm/test/kotlin/model/City.kt
+++ b/storm-kotlin-test/src/test/kotlin/st/orm/test/kotlin/model/City.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.test.kotlin.model
+
+import st.orm.Entity
+import st.orm.PK
+
+internal data class City(
+    @PK val id: Int = 0,
+    val name: String,
+) : Entity<Int>

--- a/storm-kotlin-test/src/test/resources/data.sql
+++ b/storm-kotlin-test/src/test/resources/data.sql
@@ -1,0 +1,7 @@
+drop table if exists city CASCADE;
+
+create table city (id integer auto_increment, name varchar(255), primary key (id));
+
+insert into city (name) values ('Amsterdam');
+insert into city (name) values ('Rotterdam');
+insert into city (name) values ('Utrecht');

--- a/storm-kotlin/src/main/kotlin/st/orm/template/SqlLogs.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/template/SqlLogs.kt
@@ -84,7 +84,8 @@ public fun sqlLogContext(): CoroutineContext {
  * the Micrometer observations, and test assertions to `SqlCapture`.
  *
  * The scope follows the coroutine rather than the thread it happens to run on, so it keeps recording across a
- * suspension that resumes elsewhere, and a scope opened by one coroutine is never observed by another.
+ * suspension that resumes elsewhere, and a scope opened by one coroutine is never observed by another. Code that
+ * runs outside coroutines opens the same scope with [sqlLogBlocking].
  *
  * Cost when inactive is zero: a scope registers on the interceptor chain every statement already walks, so a
  * statement executed with no scope open reads a single counter and stops.
@@ -114,4 +115,56 @@ public suspend fun <T> sqlLog(
         return block()
     }
     return recordSqlLog(name, limit, callSites, block, CoreSqlLog::report)
+}
+
+/**
+ * Records the statements executed by [block] from code that runs outside coroutines, reporting what the call cost
+ * the database.
+ *
+ * This is [sqlLog] for blocking code, mirroring how transactions ship as the [transaction] and [transactionBlocking]
+ * pair; a Kotlin service running on a request thread, such as a Spring MVC controller, wraps its work the same way:
+ *
+ * ```
+ * fun loadOwners(): List<OwnerView> = sqlLogBlocking("loadOwners") {
+ *     ownerService.loadAll()
+ * }
+ * ```
+ *
+ * The scope binds to the calling thread and to the contexts Storm builds below it: a [transaction] or
+ * [transactionBlocking] block opened inside observes it, whichever thread its coroutines resume on. A coroutine the
+ * application builds itself observes it only when launched with [sqlLogContext] alongside. Everything else,
+ * including how the summary reports and what it costs while inactive, matches [sqlLog].
+ *
+ * @param name what the scope covers, used to label the summary.
+ * @param limit the number of statements to record; the summary counts the rest regardless.
+ * @param callSites whether to attribute each execution to the application frame that caused it, which costs a
+ *   stack walk per execution while the scope records.
+ * @param block the work to record.
+ * @return the block's result.
+ * @since 1.14
+ */
+public fun <T> sqlLogBlocking(
+    name: String,
+    limit: Int = DEFAULT_SQL_LOG_LIMIT,
+    callSites: Boolean = false,
+    block: () -> T,
+): T {
+    if (!CoreSqlLog.reporting()) {
+        // Nothing consumes the summary, so no scope is opened to build one.
+        return block()
+    }
+    // A scope times executions, so it listens around them rather than intercepting the statements a call builds.
+    val recorder = CoreSqlLog.recorder(limit, callSites)
+    val started = System.nanoTime()
+    val detach = SqlInterceptorManager.attach(recorder)
+    try {
+        return block()
+    } finally {
+        try {
+            detach.close()
+        } finally {
+            // A call that failed is worth summarizing too: the statements leading up to it are the evidence.
+            CoreSqlLog.report(CoreSqlLog.summary(name, recorder, System.nanoTime() - started))
+        }
+    }
 }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/SqlLogTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/SqlLogTest.kt
@@ -63,6 +63,14 @@ internal open class SqlLogTest(
     }
 
     @Test
+    fun `sqlLogBlocking returns the block's result outside coroutines`() {
+        val pets = sqlLogBlocking("load") {
+            orm.entity(PetOwnerRef::class).select().resultList
+        }
+        pets.shouldNotBeEmpty()
+    }
+
+    @Test
     fun `a scope records the statements of the block`(): Unit = runBlocking {
         val (pets, summary) = record("load") {
             orm.entity(PetOwnerRef::class).select().resultList

--- a/storm-kotlin/src/test/kotlin/st/orm/template/StormTestExtensionTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/StormTestExtensionTest.kt
@@ -45,20 +45,20 @@ internal class StormTestExtensionTest {
 
     @Test
     fun `statement capture should record selects`(orm: ORMTemplate, capture: SqlCapture) {
-        capture.run { orm.entity(City::class).findAll() }
+        capture.record { orm.entity(City::class).findAll() }
         capture.count(Operation.SELECT) shouldBe 1
     }
 
     @Test
     fun `statement capture should record inserts`(orm: ORMTemplate, capture: SqlCapture) {
-        capture.run { orm.entity(City::class).insert(City(name = "TestCity")) }
+        capture.record { orm.entity(City::class).insert(City(name = "TestCity")) }
         capture.count(Operation.INSERT) shouldBe 1
     }
 
     @Test
     fun `statement capture should accumulate and clear`(orm: ORMTemplate, capture: SqlCapture) {
-        capture.run { orm.entity(City::class).findAll() }
-        capture.run { orm.entity(City::class).findAll() }
+        capture.record { orm.entity(City::class).findAll() }
+        capture.record { orm.entity(City::class).findAll() }
         capture.count(Operation.SELECT) shouldBe 2
         capture.clear()
         capture.count() shouldBe 0

--- a/storm-ktor-test/src/main/kotlin/st/orm/ktor/test/StormTestScope.kt
+++ b/storm-ktor-test/src/main/kotlin/st/orm/ktor/test/StormTestScope.kt
@@ -38,7 +38,10 @@ class StormTestScope internal constructor(
     val stormOrm: ORMTemplate,
 
     /**
-     * A fresh [SqlCapture] instance for verifying SQL statements executed during the test.
+     * A fresh [SqlCapture] for verifying the SQL the application executes. It is installed around every call the
+     * application handles, so a request's statements are captured wherever its handler runs; statements accumulate
+     * across requests, and [SqlCapture.clear] resets between them. Statements the test body executes directly
+     * against [stormOrm] stay outside the capture unless wrapped in the suspending `recording` extension.
      */
     val stormSqlCapture: SqlCapture,
 )

--- a/storm-ktor-test/src/main/kotlin/st/orm/ktor/test/TestStormApplication.kt
+++ b/storm-ktor-test/src/main/kotlin/st/orm/ktor/test/TestStormApplication.kt
@@ -15,10 +15,12 @@
  */
 package st.orm.ktor.test
 
+import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import st.orm.template.ORMTemplate
 import st.orm.test.SqlCapture
+import st.orm.test.kotlin.recording
 import java.sql.Connection
 import java.sql.DriverManager
 import javax.sql.DataSource
@@ -29,6 +31,12 @@ import javax.sql.DataSource
  * Creates an H2 in-memory database, executes optional SQL scripts, and provides a [StormTestScope] with
  * pre-configured [DataSource], [ORMTemplate], and [SqlCapture]. The scope also acts as an
  * [ApplicationTestBuilder] so you can configure routes, install plugins, and make test HTTP requests.
+ *
+ * The scope's [SqlCapture] is installed around every call the application handles, so the statements a request
+ * executes are captured wherever its handler runs, with no wrapping at the call site. Statements accumulate
+ * across requests; use [SqlCapture.clear] between requests to assert on one request at a time. Statements the
+ * test body executes directly against [StormTestScope.stormOrm] stay outside the capture unless wrapped in the
+ * suspending `recording` extension.
  *
  * Example usage:
  * ```kotlin
@@ -80,6 +88,13 @@ fun testStormApplication(
     val scope = StormTestScope(dataSource, ormTemplate, sqlCapture)
 
     testApplication {
+        application {
+            // The handler coroutines are not descendants of the test block, so the capture cannot be carried in
+            // from the call site; wrapping the pipeline is what makes the scope's capture observe every call.
+            intercept(ApplicationCallPipeline.Setup) {
+                sqlCapture.recording { proceed() }
+            }
+        }
         block(scope)
     }
 }

--- a/storm-ktor-test/src/test/kotlin/st/orm/ktor/test/TestStormApplicationTest.kt
+++ b/storm-ktor-test/src/test/kotlin/st/orm/ktor/test/TestStormApplicationTest.kt
@@ -2,6 +2,7 @@ package st.orm.ktor.test
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test
 import st.orm.ktor.Storm
 import st.orm.ktor.orm
 import st.orm.ktor.test.model.Pet
+import st.orm.test.CapturedSql.Operation
 
 class TestStormApplicationTest {
 
@@ -51,9 +53,53 @@ class TestStormApplicationTest {
     }
 
     @Test
-    fun `testStormApplication SqlCapture is available`() = testStormApplication(
+    fun `SqlCapture records the statements a request executes`() = testStormApplication(
         scripts = listOf("/schema.sql"),
     ) { scope ->
-        scope.stormSqlCapture shouldNotBe null
+        application {
+            install(Storm) {
+                dataSource = scope.stormDataSource
+            }
+            routing {
+                get("/pets/count") {
+                    val count = call.application.orm.entity(Pet::class).findAll().size
+                    call.respondText(count.toString())
+                }
+            }
+        }
+        client.get("/pets/count").status shouldBe HttpStatusCode.OK
+        scope.stormSqlCapture.count(Operation.SELECT) shouldBe 1
+        scope.stormSqlCapture.statements(Operation.SELECT).first().statement().uppercase() shouldContain "SELECT"
+    }
+
+    @Test
+    fun `SqlCapture accumulates across requests and clears between them`() = testStormApplication(
+        scripts = listOf("/schema.sql"),
+    ) { scope ->
+        application {
+            install(Storm) {
+                dataSource = scope.stormDataSource
+            }
+            routing {
+                get("/pets/count") {
+                    val count = call.application.orm.entity(Pet::class).findAll().size
+                    call.respondText(count.toString())
+                }
+            }
+        }
+        client.get("/pets/count")
+        client.get("/pets/count")
+        scope.stormSqlCapture.count(Operation.SELECT) shouldBe 2
+        scope.stormSqlCapture.clear()
+        client.get("/pets/count")
+        scope.stormSqlCapture.count(Operation.SELECT) shouldBe 1
+    }
+
+    @Test
+    fun `statements the test body executes directly stay outside the capture`() = testStormApplication(
+        scripts = listOf("/schema.sql"),
+    ) { scope ->
+        scope.stormOrm.entity(Pet::class).findAll()
+        scope.stormSqlCapture.count() shouldBe 0
     }
 }

--- a/storm-test/src/main/java/st/orm/test/SqlCapture.java
+++ b/storm-test/src/main/java/st/orm/test/SqlCapture.java
@@ -33,11 +33,14 @@ import st.orm.test.CapturedSql.Origin;
  *
  * <p>Statements are recorded around execution, so each carries what caused it, its bound parameter values, and how
  * long it took, and a statement that is built but never run is not captured. Statements accumulate across multiple
- * {@link #run}, {@link #execute}, or {@link #executeThrowing} calls; use {@link #clear()} to reset between
+ * {@link #record}, {@link #execute}, or {@link #executeThrowing} calls; use {@link #clear()} to reset between
  * captures.</p>
  *
- * <p>The capture is bound to the calling thread and to the contexts Storm carries it into, such as a
- * {@code transaction} block; recording is safe from any thread the work reaches.</p>
+ * <p>The capture is bound to the thread that runs the action and to the contexts Storm carries it into, such as a
+ * {@code transaction} block; it does not follow work handed to another thread or coroutine outside those contexts.
+ * Recording itself is safe from any thread a carried context reaches. Kotlin coroutine code records through the
+ * suspending {@code recording} extension of the {@code storm-kotlin-test} module, which follows the coroutine across
+ * the threads it resumes on.</p>
  *
  * <p><strong>Testing only.</strong> Captured statements retain their bound parameter values, which may be
  * sensitive (credentials, personal data). This class lives in the test-scoped {@code storm-test} module; do
@@ -77,10 +80,27 @@ public final class SqlCapture {
     /**
      * Executes the given action while capturing all SQL statements it generates.
      *
+     * <p>Named {@code record} rather than {@code run} so a Kotlin caller can never silently resolve to the
+     * {@code kotlin.run} scope function, which would execute the action without capturing anything.</p>
+     *
      * @param action the action to execute.
+     * @since 1.14
      */
-    public void run(Runnable action) {
+    public void record(Runnable action) {
         SqlInterceptorManager.listen(listener).run(action);
+    }
+
+    /**
+     * Attaches the capture to the calling thread until the returned handle is closed, for brackets around code that
+     * a callable cannot wrap, such as a test lifecycle.
+     *
+     * <p>The handle must be closed on the thread that attached, which a try-with-resources block guarantees.</p>
+     *
+     * @return the handle that detaches the capture.
+     * @since 1.14
+     */
+    public AutoCloseable attach() {
+        return SqlInterceptorManager.attach(listener);
     }
 
     /**

--- a/storm-test/src/test/java/st/orm/test/SqlCaptureTest.java
+++ b/storm-test/src/test/java/st/orm/test/SqlCaptureTest.java
@@ -24,7 +24,7 @@ class SqlCaptureTest {
     void captureDeleteOperationShouldRecordDeleteStatement(ORMTemplate orm, SqlCapture capture) {
         // Insert an item, then delete it while capturing to exercise the DELETE branch.
         Integer insertedId = orm.entity(Item.class).insertAndFetchId(new Item(0, "ToDelete"));
-        capture.run(() -> orm.entity(Item.class).remove(new Item(insertedId, "ToDelete")));
+        capture.record(() -> orm.entity(Item.class).remove(new Item(insertedId, "ToDelete")));
         assertEquals(1, capture.count(Operation.DELETE));
         var deleteStatements = capture.statements(Operation.DELETE);
         assertEquals(1, deleteStatements.size());
@@ -35,14 +35,14 @@ class SqlCaptureTest {
     void captureUndefinedOperationViaRawSql(ORMTemplate orm, SqlCapture capture) {
         // Execute raw SQL that does not start with SELECT/INSERT/UPDATE/DELETE
         // to exercise the UNDEFINED branch in the createObserver switch.
-        capture.run(() -> orm.query("SET @x = 1").executeUpdate());
+        capture.record(() -> orm.query("SET @x = 1").executeUpdate());
         var undefinedStatements = capture.statements(Operation.UNDEFINED);
         assertEquals(1, undefinedStatements.size());
     }
 
     @Test
     void capturedStatementParametersShouldContainBoundValues(ORMTemplate orm, SqlCapture capture) {
-        capture.run(() -> orm.entity(Item.class).findById(1));
+        capture.record(() -> orm.entity(Item.class).findById(1));
         var statements = capture.statements(Operation.SELECT);
         assertFalse(statements.isEmpty());
         assertNotNull(statements.getFirst().parameters());

--- a/storm-test/src/test/java/st/orm/test/StormExtensionAdditionalTest.java
+++ b/storm-test/src/test/java/st/orm/test/StormExtensionAdditionalTest.java
@@ -49,8 +49,8 @@ class StormExtensionAdditionalTest {
 
     @Test
     void statementCaptureStatementsShouldReturnFilteredStatements(ORMTemplate orm, SqlCapture capture) {
-        capture.run(() -> orm.entity(Item.class).findAll());
-        capture.run(() -> orm.entity(Item.class).insert(new Item(0, "Echo")));
+        capture.record(() -> orm.entity(Item.class).findAll());
+        capture.record(() -> orm.entity(Item.class).insert(new Item(0, "Echo")));
 
         var selects = capture.statements(CapturedSql.Operation.SELECT);
         var inserts = capture.statements(CapturedSql.Operation.INSERT);
@@ -62,7 +62,7 @@ class StormExtensionAdditionalTest {
 
     @Test
     void statementCaptureShouldReturnAllStatements(ORMTemplate orm, SqlCapture capture) {
-        capture.run(() -> orm.entity(Item.class).findAll());
+        capture.record(() -> orm.entity(Item.class).findAll());
         var allStatements = capture.statements();
         assertEquals(1, allStatements.size());
         assertNotNull(allStatements.getFirst().statement());
@@ -71,7 +71,7 @@ class StormExtensionAdditionalTest {
 
     @Test
     void statementCaptureShouldRecordUpdates(ORMTemplate orm, SqlCapture capture) {
-        capture.run(() -> orm.entity(Item.class).update(new Item(1, "Updated")));
+        capture.record(() -> orm.entity(Item.class).update(new Item(1, "Updated")));
         assertEquals(1, capture.count(CapturedSql.Operation.UPDATE));
         var updates = capture.statements(CapturedSql.Operation.UPDATE);
         assertEquals(1, updates.size());

--- a/storm-test/src/test/java/st/orm/test/StormExtensionTest.java
+++ b/storm-test/src/test/java/st/orm/test/StormExtensionTest.java
@@ -66,21 +66,21 @@ class StormExtensionTest {
 
     @Test
     void statementCaptureShouldRecordSelects(ORMTemplate orm, SqlCapture capture) {
-        capture.run(() -> orm.entity(Item.class).findAll());
+        capture.record(() -> orm.entity(Item.class).findAll());
         assertEquals(1, capture.count(Operation.SELECT));
         assertTrue(capture.count() >= 1);
     }
 
     @Test
     void statementCaptureShouldRecordInserts(ORMTemplate orm, SqlCapture capture) {
-        capture.run(() -> orm.entity(Item.class).insert(new Item(0, "Delta")));
+        capture.record(() -> orm.entity(Item.class).insert(new Item(0, "Delta")));
         assertEquals(1, capture.count(Operation.INSERT));
     }
 
     @Test
     void statementCaptureShouldAccumulateAndClear(ORMTemplate orm, SqlCapture capture) {
-        capture.run(() -> orm.entity(Item.class).findAll());
-        capture.run(() -> orm.entity(Item.class).findAll());
+        capture.record(() -> orm.entity(Item.class).findAll());
+        capture.record(() -> orm.entity(Item.class).findAll());
         assertEquals(2, capture.count(Operation.SELECT));
         capture.clear();
         assertEquals(0, capture.count());
@@ -88,7 +88,7 @@ class StormExtensionTest {
 
     @Test
     void capturedStatementShouldContainSqlAndParameters(ORMTemplate orm, SqlCapture capture) {
-        capture.run(() -> orm.entity(Item.class).findById(1));
+        capture.record(() -> orm.entity(Item.class).findById(1));
         var statements = capture.statements(Operation.SELECT);
         assertEquals(1, statements.size());
         var stmt = statements.getFirst();


### PR DESCRIPTION
Fixes #388.

## What this fixes

`SqlCapture` could not observe work that crossed a coroutine suspension: the interceptor scope lives in a plain `ThreadLocal`, and while the coroutine-aware plumbing existed for the SQL log (`SqlLogRecording`), the capture never used it. On top of that, `storm-ktor-test` handed out a `SqlCapture` that nothing installed, so the documented Ktor testing flow verified nothing. The `SqlInterceptorManager` javadoc also claimed propagation to child threads in four places, which a non-inheritable `ThreadLocal` never does. Finally, `sqlLog { }` was suspend-only while transactions ship as a `transaction`/`transactionBlocking` pair, leaving blocking Kotlin code (Spring MVC being the common case) without a SQL log scope.

## Changes

- **storm-test**: `SqlCapture.run(Runnable)` is renamed to `record(Runnable)`, and `attach(): AutoCloseable` is added for brackets a callable cannot wrap. The class javadoc now states the real thread binding.
- **storm-kotlin-test (new module)**: `suspend fun SqlCapture.recording { }` follows the coroutine across the threads it resumes on, covering the coroutines launched within the block. It is built entirely on public API: a `ThreadContextElement` attaches the capture on every resume and detaches on suspension, with a per-instance key so nested captures stack the way the blocking entry points nest.
- **storm-ktor-test**: `testStormApplication` installs the scope's capture around every call the application handles, via a `Setup`-phase pipeline interceptor. Handler coroutines are not descendants of the test block, so no call-site binding could ever reach them; wrapping the pipeline is what makes the documented flow work. Statements the test body executes directly against `stormOrm` stay outside the capture, so seeding never distorts a request's counts. The assert-only-non-null test is replaced with tests that capture through real requests.
- **storm-kotlin**: `sqlLogBlocking(name, limit, callSites) { }` mirrors the `transaction`/`transactionBlocking` pairing. It reports through the `st.orm.sql.perf` logger like `sqlLog`, and a `transaction { }` opened inside carries the scope into its coroutines.
- **storm-core**: the four child-thread javadoc claims now state that a scope covers the thread running the action, with `holder()` as the carrier for integrations; a duplicated javadoc block above `listen` is removed.
- **docs**: the Ktor `SqlCapture` example now shows the working shape, testing.md documents coroutine capture and the new module, sql-logging.md documents `sqlLogBlocking`, installation.md lists `storm-kotlin-test`. Docs changes appear at `/docs/next` until the next release snapshots them.

## A correction to the issue's diagnosis

The claim that `capture.run { someSuspendCall() }` silently resolves to `kotlin.run` does not hold as stated: verified by compilation under both Kotlin 2.0.21 and 2.3.10, the `run(Runnable)` member wins resolution on the lambda's shape alone, so a suspending block fails to compile with "Suspension functions can only be called within coroutine body". The documented Ktor example therefore did not compile at all. The silent variant is real but different: a value-expecting call site such as `val users = capture.run { orm.findAll() }` disqualifies the void member on expected type, resolves to `kotlin.run`, and executes without capturing.

The same resolution rule shaped the API: a member always beats a same-named extension, so the suspending entry point cannot share the member's name. Hence the `record` member for blocking code and the `recording` extension for coroutine code; a suspending block inside `record { }` is a compile error pointing at `recording { }`, and neither name can fall through to `kotlin.run`.

## Breaking change

`SqlCapture.run(Runnable)` is gone (1.14 policy, no shims). Java call sites fail to compile and rename to `record`. Kotlin call sites of the form `capture.run { blocking work }` keep compiling by resolving to `kotlin.run` and stop capturing: most count assertions then fail visibly, but zero-expectation guards such as `count(FETCH) == 0` pass vacuously, so this deserves a release-notes callout.

## Testing

All touched modules green: storm-core 2633, storm-kotlin 1730 (including a new `sqlLogBlocking` test), storm-test 59, storm-kotlin-test 5 (capture across a `Dispatchers.IO` hop, inheritance by launched coroutines, member resolution for blocking blocks), storm-ktor-test 6 (capture through real requests, accumulation and clearing, test-body isolation).