### PR TITLE
fix: grouping by a reference names the referenced table's key

### DIFF
--- a/storm-core/src/main/java/st/orm/core/template/impl/MetamodelFactory.java
+++ b/storm-core/src/main/java/st/orm/core/template/impl/MetamodelFactory.java
@@ -300,7 +300,19 @@ public final class MetamodelFactory {
                 return null;
             }
             RecordField pk = findPkField(referencedType).orElse(null);
-            return pk == null ? null : of((Class) rootTable, path + "." + pk.name());
+            if (pk == null) {
+                return null;
+            }
+            String keyPath = path + "." + pk.name();
+            Metamodel<?, ?> key = of((Class) rootTable, keyPath);
+            if (key.fieldPath().equals(keyPath)) {
+                return key;
+            }
+            // A reference rewrites the key beyond it onto the reference itself as it is built, which is the
+            // equivalence this method exists to undo, so the path from the query root cannot express it. Rooting the
+            // metamodel at the referenced table names the same column: the table is joined once a query element
+            // reaches beyond the reference, and the key is resolved against that occurrence.
+            return of((Class) referencedType, pk.name());
         } catch (SqlTemplateException | RuntimeException e) {
             return null;
         }

--- a/storm-core/src/test/java/st/orm/core/GroupByForeignKeyPathIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/GroupByForeignKeyPathIntegrationTest.java
@@ -144,6 +144,44 @@ public class GroupByForeignKeyPathIntegrationTest {
     }
 
     /**
+     * A reference states a to-one relationship like an entity foreign key does, so grouping by one is the same
+     * identity and has to name the referenced table's key when the select list carries that table.
+     *
+     * <p>The key beyond a reference is rewritten onto the reference itself as the metamodel is built, so the path
+     * from the query root cannot express that key; the grouping has to reach it another way.</p>
+     */
+    @Test
+    public void groupByAReferenceFieldNamesTheReferencedKeyWhenTheTableIsSelected() {
+        var results = new ArrayList<PetVisitCount>();
+        String sql = captureSql(() -> results.addAll(ORMTemplate.of(dataSource)
+                .selectFrom(Visit.class, PetVisitCount.class, raw("\0, COUNT(*)", Pet.class))
+                .groupBy(Visit_.pet)
+                .getResultList()));
+        String groupBy = sql.substring(sql.toUpperCase().indexOf("GROUP BY"));
+        assertFalse(groupBy.contains("pet_id"),
+                "GROUP BY must name the pet's key, not the reference column, when Pet is selected: " + sql);
+        assertTrue(groupBy.matches("(?i)GROUP BY \\w+\\.id\\b.*"),
+                "GROUP BY must name the referenced table's key: " + sql);
+        assertEquals(8, results.size());
+    }
+
+    /**
+     * Nothing selects the referenced table, so the reference keeps naming its own column and stays unresolved.
+     */
+    @Test
+    public void groupByAReferenceFieldKeepsTheReferenceColumnWhenTheTableIsNotSelected() {
+        record PetIdCount(@Nullable Integer petId, int visitCount) {}
+        var results = new ArrayList<PetIdCount>();
+        String sql = captureSql(() -> results.addAll(ORMTemplate.of(dataSource)
+                .selectFrom(Visit.class, PetIdCount.class, raw("\0, COUNT(*)", Visit_.pet))
+                .groupBy(Visit_.pet)
+                .getResultList()));
+        String groupBy = sql.substring(sql.toUpperCase().indexOf("GROUP BY"));
+        assertTrue(groupBy.contains("pet_id"), "GROUP BY should name the reference column: " + sql);
+        assertFalse(results.isEmpty());
+    }
+
+    /**
      * ORDER BY places no requirement on which of the two equal columns is named, so it keeps the foreign key column.
      */
     @Test


### PR DESCRIPTION
Follow-up to #493, which fixed this for entity foreign keys but not for references.

## The defect

A reference states a to-one relationship the way an entity foreign key does, so grouping by one is the same identity. It named the reference column instead, leaving the selected key ungrouped:

```kotlin
select<RelatedMovie, _, _> { "${Movie::class}, COUNT(*)" }
    .groupBy(Principal_.movie)        // Principal.movie is a Ref<Movie>
```
```sql
SELECT m.id, m.primary_title, m.original_title, m.start_year, m.runtime_minutes, COUNT(*)
FROM principal p INNER JOIN movie m ON p.movie_id = m.id
WHERE p.person_id IN (?, ?) AND p.movie_id <> ?
GROUP BY p.movie_id
```

`m.id` is selected and not grouped, which PostgreSQL rejects — the statement #493 exists to stop generating, still generated for the reference spelling. Not a corner case either: a reference is the usual way to model a to-one, and this came from an example application's query rather than a constructed one.

## Cause

The equivalence runs both ways. A key beyond a reference is rewritten onto the reference as the metamodel is built — the same rewrite `canonical` performs, applied at construction — so `referencedKey` asking for `movie.id` from the query root got `movie` back, on the referencing table. The check then compared the *referencing* table against the select list, found no match, and kept the reference column:

```
field=movie  collapsed=movie  refKey=movie/Principal  selected=Movie  isSelected=false
```

Entity foreign keys were unaffected because their key path survives from the root, which is why one spelling worked and the other did not.

## Fix

When the path from the root collapses, the metamodel is rooted at the referenced table instead. It names the same column: the table is joined once a query element reaches beyond the reference, and the key resolves against that occurrence. The root-relative path is still preferred wherever it survives, which keeps resolution unambiguous where a table occurs more than once.

## Verification

The example query now emits `GROUP BY m.id`.

| | |
|---|---|
| storm-core | 2643 tests, including two new ones pinning both reference outcomes |
| storm-postgresql | 186 tests, PostgreSQL 17 container |
| storm-mssqlserver, storm-oracle | expansion still correct against real instances |

Worth noting for review: the equivalent shape in storm-core (`groupBy(Visit_.pet)` with `Pet` selected) produced correct SQL *before* this fix, by a different route through alias resolution. So the core tests added here guard the contract rather than reproduce the original failure — the failing case came from an application query, and that is what was used to confirm the repair.