### PR TITLE
ci: dialect tests pin their container images, the Kotlin plugin variant is guarded, and two working files are ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,11 @@ website/static/api/
 # prebuild step of every site build. Committing it only lets it drift.
 website/static/llms-full.txt
 
-# Working analysis doc — not for check-in
+### Maven ###
+# Machine-local heap tuning for the reactor. Maven reads it automatically, so a
+# contributor's setting would otherwise land in every build that shares the repo.
+.mvn/jvm.config
+
+# Working analysis docs — not for check-in
 ADOPTION_ANALYSIS.md
+ARTICLE_SCHEDULE.md

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,27 @@
                             </rules>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>require-kotlin-variant-match</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- kotlin.major.minor selects the storm-compiler-plugin variant that storm-kotlin
+                                     and storm-kotlinx-serialization compile against. It stays an explicit property
+                                     rather than a derived one, mirroring the Gradle plugin's compilerPluginVariant,
+                                     so a variant can be pinned forward for a Kotlin release the plugin predates.
+                                     Left to drift instead, the two modules silently compile against a plugin built
+                                     for another compiler generation, which surfaces far from its cause. Every
+                                     module that overrides kotlin.version therefore overrides this one too. -->
+                                <evaluateBeanshell>
+                                    <condition>"${kotlin.version}".startsWith("${kotlin.major.minor}.")</condition>
+                                    <message>kotlin.major.minor (${kotlin.major.minor}) does not match kotlin.version (${kotlin.version}): the storm-compiler-plugin-${kotlin.major.minor} variant targets another compiler generation. Set both properties together.</message>
+                                </evaluateBeanshell>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/storm-ktor-test/pom.xml
+++ b/storm-ktor-test/pom.xml
@@ -33,6 +33,7 @@
     <!-- Matches storm-ktor's toolchain (Ktor 3.4 / Kotlin 2.3 / coroutines 1.10); see storm-ktor/pom.xml. -->
     <properties>
         <kotlin.version>2.3.10</kotlin.version>
+        <kotlin.major.minor>2.3</kotlin.major.minor>
         <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
     </properties>
     <build>

--- a/storm-ktor/pom.xml
+++ b/storm-ktor/pom.xml
@@ -35,6 +35,7 @@
          it overrides the same versions) this does not force the newer toolchain onto any other module. -->
     <properties>
         <kotlin.version>2.3.10</kotlin.version>
+        <kotlin.major.minor>2.3</kotlin.major.minor>
         <kotlin.coroutines.version>1.10.2</kotlin.coroutines.version>
     </properties>
     <build>

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBEntityRepositoryTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBEntityRepositoryTest.java
@@ -56,7 +56,7 @@ public class MariaDBEntityRepositoryTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static MariaDBContainer<?> mariadbContainer = new MariaDBContainer<>("mariadb:latest")
+    public static MariaDBContainer<?> mariadbContainer = new MariaDBContainer<>("mariadb:11.8")
             .withDatabaseName("test")
             .withUsername("test")
             .withPassword("test")

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBPolymorphicTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBPolymorphicTest.java
@@ -39,7 +39,7 @@ public class MariaDBPolymorphicTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static MariaDBContainer<?> mariadbContainer = new MariaDBContainer<>("mariadb:latest")
+    public static MariaDBContainer<?> mariadbContainer = new MariaDBContainer<>("mariadb:11.8")
             .withDatabaseName("test")
             .withUsername("test")
             .withPassword("test")

--- a/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBSchemaValidatorTest.java
+++ b/storm-mariadb/src/test/java/st/orm/spi/mariadb/MariaDBSchemaValidatorTest.java
@@ -53,7 +53,7 @@ public class MariaDBSchemaValidatorTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static MariaDBContainer<?> mariadbContainer = new MariaDBContainer<>("mariadb:latest")
+    public static MariaDBContainer<?> mariadbContainer = new MariaDBContainer<>("mariadb:11.8")
             .withDatabaseName("test")
             .withUsername("test")
             .withPassword("test")

--- a/storm-oracle/src/test/java/st/orm/spi/oracle/OracleEntityRepositoryTest.java
+++ b/storm-oracle/src/test/java/st/orm/spi/oracle/OracleEntityRepositoryTest.java
@@ -60,7 +60,7 @@ public class OracleEntityRepositoryTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static GenericContainer<?> oracleContainer = new GenericContainer<>("gvenzl/oracle-free:latest")
+    public static GenericContainer<?> oracleContainer = new GenericContainer<>("gvenzl/oracle-free:23")
             .withExposedPorts(1521)
             .withEnv("ORACLE_PASSWORD", "oracle")
             .withEnv("APP_USER", "test")

