### PR TITLE
ci: exclude storm-kotlin-test from the aggregate Javadoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,9 +58,12 @@ jobs:
           #   storm-java21     -> st.orm.repository, st.orm.template (ORMTemplate,
           #                       query builder, repositories)
           # Everything else is excluded on purpose:
-          #   - Kotlin modules (Ktor, compiler-plugin variants) have no module
-          #     descriptor and break aggregation ("named and unnamed modules");
+          #   - Kotlin modules (Ktor, kotlin-test, compiler-plugin variants) have no
+          #     module descriptor and break aggregation ("named and unnamed modules");
           #     they are published separately as KDoc under /api/kotlin.
+          # Modules are selected by exclusion, so a module added to the reactor is
+          # published unless it is listed here. An added module without a descriptor
+          # fails this step until it is.
           #   - storm-core is the internal engine (st.orm.core.*).
           #   - dialect SPIs, storm-test and storm-metamodel-processor are not
           #     part of the user-facing API; Spring/Jackson/Micrometer are integrations.
@@ -71,7 +74,7 @@ jobs:
             -Dmaven.javadoc.failOnError=false \
             -DadditionalJOption=--enable-preview \
             -Ddoclint=none \
-            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-spring-boot-test-autoconfigure,!:storm-jackson3,!:storm-micrometer,!:storm-ktor,!:storm-ktor-test,!:storm-compiler-plugin-2.0,!:storm-compiler-plugin-2.1,!:storm-compiler-plugin-2.2,!:storm-compiler-plugin-2.3,!:storm-compiler-plugin-2.4,!:storm-metamodel-processor,!:storm-core,!:storm-test,!:storm-jackson2,!:storm-oracle,!:storm-mssqlserver,!:storm-postgresql,!:storm-mysql,!:storm-mariadb,!:storm-sqlite,!:storm-h2,!:storm-spring'
+            -pl '!:storm-kotlin,!:storm-kotlin-spring,!:storm-kotlin-spring-boot-starter,!:storm-kotlinx-serialization,!:storm-metamodel-ksp,!:storm-spring-boot-starter,!:storm-spring-boot-test-autoconfigure,!:storm-jackson3,!:storm-micrometer,!:storm-ktor,!:storm-ktor-test,!:storm-kotlin-test,!:storm-compiler-plugin-2.0,!:storm-compiler-plugin-2.1,!:storm-compiler-plugin-2.2,!:storm-compiler-plugin-2.3,!:storm-compiler-plugin-2.4,!:storm-metamodel-processor,!:storm-core,!:storm-test,!:storm-jackson2,!:storm-oracle,!:storm-mssqlserver,!:storm-postgresql,!:storm-mysql,!:storm-mariadb,!:storm-sqlite,!:storm-h2,!:storm-spring'
 
       - name: Copy Javadoc to website/static/api/java
         run: |


### PR DESCRIPTION
`Deploy Documentation` has failed on every push to main since `37eb9c6e`, so the documentation site has not deployed since 2026-08-12 09:04.

## Cause

The Javadoc step selects modules by exclusion, listing everything not to publish. `storm-kotlin-test` arrived with the coroutine-aware `SqlCapture` work and was not on that list, and being a Kotlin module it carries no module descriptor. Aggregation then saw two named modules and one unnamed:

```
[ERROR] Error while creating javadoc report: Aggregator report contains named and unnamed modules
```

Javadoc produced nothing, and the following step reported it:

```
##[error]Aggregate Javadoc not found (checked target/site/apidocs and target/reports/apidocs); /api/java/index.html would 404
```

That guard did its job; the gap is that the exclusion list publishes a new module by default.

## Fix

`storm-kotlin-test` joins the exclusion list, and the comment now states that modules are selected by exclusion, so the next module added without a descriptor reads as a listed consequence rather than a puzzle.

Verified locally: aggregation completes with no error, `index.html` is produced, and module mode is preserved — the report still carries `storm.foundation/` and `storm.java/` directories, which the documentation links depend on.

## Why not select by inclusion

`-pl :storm-foundation,:storm-java21` is the sturdier shape and matches what the comment already says is published, but it does not work here: restricting the reactor moves the aggregator off the root project, so the report is written under `storm-foundation/target/reports/apidocs` and `storm-java21` is skipped entirely. The copy step looks at the root and finds nothing. Ruled out by trying it.

A CI step that diffs the reactor against published-plus-excluded and fails with "classify storm-x" would remove the trap for good, and is worth doing separately.