### PR TITLE
docs: state the repository method naming grammar so the ByRef suffix is predictable

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -41,6 +41,37 @@ EntityRepository<User, Integer> userRepository = orm.entity(User.class);
 
 ---
 
+## Reading Method Names
+
+Repository method names follow a grammar, so you can mostly construct the name you need rather than searching for it:
+
+| Part | Meaning |
+|---|---|
+| `find` | yields nothing when there is no match: `null` in Kotlin, an empty `Optional` in Java |
+| `get` | throws when there is no match |
+| `findAll` | yields a list |
+| `Ref` before `By` | returns a `Ref` in place of the entity |
+| `Id` | selects on the primary key |
+
+A ref argument is an overload rather than a separate method. The same name takes a value or a ref, and the compiler picks by argument type:
+
+```kotlin
+users.findAllBy(User_.city, city)      // List<User>      selected by a City
+users.findAllBy(User_.city, cityRef)   // List<User>      selected by a Ref<City>
+users.findAllRefBy(User_.city, city)   // List<Ref<User>> selected by a City
+```
+
+The `ByRef` suffix marks the two cases where a distinct name is unavoidable. Selecting on a *collection* of refs erases to the same signature on the JVM as a collection of values, so the ref form needs its own name:
+
+```kotlin
+users.findAllBy(User_.city, cities)       // List<User> selected by City values
+users.findAllByRef(User_.city, cityRefs)  // List<User> selected by Ref<City> values
+```
+
+Selecting on the entity's own refs takes the suffix for the same reason, as in `findByRef(ref)`, `findAllByRef(refs)` and `removeByRef(ref)`.
+
+---
+
 ## Basic CRUD Operations
 
 <Tabs groupId="language">

--- a/storm-core/src/main/java/st/orm/core/repository/Repository.java
+++ b/storm-core/src/main/java/st/orm/core/repository/Repository.java
@@ -20,6 +20,26 @@ import st.orm.core.template.ORMTemplate;
 
 /**
  * Base interface for all repositories.
+ *
+ * <h2>Method names</h2>
+ *
+ * <p>Repository method names follow a grammar, so a name is mostly constructed rather than looked up:</p>
+ *
+ * <ul>
+ *     <li>{@code find} yields an empty {@code Optional} when nothing matches, {@code get} throws, and
+ *     {@code findAll} yields a list.</li>
+ *     <li>{@code Ref} <em>before</em> {@code By} returns {@link st.orm.Ref} in place of the entity:
+ *     {@code findAllBy} gives {@code List<E>}, {@code findAllRefBy} gives {@code List<Ref<E>>}.</li>
+ *     <li>{@code Id} selects on the primary key.</li>
+ * </ul>
+ *
+ * <p>A ref argument is an overload rather than a separate method, so {@code findAllBy(field, value)} and
+ * {@code findAllBy(field, ref)} share one name and the compiler picks by argument type.</p>
+ *
+ * <p>The {@code ByRef} suffix marks the two cases where a distinct name is unavoidable. Selecting on a
+ * <em>collection</em> of refs erases to the same JVM signature as a collection of values, so the ref form is spelled
+ * {@code findAllByRef(field, refs)}. Selecting on the entity's own refs likewise takes the suffix, as in
+ * {@code findByRef(ref)} and {@code removeByRef(ref)}.</p>
  */
 public interface Repository {
 

--- a/storm-kotlin/src/main/kotlin/st/orm/repository/Repository.kt
+++ b/storm-kotlin/src/main/kotlin/st/orm/repository/Repository.kt
@@ -24,6 +24,22 @@ import st.orm.template.ORMTemplate
  * Both [EntityRepository] and [ProjectionRepository] extend this interface. Custom repository
  * interfaces should extend one of those specialized interfaces rather than this one directly.
  *
+ * <h2>Method names</h2>
+ *
+ * Repository method names follow a grammar, so a name is mostly constructed rather than looked up:
+ *
+ * - `find` yields `null` when nothing matches, `get` throws, and `findAll` yields a list.
+ * - `Ref` **before** `By` returns [st.orm.Ref] in place of the entity: `findAllBy` gives `List<E>`, `findAllRefBy`
+ *   gives `List<Ref<E>>`.
+ * - `Id` selects on the primary key.
+ *
+ * A ref argument is an overload rather than a separate method, so `findAllBy(field, value)` and
+ * `findAllBy(field, ref)` share one name and the compiler picks by argument type.
+ *
+ * The `ByRef` suffix marks the two cases where a distinct name is unavoidable. Selecting on a *collection* of refs
+ * erases to the same JVM signature as a collection of values, so the ref form is spelled `findAllByRef(field, refs)`.
+ * Selecting on the entity's own refs likewise takes the suffix, as in `findByRef(ref)` and `removeByRef(ref)`.
+ *
  * @see EntityRepository
  * @see ProjectionRepository
  * @see ORMTemplate


### PR DESCRIPTION
Fixes #488.

The `ByRef` suffix appears on some repository methods and not others, with nothing stating when it applies. A caller cannot tell whether the ref form of a method is an overload of the name they already know or a differently named method, so the suffix reads as arbitrary.

It is not arbitrary, but it has two unrelated justifications and neither was written down. Normally a ref argument is just an overload — `V` is pinned by the metamodel, so `Metamodel<Owner, City>` forces `V = City` and a `Ref<City>` can only bind to the ref form:

```kotlin
findAllBy(field, value: V)      // EntityRepository.kt:1392
findAllBy(field, value: Ref<V>) // :1402  — same name, resolved by argument type
```

The suffix marks the places a distinct name is unavoidable. `Iterable<V>` and `Iterable<Ref<V>>` erase to the same JVM signature, so a collection of refs cannot share the name:

```kotlin
findAllBy(field, values: Iterable<V>)         // :1412
findAllByRef(field, values: Iterable<Ref<V>>) // :1422
```

Selecting on the entity's own refs is the same case, as in `findByRef(ref)`, `findAllByRef(refs)` and `removeByRef(ref)`.

## What changes

Documentation only. No API change, no CHANGELOG entry, following how the other documentation sweeps landed.

The grammar governs reads and writes alike, so it goes on the base `Repository` interface that `EntityRepository` and `ProjectionRepository` both extend, on the Kotlin and Java surfaces, plus a "Reading Method Names" section in the repositories guide for readers who are not in the API docs.

Stated compactly it is four lines, and the surface already obeys it:

- `find` yields nothing when there is no match, `get` throws, `findAll` yields a list.
- `Ref` before `By` returns `Ref` in place of the entity.
- `Id` selects on the primary key.
- A ref argument is an overload; `ByRef` marks only the two cases where a distinct name is forced.

## Verification

Every signature the new text cites was checked to exist on `main` — the three `findAllBy` overloads, `findAllByRef(field, refs)`, `findAllRefBy(field, value)`, `findAllByRef(refs)`, `findByRef(ref)` and `removeByRef(ref)`. The reactor builds with javadoc generation enabled, so the new Javadoc and KDoc blocks are valid, and `spotless:check` passes.