--- a/storm-oracle/src/test/java/st/orm/spi/oracle/OraclePolymorphicTest.java
+++ b/storm-oracle/src/test/java/st/orm/spi/oracle/OraclePolymorphicTest.java
@@ -40,7 +40,7 @@ public class OraclePolymorphicTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static GenericContainer<?> oracleContainer = new GenericContainer<>("gvenzl/oracle-free:latest")
+    public static GenericContainer<?> oracleContainer = new GenericContainer<>("gvenzl/oracle-free:23")
             .withExposedPorts(1521)
             .withEnv("ORACLE_PASSWORD", "oracle")
             .withEnv("APP_USER", "test")

--- a/storm-oracle/src/test/java/st/orm/spi/oracle/OracleSchemaValidatorTest.java
+++ b/storm-oracle/src/test/java/st/orm/spi/oracle/OracleSchemaValidatorTest.java
@@ -54,7 +54,7 @@ public class OracleSchemaValidatorTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static GenericContainer<?> oracleContainer = new GenericContainer<>("gvenzl/oracle-free:latest")
+    public static GenericContainer<?> oracleContainer = new GenericContainer<>("gvenzl/oracle-free:23")
             .withExposedPorts(1521)
             .withEnv("ORACLE_PASSWORD", "oracle")
             .withEnv("APP_USER", "test")

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLEntityRepositoryTest.java
@@ -59,7 +59,7 @@ public class PostgreSQLEntityRepositoryTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:latest")
+    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:17")
             .withDatabaseName("test")
             .withUsername("test")
             .withPassword("test")

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLJsonTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLJsonTest.java
@@ -58,7 +58,7 @@ public class PostgreSQLJsonTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:latest")
+    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:17")
             .withDatabaseName("test")
             .withUsername("test")
             .withPassword("test")

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLPolymorphicTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLPolymorphicTest.java
@@ -39,7 +39,7 @@ public class PostgreSQLPolymorphicTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:latest")
+    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:17")
             .withDatabaseName("test")
             .withUsername("test")
             .withPassword("test")

--- a/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLSchemaValidatorTest.java
+++ b/storm-postgresql/src/test/java/st/orm/spi/postgresql/PostgreSQLSchemaValidatorTest.java
@@ -53,7 +53,7 @@ public class PostgreSQLSchemaValidatorTest {
 
     @SuppressWarnings("resource")
     @Container
-    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:latest")
+    public static PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:17")
             .withDatabaseName("test")
             .withUsername("test")
             .withPassword("test")


### PR DESCRIPTION
Four build-hygiene items from the fresh-eyes review that survived the #413 sweep.

## Dialect test containers are pinned

`#413` pinned the `docker-compose.yml` images but not the Testcontainers constructors, which is what `mvn verify` actually runs. Ten sites across three modules still named `:latest`:

| Module | Was | Now | Declared in docker-compose.yml |
|---|---|---|---|
| storm-postgresql (4) | `postgres:latest` | `postgres:17` | `postgres:17` |
| storm-mariadb (3) | `mariadb:latest` | `mariadb:11.8` | `mariadb:11.8` |
| storm-oracle (3) | `gvenzl/oracle-free:latest` | `gvenzl/oracle-free:23` | `gvenzl/oracle-free:23` |

storm-mysql and storm-mssqlserver already name their versions inline, so this makes the five server modules consistent. `postgres:latest` was resolving to 18.4, so those tests had drifted a full major ahead of the version the module declares.

This pins the major/minor line rather than a digest, which is the same bar `docker-compose.yml` already sets; the images still take patch updates within the line.

## The Kotlin compiler-plugin variant is guarded

`kotlin.major.minor` selects `storm-compiler-plugin-${kotlin.major.minor}`, which storm-kotlin and storm-kotlinx-serialization compile against, and nothing tied it to `kotlin.version`. Raising one without the other compiles both modules against a plugin built for a different compiler generation, and the failure surfaces far from its cause.

A `require-kotlin-variant-match` enforcer rule now requires the two to agree. The property stays explicit rather than derived, mirroring the Gradle plugin's `compilerPluginVariant`, so a variant can still be pinned forward for a Kotlin release the plugin predates.

Writing the rule surfaced that storm-ktor and storm-ktor-test override `kotlin.version` to 2.3.10 for Ktor's toolchain without a matching variant, so both now declare `2.3`.

## Two working files are ignored

`.mvn/jvm.config` is machine-local heap tuning that Maven picks up automatically, and `ARTICLE_SCHEDULE.md` is a working document. Both were untracked and unignored, one `git add .` from being committed. `ADOPTION_ANALYSIS.md` was already handled this way.

## Verification

The container pins change what these tests run against, so all three suites were run against the new images rather than assumed:

| Suite | Result | Server version |
|---|---|---|
| storm-postgresql | 181 passed | 17.9 |
| storm-mariadb | 163 passed | 11.8.8 |
| storm-oracle | 174 passed | 23.1 |

The enforcer rule was checked in both directions: `mvn validate` passes across all 30 modules, and `-Dkotlin.major.minor=2.1` fails with the intended message rather than a downstream compiler error. `mvn spotless:check` passes, and `git check-ignore` confirms both new patterns match.

No CHANGELOG entry, following how #413, #381 and the dependabot work landed: build and CI changes are not user-facing.