### PR TITLE
docs: the manual install adds the metamodel processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,16 +143,38 @@ Without the Gradle plugin, import the BOM once and add the modules yourself. On 
 </dependencyManagement>
 ```
 
-**Gradle (Kotlin DSL):**
+**Gradle (Kotlin DSL), Kotlin:**
 
 ```kotlin
 dependencies {
     implementation(platform("st.orm:storm-bom:1.13.1"))
     implementation("st.orm:storm-kotlin")
     runtimeOnly("st.orm:storm-core")
+    ksp("st.orm:storm-metamodel-ksp")
     kotlinCompilerPluginClasspath("st.orm:storm-compiler-plugin-2.0")
 }
 ```
+
+**Gradle (Kotlin DSL), Java:**
+
+```kotlin
+dependencies {
+    implementation(platform("st.orm:storm-bom:1.13.1"))
+    implementation("st.orm:storm-java21")
+    runtimeOnly("st.orm:storm-core")
+    annotationProcessor("st.orm:storm-metamodel-processor")
+}
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("--enable-preview")
+}
+
+tasks.withType<Test> {
+    jvmArgs("--enable-preview")
+}
+```
+
+Both paths add the metamodel processor, which generates the `User_` and `City_` classes queries are written against, and the Java path sets the preview flags that Storm's string templates require. The Gradle plugin does all of that for you.
 
 With the BOM imported, add Storm modules without specifying versions.
 


### PR DESCRIPTION
The README's *Without the plugin (Maven, or manual Gradle)* section left out a dependency you cannot work without.

## The gap

The Gradle snippet imported the BOM and added `storm-kotlin`, `storm-core` and the compiler plugin, but not `storm-metamodel-ksp`. A reader following it gets no `User_` or `City_` classes, so there is nothing to write a query against, and no indication of why.

The module table two sections earlier lists the processor for a Kotlin stack, and `docs/installation.md` includes it in the same snippet. The README was the only place that omitted it.

The section also says "Maven, or manual Gradle" but showed the Kotlin path only, so a Java reader got neither `storm-metamodel-processor` nor the preview flags that string templates require.

## The change

`ksp("st.orm:storm-metamodel-ksp")` joins the Kotlin snippet, and Java gets its own, matching the installation guide:

```kotlin
dependencies {
    implementation(platform("st.orm:storm-bom:1.13.1"))
    implementation("st.orm:storm-java21")
    runtimeOnly("st.orm:storm-core")
    annotationProcessor("st.orm:storm-metamodel-processor")
}

tasks.withType<JavaCompile> {
    options.compilerArgs.add("--enable-preview")
}

tasks.withType<Test> {
    jvmArgs("--enable-preview")
}
```

A sentence after the two says what they have in common and that the Gradle plugin does all of it, which is the point of the section they sit under.

## On the versions

They stay at `1.13.1`. The release workflow rewrites them from the tag, so bumping by hand would only drift. Its own comment warns that a README edit can drift away from the patterns it matches, so I ran the sync against the edited file with GNU sed: all three guards pass, no stale version survives, and the new Java block's BOM line bumps with the rest.

The plugin remains the recommended path and is unchanged; this only makes the documented alternative complete.