### PR TITLE
Rework the site around production evaluation, and unify onboarding on the quickstart

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,106 +1,146 @@
-# Get Started
-
-Storm is a modern SQL Template and ORM framework for Kotlin 2.0+ and Java 21. It uses immutable data classes and records instead of proxied entities, giving you predictable behavior, type-safe queries, and high performance.
-
-## Choose Your Path
-
-> **Fastest start:** each example app is a GitHub template. Click **Use this template** to generate a runnable project, then replace the sample entities with your own: [Kotlin + Ktor](https://github.com/storm-orm/storm-example-kotlin-ktor/generate) · [Kotlin + Spring Boot](https://github.com/storm-orm/storm-example-kotlin-spring-boot-4/generate) · [Java + Spring Boot](https://github.com/storm-orm/storm-example-java-spring-boot-4/generate).
-
-Two ways to get started, and both reach the same working setup: follow the guides by hand, or let your AI coding tool do it. Pick whichever fits your workflow.
+---
+title: Set Up Your Project
+sidebar_label: Set Up Your Project
+description: "Wire Storm into a project you intend to keep: prerequisites, the four setup routes, and how to verify the result."
+---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+# Set Up Your Project
+
+This page is about getting Storm into a real project: what it needs from your toolchain, which of the four setup routes fits your situation, and how to prove the wiring works before you write application code.
+
+:::tip Just want to see it work?
+The **[Quickstart](/quickstart)** takes about five minutes, needs no database server, and ends with a working query and the SQL it generated. It is the fastest way to judge Storm, and it is the recommended first stop. Come back here when you are setting up a project you intend to keep.
+:::
+
+## Prerequisites
+
+| Requirement | Version |
+|-------------|---------|
+| JDK (Kotlin path) | 21 or later |
+| JDK (Java path) | 21 exactly; preview class files are version-locked |
+| Kotlin (if using Kotlin) | 2.0 or later |
+| Build tool | Maven 3.9+ or Gradle 8+ (Gradle 8.5+ for the Storm plugin) |
+| Database | Any JDBC-compatible database |
+
+Kotlin users need no preview flags. Java users must enable `--enable-preview` on compilation, tests, and execution, and must build and run on a JDK 21 toolchain. [Installation](installation.md) covers both in full, including the exact Maven and Gradle configuration.
+
+The JDK 21 pin is a property of the platform, not of Storm: the Java API is built on String Templates (JEP 430), a preview feature, and preview class files only load on the JDK that compiled them. When the JDK ships a stable successor, the Java API drops the preview flags and the version pin and stands alongside Kotlin as a first-class path. [String Templates](string-templates.md#status) covers where that stands today, and which modules are affected (only `storm-java21`; the core framework and the Kotlin API are not).
+
+## Choose a Setup Route
+
+All four routes end at the same place: a project with the Storm dependencies, the metamodel processor, and the Kotlin compiler plugin wired up.
+
 <Tabs>
-<TabItem value="manual" label="Manual" default>
+<TabItem value="gradle" label="Gradle plugin" default>
 
-### Manual Setup
+### Gradle plugin (recommended for Kotlin)
 
-Follow these three steps in order for the fastest path from zero to a working application.
+One plugin application imports the BOM, adds the core dependencies, wires the metamodel processor through KSP, selects the compiler-plugin variant matching your Kotlin version, and sets the Java preview flags.
 
-**1. Installation**
+```kotlin
+plugins {
+    kotlin("jvm") version "2.4.0"
+    id("com.google.devtools.ksp") version "2.3.10"
+    id("st.orm") version "@@STORM_VERSION@@"
+}
+```
 
-Set up your project with the right dependencies, build flags, and optional modules.
-
-**[Go to Installation](installation.md)**
-
-**2. First Entity**
-
-Define your first entity, create an ORM template, and perform insert, read, update, and remove operations.
-
-**[Go to First Entity](first-entity.md)**
-
-**3. First Query**
-
-Write custom queries, build repositories, stream results, and use the type-safe metamodel.
-
-**[Go to First Query](first-query.md)**
+Add the dialect module and JDBC driver for your database, and you are done. See [Installation](installation.md#gradle-plugin-recommended) for the plugin's configuration options and the per-Kotlin-version matrix.
 
 </TabItem>
-<TabItem value="ai" label="AI-Assisted">
+<TabItem value="maven" label="Maven BOM">
 
-### AI-Assisted Setup
+### Maven BOM
 
-If you use an AI coding tool (Claude Code, Cursor, GitHub Copilot, Windsurf, or Codex), Storm provides rules, skills, and an optional database-aware MCP server that give the AI deep knowledge of Storm's conventions. The AI can generate entities from your schema, write queries, and verify its own work against a real database.
+Import the BOM once, then declare Storm modules without version numbers. The metamodel annotation processor is added to the compiler plugin's `annotationProcessorPaths`, and the Java path needs `--enable-preview`.
 
-**1. Install the Storm CLI and run it in your project:**
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>st.orm</groupId>
+            <artifactId>storm-bom</artifactId>
+            <version>@@STORM_VERSION@@</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+See [Installation](installation.md) for the full `pom.xml`, including the processor and preview-flag configuration.
+
+</TabItem>
+<TabItem value="template" label="Template repository">
+
+### Start from a template
+
+Each example application is a GitHub template with the build, schema, entities, and tests already wired. Click **Use this template** to generate a repository, then replace the sample entities with your own:
+
+- [Kotlin + Ktor](https://github.com/storm-orm/storm-example-kotlin-ktor/generate)
+- [Kotlin + Spring Boot](https://github.com/storm-orm/storm-example-kotlin-spring-boot-4/generate)
+- [Java + Spring Boot](https://github.com/storm-orm/storm-example-java-spring-boot-4/generate)
+
+The full set, with what each one demonstrates, is on the [example projects page](/examples/).
+
+</TabItem>
+<TabItem value="ai" label="AI-assisted">
+
+### AI-assisted setup
+
+If you work with an AI coding tool (Claude Code, Cursor, GitHub Copilot, Windsurf, or Codex), one command installs Storm's rules and skills for it and can connect it to your development database:
 
 ```bash
 npx @storm-orm/cli init
 ```
 
-The interactive setup configures your AI tool with Storm's rules and skills, and optionally connects it to your development database for schema-aware code generation.
+The tool can then add the dependencies, generate entities from your existing tables, and write repository methods. It has Storm's documentation and, with the MCP server configured, your real schema.
 
-**2. Ask your AI tool to set up Storm:**
-
-Once `storm init` has configured your tool, you can ask it to add the right dependencies, create entities from your database tables, and write queries. The AI has access to Storm's full documentation and your database schema.
-
-For example:
-- "Add Storm to this project with Spring Boot and PostgreSQL"
-- "Set up Storm with Ktor and PostgreSQL"
-- "Create entities for the users and orders tables"
-- "Write a repository method that finds orders by status with pagination"
-
-**3. Verify:**
-
-Storm's AI workflow includes built-in verification. The AI can run `ORMTemplate.validateSchema()` to prove entities match the database and `SqlCapture` to inspect generated SQL, all in an isolated H2 test database before anything touches production.
-
-See [AI-Assisted Development](ai.md) for the full setup guide, available skills, and MCP server configuration.
+See [AI-Assisted Development](ai.md) for the full setup and [Database and MCP](database-and-mcp.md) for the schema-aware server.
 
 </TabItem>
 </Tabs>
 
----
+## Verify the Wiring
 
-## What's Next
+Two checks catch almost every setup mistake before it reaches application code.
 
-Once you have completed the steps above, explore the features that match your needs:
+**Does the metamodel generate?** After a build, a `User` entity should have a generated `User_` alongside it. If it does not, the annotation processor (Java) or KSP (Kotlin) is not on the compile path. See [Metamodel](metamodel.md) for how generation is configured per build tool.
 
-**Core Concepts:**
-- [Entities](entities.md) -- annotations, nullability, naming conventions
-- [Queries](queries.md) -- query DSL, filtering, joins, aggregation
-- [Relationships](relationships.md) -- one-to-one, many-to-one, many-to-many
-- [Repositories](repositories.md) -- custom repository pattern
+**Do the entities match the database?** Schema validation compares every mapped entity against the live schema and reports missing tables, missing columns, type mismatches, and nullability disagreements in one pass. `validateSchemaOrThrow()` fails loudly; `validateSchema()` returns the findings as a list so you can assert on them:
 
-**Operations:**
-- [Transactions](transactions.md) -- transaction management and propagation
-- [Upserts](upserts.md) -- insert-or-update operations
-- [Batch Processing & Streaming](batch-streaming.md) -- bulk operations and large datasets
-- [Dirty Checking](dirty-checking.md) -- automatic change detection on update
+<Tabs groupId="language">
+<TabItem value="kotlin" label="Kotlin" default>
 
-**Integration:**
-- [Spring Integration](spring-integration.md) -- Spring Boot Starter, auto-configuration, and DI
-- [Testing](testing.md) -- JUnit 5 integration and statement capture
-- [Database Dialects](dialects.md) -- database-specific features
+```kotlin
+dataSource.orm.validateSchemaOrThrow()
+```
 
-**Advanced:**
-- [Refs](refs.md) -- lightweight entity references for deferred loading
-- [Projections](projections.md) -- read-only views of entities
-- [SQL Templates](sql-templates.md) -- raw SQL with type safety
-- [Metamodel](metamodel.md) -- compile-time type-safe field references
-- [JSON Support](json.md) -- JSON columns and aggregation
-- [Entity Serialization](serialization.md) -- JSON serialization with Ref support
+</TabItem>
+<TabItem value="java" label="Java">
 
-**Migration:**
-- [Migration from JPA](migration-from-jpa.md) -- step-by-step guide
-- [Storm vs Other Frameworks](comparison.md) -- feature comparison
+```java
+ORMTemplate.of(dataSource).validateSchemaOrThrow();
+```
+
+</TabItem>
+</Tabs>
+
+Run it at startup in development, or as a test. [Schema Validation](validation.md#schema-validation) covers what is checked, how to scope it to specific entities, and the strict mode.
+
+## Next
+
+With the project wired, work through the model:
+
+1. [First Entity](first-entity.md) -- define entities, insert and fetch records
+2. [First Query](first-query.md) -- filtering, repositories, and streaming
+3. [Entities](entities.md) -- annotations, nullability, naming conventions
+
+Integrating with a framework instead? Go straight to [Spring Integration](spring-integration.md) or [Ktor Integration](ktor-integration.md), which cover dependency injection, transaction management, and configuration for each.
+
+The full map of the documentation, including paths for migrating from JPA and for evaluating Storm in production, is on the [introduction page](index.md).
+
+Stuck on the setup, or something here did not match what you saw? Ask in [Discord](https://discord.gg/SgQpcweUJD) or open a [discussion](https://github.com/storm-orm/storm-framework/discussions).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,43 +8,22 @@ import TabItem from '@theme/TabItem';
 
 # Storm
 
-**Storm** is an ORM for Kotlin 2.0+ and Java 21, built on a SQL template engine. It aims for simplicity, type safety, and predictable performance, through immutable models and metadata generated at compile time.
+**Storm** is an ORM for Kotlin 2.0+ and Java 21, built on a SQL template engine. Entities are plain immutable data classes and records, queries are checked at compile time, and every database call is explicit: no proxies, no persistence context, no accidental N+1 queries.
 
-**Key benefits:**
+## Start Here
 
-- **Minimal code**: Define entities with simple records/data classes and query with concise, readable syntax, no boilerplate.
-- **Parameterized by default**: String interpolations are automatically converted to bind variables, making queries SQL injection safe by design.
-- **Close to SQL**: Storm stays close to SQL rather than abstracting it away, so you keep control of what runs against your database.
-- **Type-safe**: Storm's DSL mirrors SQL, so a wrong column or a wrong type is a compile error rather than a runtime one.
-- **Direct Database Interaction**: Method calls translate directly into database operations. Entity graphs load in a single query, which removes the N+1 problem.
-- **Stateless**: Record-based entities carry no session state, so there is no lazy initialization to fail later and nothing to attach, detach, or merge.
-- **Performance**: Template caching, transaction-scoped entity caching, and zero-overhead dirty checking (thanks to immutability). Batch processing, lazy streams, and upserts are built in.
-- **Universal Database Compatibility**: Works with all SQL databases.
+| If you want to | Go to |
+|----------------|-------|
+| See Storm work end to end, in five minutes | **[Quickstart](/quickstart)** |
+| Add Storm to a project you already have | [Set Up Your Project](getting-started.md) |
+| Understand the model before writing code | [Entities](entities.md), then [Queries](queries.md) |
+| Decide whether to adopt it | [Evaluating for Production](#evaluating-for-production) |
 
-## Why Storm?
+The [Quickstart](/quickstart) is the fastest first experience: an empty project, two linked entities, and one type-safe query across the relation, with the generated SQL shown at every step. It takes about five minutes and needs no database server. The rest of this documentation assumes you have either done it or do not need it.
 
-Storm draws inspiration from established ORMs such as Hibernate, but is built from scratch around a clear design philosophy: capture intent using the minimum amount of code, optimized for Kotlin and modern Java.
+## What Storm Looks Like
 
-**Storm's mission:** Make database development productive and enjoyable, with full developer control and high performance.
-
-Storm embraces SQL rather than abstracting it away. Database interactions stay simple without becoming opaque.
-
-| Traditional ORM Pain | Storm Solution |
-|----------------------|----------------|
-| N+1 queries from lazy loading | Entity graphs load in a single query |
-| Hidden magic (proxies, implicit flush, cascades) | Stateless records; explicit, predictable behavior |
-| Entity state confusion (managed/detached/transient) | Immutable records; no state to manage |
-| Entities tied to session/context | Stateless records easily cached and shared across layers |
-| Dirty checking via bytecode manipulation | Dirty checking that costs almost nothing, thanks to immutability |
-| Complex mapping configuration | Convention over configuration |
-| Runtime query errors | Compile-time type-safe DSL |
-| SQL hidden behind abstraction layers | SQL-first design; stay close to the database |
-
-**Storm is ideal for** developers who want a database-first approach, where records mirror the schema. Custom mappings are supported when you need them, but the model works best when the two line up.
-
-## Choose Your Language
-
-Both Kotlin and Java support SQL Templates for query composition. Kotlin additionally provides a type-safe DSL with infix operators.
+Both Kotlin and Java support SQL templates for query composition. Kotlin additionally provides a type-safe DSL with infix operators.
 
 <Tabs groupId="language">
 <TabItem value="kotlin" label="Kotlin" default>
@@ -116,66 +95,28 @@ List<User> users = orm.entity(User.class)
 </TabItem>
 </Tabs>
 
-## AI Assisted Development
+## Why Storm
 
-Storm is the ORM that AI coding assistants get right. Its stateless, immutable entities mean what you see in the source code is exactly what exists at runtime: no hidden proxies, no lazy loading surprises, no persistence context rules that trip up AI-generated code. When you ask your AI tool to write a query, define an entity, or build a repository, the output is straightforward data classes and explicit SQL, the same code a senior developer would write by hand.
+Storm draws inspiration from established ORMs such as Hibernate, but is built from scratch around a clear design philosophy: capture intent using the minimum amount of code, optimized for Kotlin and modern Java. It embraces SQL rather than abstracting it away, so database interactions stay simple without becoming opaque.
 
-**Get started in seconds:**
+| Traditional ORM Pain | Storm Solution |
+|----------------------|----------------|
+| N+1 queries from lazy loading | Entity graphs load in a single query |
+| Hidden magic (proxies, implicit flush, cascades) | Stateless records; explicit, predictable behavior |
+| Entity state confusion (managed/detached/transient) | Immutable records; no state to manage |
+| Entities tied to session/context | Stateless records easily cached and shared across layers |
+| Dirty checking via bytecode manipulation | Dirty checking that costs almost nothing, thanks to immutability |
+| Complex mapping configuration | Convention over configuration |
+| Runtime query errors | Compile-time type-safe DSL |
+| SQL hidden behind abstraction layers | SQL-first design; stay close to the database |
 
-```bash
-npx @storm-orm/cli
-```
+Three further properties shape day-to-day use:
 
-This configures your AI tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's patterns, conventions, and slash commands. See [more on ai](ai.md) for details.
+- **Parameterized by default.** String interpolations become bind variables, so queries are SQL injection safe by design.
+- **Direct database interaction.** Method calls translate into database operations. Nothing is deferred to a flush you did not ask for.
+- **Performance by construction.** Template caching, transaction-scoped entity caching, compile-time row mapping, and dirty checking that costs almost nothing thanks to immutability. Batch processing, lazy streams, and upserts are built in.
 
-## Quick Start
-
-The Storm Gradle plugin sets up a Kotlin project in one line: it imports the BOM, adds the core dependencies, and wires the metamodel processor and Kotlin compiler plugin. Maven users import the BOM once and omit version numbers from individual Storm dependencies.
-
-<Tabs groupId="language">
-<TabItem value="kotlin" label="Kotlin (Gradle)" default>
-
-```kotlin
-plugins {
-    kotlin("jvm") version "2.4.0"
-    id("com.google.devtools.ksp") version "2.3.10"
-    id("st.orm") version "@@STORM_VERSION@@"
-}
-```
-
-</TabItem>
-<TabItem value="java" label="Java (Maven)">
-
-```xml
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>st.orm</groupId>
-            <artifactId>storm-bom</artifactId>
-            <version>@@STORM_VERSION@@</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-
-<dependencies>
-    <dependency>
-        <groupId>st.orm</groupId>
-        <artifactId>storm-java21</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>st.orm</groupId>
-        <artifactId>storm-core</artifactId>
-        <scope>runtime</scope>
-    </dependency>
-</dependencies>
-```
-
-</TabItem>
-</Tabs>
-
-Ready to get started? Head to the [Getting Started](getting-started.md) guide.
+**Storm is ideal for** developers who want a database-first approach, where records mirror the schema. Custom mappings are supported when you need them, but the model works best when the two line up.
 
 ## Learning Paths
 
@@ -183,16 +124,17 @@ Not sure where to begin? Pick the path that fits your situation.
 
 ### New to Storm
 
-If you are new to Storm, follow these guides in order to build a solid foundation:
+Follow these guides in order to build a solid foundation:
 
-1. [Installation](installation.md) -- add Storm to your project
-2. [First Entity](first-entity.md) -- define entities, insert and fetch records
-3. [First Query](first-query.md) -- filtering, repositories, and streaming
-4. [Entities](entities.md) -- annotations, nullability, naming conventions
-5. [Queries](queries.md) -- the full query DSL and builder reference
-6. [Repositories](repositories.md) -- the repository pattern and custom query methods
-7. [Relationships](relationships.md) -- foreign keys, entity graphs, and many-to-many
-8. [Entity Design](entity-design.md) -- when to inline a foreign key and when to reach for a Ref
+1. [Set Up Your Project](getting-started.md) -- choose a setup route and get the build wired
+2. [Installation](installation.md) -- dependencies, build flags, and optional modules in full
+3. [First Entity](first-entity.md) -- define entities, insert and fetch records
+4. [First Query](first-query.md) -- filtering, repositories, and streaming
+5. [Entities](entities.md) -- annotations, nullability, naming conventions
+6. [Queries](queries.md) -- the full query DSL and builder reference
+7. [Repositories](repositories.md) -- the repository pattern and custom query methods
+8. [Relationships](relationships.md) -- foreign keys, entity graphs, and many-to-many
+9. [Entity Design](entity-design.md) -- when to inline a foreign key and when to reach for a Ref
 
 ### Migrating from JPA
 
@@ -209,13 +151,17 @@ If you are coming from JPA or Hibernate, these pages explain the key differences
 
 If you are a tech lead or architect evaluating Storm for a production system, these pages cover the areas that matter most:
 
-1. [Storm vs Other Frameworks](comparison.md) -- feature-level comparison across frameworks
-2. [Spring Integration](spring-integration.md) -- Spring Boot auto-configuration, repository scanning, DI
-3. [Ktor Integration](ktor-integration.md) -- Ktor plugin, HOCON configuration, coroutine-native transactions
-4. [Batch Processing and Streaming](batch-streaming.md) -- bulk operations and large dataset handling
-4. [Testing](testing.md) -- JUnit 5 integration, statement capture, and test isolation
-5. [Configuration](configuration.md) -- runtime tuning, dirty checking modes, cache retention
-6. [Database Dialects](dialects.md) -- database-specific optimizations
+1. [What Storm Does Not Do](#what-storm-does-not-do) -- the deliberate omissions, before anything else
+2. [Storm vs Other Frameworks](comparison.md) -- feature-level comparison across frameworks
+3. [Spring Integration](spring-integration.md) -- Spring Boot auto-configuration, repository scanning, DI
+4. [Ktor Integration](ktor-integration.md) -- Ktor plugin, HOCON configuration, coroutine-native transactions
+5. [Batch Processing and Streaming](batch-streaming.md) -- bulk operations and large dataset handling
+6. [Testing](testing.md) -- JUnit 5 integration, statement capture, and test isolation
+7. [Configuration](configuration.md) -- runtime tuning, dirty checking modes, cache retention
+8. [Security](security.md) -- injection safety, and what is guaranteed by construction
+9. [Database Dialects](dialects.md) -- database-specific optimizations
+
+Release history, the issue tracker, the security policy, and the benchmark harness are linked from the [project home page](/).
 
 ## What Storm Does Not Do
 
@@ -238,10 +184,22 @@ See [Database Dialects](dialects.md) for installation and configuration details.
 - Kotlin 2.0+ (JDK 21 or later), or Java on JDK 21 exactly (the Java API uses preview class files, which are version-locked)
 - Maven 3.9+ or Gradle 8+
 
+## AI-Assisted Development
+
+Storm's stateless, immutable entities mean what you see in the source code is exactly what exists at runtime: no hidden proxies, no lazy loading surprises, no persistence context rules that trip up generated code. When you ask an AI tool to write a query, define an entity, or build a repository, the output is straightforward data classes and explicit SQL.
+
+One command configures your tool (Claude Code, Cursor, Copilot, Windsurf, or Codex) with Storm's rules, skills, and slash commands, and can connect it to your development database for schema-aware generation:
+
+```bash
+npx @storm-orm/cli init
+```
+
+See [AI-Assisted Development](ai.md) for the full setup, and [Database and MCP](database-and-mcp.md) for the schema-aware server.
+
 ## Glossary
 
 New to Storm's terminology? See the [Glossary](glossary.md) for definitions of key terms like Entity, Projection, Metamodel, Ref, Hydration, and more.
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,8 @@ This page covers everything you need to add Storm to your project: prerequisites
 
 Kotlin users do not need any preview flags. Java users must enable `--enable-preview` on compilation, tests, and execution because the Java API uses String Templates (JEP 430), and must build and run on a JDK 21 toolchain: preview class files only load on the JDK that compiled them.
 
+The pin is a property of the platform rather than of Storm, and it is not permanent. When the JDK ships a stable successor to String Templates, the Java API drops both the preview flags and the version pin and stands alongside Kotlin as a first-class path. Only `storm-java21` depends on the preview feature; the core framework and the Kotlin API are unaffected. See [String Templates](string-templates.md#status) for the current state.
+
 ## Gradle Plugin (Recommended)
 
 The Storm Gradle plugin collapses the whole setup into one plugin application. It imports the BOM, adds the core dependencies for your language, wires the metamodel processor, selects the Kotlin compiler-plugin variant matching your Kotlin version, and configures the Java preview flags. Requires Gradle 8.5+.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -8,6 +8,17 @@ const staticVersionReplace = require('./plugins/static-version-replace');
 const exampleReadmes = require('./plugins/example-readmes');
 const versionedDocsCanonical = require('./plugins/versioned-docs-canonical');
 
+// The canonical repository. Every "GitHub" affordance on the site points here
+// (see also src/components/tutorial/tutorialTheme.js); the organization's
+// repository list is a different destination and is only linked where that
+// breadth is the point.
+const GITHUB_REPO = 'https://github.com/storm-orm/storm-framework';
+
+// The community server. A permanent invite (no expiry, no use limit): Discord's
+// default invites lapse after seven days, and a dead invite in the site footer
+// would go unnoticed for a long time.
+const DISCORD = 'https://discord.gg/SgQpcweUJD';
+
 const config: Config = {
   title: 'Storm Framework',
   tagline: 'A modern, high-performance ORM for Kotlin 2.0+ and Java 21+',
@@ -42,6 +53,41 @@ const config: Config = {
 
   plugins: [
     [staticVersionReplace, { version: stormVersion }],
+    // Documentation search. The index is built from the docs at build time and
+    // shipped as a static asset, so search works offline and sends nothing to a
+    // third party — no hosted service, no crawler, no API key to rotate.
+    // Only the current docs version is indexed: the older snapshots would
+    // multiply every hit by ~14 near-identical copies.
+    [
+      require.resolve('@easyops-cn/docusaurus-search-local'),
+      {
+        indexDocs: true,
+        // The blog and the marketing pages are hand-built React pages served
+        // outside the Docusaurus chrome, so they carry no search bar; indexing
+        // them would build an index nothing can query.
+        indexBlog: false,
+        indexPages: false,
+        docsRouteBasePath: '/docs',
+        // Content dirs, used only to compute the index's content hash so a docs
+        // edit busts the cached index. Both halves of the docs tree count: the
+        // `current` version (../docs) and the released snapshots.
+        docsDir: ['../docs', 'versioned_docs'],
+        // The index is fetched with a content hash in the query, so a stale
+        // index can never be served from cache after a docs change.
+        hashed: true,
+        // Programming docs need their stop words: "as", "in", "not" and "for"
+        // are all meaningful query terms here.
+        removeDefaultStopWordFilter: true,
+        searchResultLimits: 8,
+        searchResultContextMaxLength: 60,
+        highlightSearchTermsOnTargetPage: true,
+        // One index per docs version, so a search made while reading 1.13.1
+        // returns 1.13.1 pages rather than every snapshot at once. Old
+        // snapshots are excluded: they are near-identical copies that would
+        // multiply every hit by ~14 and bloat the build for no gain.
+        ignoreFiles: [/^\/docs\/\d+\.\d+\.\d+\//],
+      },
+    ],
     // Point versioned and `next` docs canonicals at the current /docs/ page so
     // old snapshots do not compete with the live docs (see the plugin).
     versionedDocsCanonical,
@@ -116,7 +162,20 @@ const config: Config = {
               path: 'next',
             },
           },
-          editUrl: 'https://github.com/storm-orm/storm-framework/edit/main/docs/',
+          // "Edit this page" must land on a file that exists. The string form
+          // appends the doc path to the docs plugin's `path`, which produced
+          // `docs/../docs/<file>` for the current version and, worse,
+          // `docs/versioned_docs/version-X/<file>` for released ones — a path
+          // that is not in the repository at all (the snapshots live under
+          // website/versioned_docs), so every edit link on the live /docs/*
+          // pages opened GitHub's "create a new file" screen.
+          //
+          // Every version therefore points at the living source in docs/.
+          // Released snapshots are frozen by policy: a correction belongs in
+          // the current docs and ships with the next release, so sending an
+          // editor to the snapshot would be wrong even if the path resolved.
+          editUrl: ({docPath}) =>
+            `${GITHUB_REPO}/edit/main/docs/${docPath}`,
           beforeDefaultRemarkPlugins: [
             [remarkStormVersion, { version: stormVersion }],
           ],
@@ -168,6 +227,19 @@ const config: Config = {
           type: 'docsVersionDropdown',
           position: 'right',
         },
+        // The canonical first-run path, listed first and labelled the same as
+        // the marketing CTAs so "Quickstart" means one thing across the site.
+        {
+          to: '/quickstart',
+          label: 'Quickstart',
+          position: 'left',
+        },
+        {
+          type: 'docSidebar',
+          sidebarId: 'docs',
+          position: 'left',
+          label: 'Documentation',
+        },
         {
           to: '/tutorials/',
           label: 'Tutorials',
@@ -194,13 +266,7 @@ const config: Config = {
           position: 'left',
         },
         {
-          type: 'docSidebar',
-          sidebarId: 'docs',
-          position: 'left',
-          label: 'Documentation',
-        },
-        {
-          href: 'https://github.com/orgs/storm-orm/repositories',
+          href: GITHUB_REPO,
           label: 'GitHub',
           position: 'right',
         },
@@ -210,22 +276,44 @@ const config: Config = {
       style: 'dark',
       links: [
         {
-          title: 'Docs',
+          title: 'Learn',
           items: [
-            {label: 'Get Started', to: '/quickstart'},
+            {label: 'Quickstart', to: '/quickstart'},
+            {label: 'Installation', to: '/docs/installation'},
             {label: 'Entities', to: '/docs/entities'},
             {label: 'Queries', to: '/docs/queries'},
+            {label: 'Tutorials', to: '/tutorials/'},
+            {label: 'Example Projects', to: '/examples/'},
+          ],
+        },
+        {
+          title: 'Evaluate',
+          items: [
+            {label: 'Comparison', to: '/comparison'},
+            {label: 'Benchmarks', to: '/benchmarks'},
+            {label: 'What Storm does not do', to: '/docs/#what-storm-does-not-do'},
+            {label: 'Releases', href: `${GITHUB_REPO}/releases`},
+            {label: 'Changelog', href: `${GITHUB_REPO}/blob/main/CHANGELOG.md`},
+            {label: 'Maven Central', href: 'https://central.sonatype.com/namespace/st.orm'},
+          ],
+        },
+        {
+          title: 'Project',
+          items: [
+            {label: 'GitHub', href: GITHUB_REPO},
+            {label: 'Discord', href: DISCORD},
+            {label: 'Issues', href: `${GITHUB_REPO}/issues`},
+            {label: 'Discussions', href: `${GITHUB_REPO}/discussions`},
+            {label: 'Contributing', href: `${GITHUB_REPO}/blob/main/CONTRIBUTING.md`},
+            {label: 'Security policy', href: `${GITHUB_REPO}/blob/main/SECURITY.md`},
+            {label: 'Apache 2.0 license', href: `${GITHUB_REPO}/blob/main/LICENSE.txt`},
           ],
         },
         {
           title: 'More',
           items: [
-            {label: 'Tutorials', to: '/tutorials/'},
-            {label: 'Example Projects', to: '/examples/'},
             {label: 'Blog', to: '/blog/'},
-            {label: 'GitHub', href: 'https://github.com/storm-orm/storm-framework'},
-            {label: 'Discussions', href: 'https://github.com/storm-orm/storm-framework/discussions'},
-            {label: 'Maven Central', href: 'https://central.sonatype.com/namespace/st.orm'},
+            {label: 'Home', to: '/'},
           ],
         },
       ],
@@ -233,7 +321,20 @@ const config: Config = {
     },
     prism: {
       theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      // Dracula, with one correction: its comment colour measures 4.06:1 on the
+      // code background, just under the 4.5:1 minimum — and comments in these
+      // samples carry the explanation, not decoration. One step lighter in the
+      // same hue clears it at 4.8:1. It has to be patched into the theme rather
+      // than overridden in CSS, because prism-react-renderer writes token
+      // colours as inline styles, which no stylesheet rule can outrank.
+      darkTheme: {
+        ...prismThemes.dracula,
+        styles: prismThemes.dracula.styles.map((entry) =>
+          entry.types.includes('comment')
+            ? {...entry, style: {...entry.style, color: '#6f7cae'}}
+            : entry
+        ),
+      },
       additionalLanguages: ['java', 'kotlin', 'groovy'],
     },
     colorMode: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,7 @@
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/plugin-client-redirects": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
+        "@easyops-cn/docusaurus-search-local": "0.55.3",
         "marked": "^18.0.9",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.2.8",
@@ -4086,6 +4087,156 @@
         "node": ">=20.0"
       }
     },
+    "node_modules/@easyops-cn/autocomplete.js": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/autocomplete.js/-/autocomplete.js-0.38.1.tgz",
+      "integrity": "sha512-drg76jS6syilOUmVNkyo1c7ZEBPcPuK+aJA7AksM5ZIIbV57DMHCywiCr+uHyv8BE5jUTU98j/H7gVrkHrWW3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "immediate": "^3.2.3"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local": {
+      "version": "0.55.3",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.55.3.tgz",
+      "integrity": "sha512-PlMKmxuonvZ1C+/zJS1hJaF1xaxD1TsUvOMzpP6DdQMtZqmTaYjcLGM12ePzl0m1rp3AgfTBeDbFNHQhwnH/dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/plugin-content-docs": "^2 || ^3",
+        "@docusaurus/theme-translations": "^2 || ^3",
+        "@docusaurus/utils": "^2 || ^3",
+        "@docusaurus/utils-common": "^2 || ^3",
+        "@docusaurus/utils-validation": "^2 || ^3",
+        "@easyops-cn/autocomplete.js": "^0.38.1",
+        "@node-rs/jieba": "^1.6.0",
+        "cheerio": "^1.0.0",
+        "clsx": "^2.1.1",
+        "comlink": "^4.4.2",
+        "debug": "^4.2.0",
+        "fs-extra": "^10.0.0",
+        "klaw-sync": "^6.0.0",
+        "lunr": "^2.3.9",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-common": "^2 || ^3",
+        "open-ask-ai": "^0.7.3",
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || 17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "open-ask-ai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -4654,6 +4805,18 @@
         "react": ">=16"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -4664,6 +4827,271 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@node-rs/jieba": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba/-/jieba-1.10.4.tgz",
+      "integrity": "sha512-GvDgi8MnBiyWd6tksojej8anIx18244NmIOc1ovEw8WKNUejcccLfyu8vj66LWSuoZuKILVtNsOy4jvg3aoxIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/jieba-android-arm-eabi": "1.10.4",
+        "@node-rs/jieba-android-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-x64": "1.10.4",
+        "@node-rs/jieba-freebsd-x64": "1.10.4",
+        "@node-rs/jieba-linux-arm-gnueabihf": "1.10.4",
+        "@node-rs/jieba-linux-arm64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-arm64-musl": "1.10.4",
+        "@node-rs/jieba-linux-x64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-x64-musl": "1.10.4",
+        "@node-rs/jieba-wasm32-wasi": "1.10.4",
+        "@node-rs/jieba-win32-arm64-msvc": "1.10.4",
+        "@node-rs/jieba-win32-ia32-msvc": "1.10.4",
+        "@node-rs/jieba-win32-x64-msvc": "1.10.4"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm-eabi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm-eabi/-/jieba-android-arm-eabi-1.10.4.tgz",
+      "integrity": "sha512-MhyvW5N3Fwcp385d0rxbCWH42kqDBatQTyP8XbnYbju2+0BO/eTeCCLYj7Agws4pwxn2LtdldXRSKavT7WdzNA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm64/-/jieba-android-arm64-1.10.4.tgz",
+      "integrity": "sha512-XyDwq5+rQ+Tk55A+FGi6PtJbzf974oqnpyCcCPzwU3QVXJCa2Rr4Lci+fx8oOpU4plT3GuD+chXMYLsXipMgJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-arm64/-/jieba-darwin-arm64-1.10.4.tgz",
+      "integrity": "sha512-G++RYEJ2jo0rxF9626KUy90wp06TRUjAsvY/BrIzEOX/ingQYV/HjwQzNPRR1P1o32a6/U8RGo7zEBhfdybL6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-x64/-/jieba-darwin-x64-1.10.4.tgz",
+      "integrity": "sha512-MmDNeOb2TXIZCPyWCi2upQnZpPjAxw5ZGEj6R8kNsPXVFALHIKMa6ZZ15LCOkSTsKXVC17j2t4h+hSuyYb6qfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-freebsd-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-freebsd-x64/-/jieba-freebsd-x64-1.10.4.tgz",
+      "integrity": "sha512-/x7aVQ8nqUWhpXU92RZqd333cq639i/olNpd9Z5hdlyyV5/B65LLy+Je2B2bfs62PVVm5QXRpeBcZqaHelp/bg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm-gnueabihf": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm-gnueabihf/-/jieba-linux-arm-gnueabihf-1.10.4.tgz",
+      "integrity": "sha512-crd2M35oJBRLkoESs0O6QO3BBbhpv+tqXuKsqhIG94B1d02RVxtRIvSDwO33QurxqSdvN9IeSnVpHbDGkuXm3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-gnu/-/jieba-linux-arm64-gnu-1.10.4.tgz",
+      "integrity": "sha512-omIzNX1psUzPcsdnUhGU6oHeOaTCuCjUgOA/v/DGkvWC1jLcnfXe4vdYbtXMh4XOCuIgS1UCcvZEc8vQLXFbXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-musl/-/jieba-linux-arm64-musl-1.10.4.tgz",
+      "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-gnu/-/jieba-linux-x64-gnu-1.10.4.tgz",
+      "integrity": "sha512-WZO8ykRJpWGE9MHuZpy1lu3nJluPoeB+fIJJn5CWZ9YTVhNDWoCF4i/7nxz1ntulINYGQ8VVuCU9LD86Mek97g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-musl/-/jieba-linux-x64-musl-1.10.4.tgz",
+      "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-wasm32-wasi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-wasm32-wasi/-/jieba-wasm32-wasi-1.10.4.tgz",
+      "integrity": "sha512-Y2umiKHjuIJy0uulNDz9SDYHdfq5Hmy7jY5nORO99B4pySKkcrMjpeVrmWXJLIsEKLJwcCXHxz8tjwU5/uhz0A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-arm64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-arm64-msvc/-/jieba-win32-arm64-msvc-1.10.4.tgz",
+      "integrity": "sha512-nwMtViFm4hjqhz1it/juQnxpXgqlGltCuWJ02bw70YUDMDlbyTy3grCJPpQQpueeETcALUnTxda8pZuVrLRcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-ia32-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-ia32-msvc/-/jieba-win32-ia32-msvc-1.10.4.tgz",
+      "integrity": "sha512-DCAvLx7Z+W4z5oKS+7vUowAJr0uw9JBw8x1Y23Xs/xMA4Em+OOSiaF5/tCJqZUCJ8uC4QeImmgDFiBqGNwxlyA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-x64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-x64-msvc/-/jieba-win32-x64-msvc-1.10.4.tgz",
+      "integrity": "sha512-+sqemSfS1jjb+Tt7InNbNzrRh1Ua3vProVvC4BZRPg010/leCbGFFiQHpzcPRfpxAXZrzG5Y0YBTsPzN/I4yHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5222,6 +5650,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -6899,6 +7337,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -8101,6 +8545,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -9817,6 +10286,12 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10403,6 +10878,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -10581,6 +11065,24 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
+    },
+    "node_modules/lunr-languages": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.21.0.tgz",
+      "integrity": "sha512-Hj0VwJP1FGwZzVMMZdDtWY2GB2VVKtvVElYtVajzCZCDr2RTucyLpPibrOPGgTlcq2ENQy2gYLtPnzyFu9jZCg==",
+      "license": "MPL-1.1"
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "license": "MIT"
     },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",
@@ -13548,6 +14050,18 @@
       "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -17363,6 +17877,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -18280,6 +18803,40 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/website/package.json
+++ b/website/package.json
@@ -8,12 +8,15 @@
     "prebuild": "bash scripts/generate-llms-full.sh",
     "build": "docusaurus build",
     "serve": "docusaurus serve",
-    "clear": "docusaurus clear"
+    "clear": "docusaurus clear",
+    "check-links": "node scripts/check-links.mjs",
+    "check-links:external": "node scripts/check-links.mjs --external"
   },
   "dependencies": {
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/plugin-client-redirects": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
+    "@easyops-cn/docusaurus-search-local": "0.55.3",
     "marked": "^18.0.9",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.8",

--- a/website/scripts/check-links.mjs
+++ b/website/scripts/check-links.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+//
+// Link checker for the built site (website/build).
+//
+// Docusaurus already fails the build on a broken Markdown link (onBrokenLinks:
+// 'throw'), but that check only sees links it routed itself. The hand-built
+// pages — the landing page, /quickstart, /comparison, /benchmarks, the
+// tutorials and the blog — are rendered from raw HTML strings, so their links
+// are invisible to it. This walks the emitted HTML instead, which sees every
+// link on every page regardless of how it got there.
+//
+// Usage:
+//   node scripts/check-links.mjs              # internal links + fragments
+//   node scripts/check-links.mjs --external   # also probe external URLs
+//
+// Exits non-zero when anything is broken.
+
+import {readFileSync, readdirSync, statSync, existsSync} from 'node:fs';
+import {join, resolve, dirname, posix} from 'node:path';
+
+const BUILD = resolve(process.cwd(), 'build');
+const CHECK_EXTERNAL = process.argv.includes('--external');
+
+if (!existsSync(BUILD)) {
+  console.error('No build/ directory. Run `npm run build` first.');
+  process.exit(1);
+}
+
+// Frozen release snapshots are near-identical copies of the live docs; their
+// internal links are already validated by the Docusaurus build, and walking all
+// fourteen of them multiplies the run for no new information.
+const VERSIONED_DOCS = /^docs\/\d+\.\d+\.\d+\//;
+// Generated API trees (Javadoc/KDoc). They are copied in by the deploy workflow
+// and are absent from a local build, so their links are not ours to validate.
+const GENERATED = /^api\//;
+
+/** Every .html file in the build, as build-relative posix paths. */
+function htmlFiles(dir, base = '') {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const abs = join(dir, name);
+    const rel = base ? posix.join(base, name) : name;
+    if (statSync(abs).isDirectory()) {
+      if (GENERATED.test(rel + '/')) continue;
+      out.push(...htmlFiles(abs, rel));
+    } else if (name.endsWith('.html')) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+const pages = htmlFiles(BUILD).filter(
+  (p) => !VERSIONED_DOCS.test(p) && !GENERATED.test(p)
+);
+
+/** Anchor ids available on a built page, cached per file. */
+const idCache = new Map();
+function idsOf(relFile) {
+  if (idCache.has(relFile)) return idCache.get(relFile);
+  let ids = new Set();
+  const abs = join(BUILD, relFile);
+  if (existsSync(abs)) {
+    const html = readFileSync(abs, 'utf8');
+    for (const m of html.matchAll(/\sid="([^"]+)"/g)) ids.add(m[1]);
+    for (const m of html.matchAll(/\sname="([^"]+)"/g)) ids.add(m[1]);
+  }
+  idCache.set(relFile, ids);
+  return ids;
+}
+
+/**
+ * Maps a site path to the built file that serves it. Docusaurus emits either
+ * `<path>.html` or `<path>/index.html`; static assets are served verbatim.
+ */
+function resolveTarget(pathname) {
+  const clean = pathname.replace(/^\/+/, '') || 'index.html';
+  const candidates = clean.endsWith('.html')
+    ? [clean]
+    : clean.endsWith('/')
+      ? [clean + 'index.html']
+      : [clean, clean + '/index.html', clean + '.html'];
+  for (const c of candidates) {
+    const abs = join(BUILD, c);
+    if (existsSync(abs) && statSync(abs).isFile()) return c;
+  }
+  return null;
+}
+
+const broken = [];
+const externals = new Map(); // url -> Set(pages)
+
+for (const page of pages) {
+  const html = readFileSync(join(BUILD, page), 'utf8');
+  const pageDir = dirname('/' + page);
+  const seen = new Set();
+
+  // Connection hints (preconnect / dns-prefetch) name an origin to warm up, not
+  // a document to fetch. Probing them reports a 404 for a tag that is doing
+  // exactly its job, so drop those tags before extracting links.
+  const linkable = html.replace(
+    /<link\b[^>]*\brel="(?:preconnect|dns-prefetch)"[^>]*>/gi,
+    ''
+  );
+
+  for (const m of linkable.matchAll(/\s(?:href|src)="([^"]*)"/g)) {
+    const raw = m[1].trim();
+    if (!raw || seen.has(raw)) continue;
+    seen.add(raw);
+
+    if (/^(mailto:|tel:|javascript:|data:)/i.test(raw)) continue;
+    if (raw.startsWith('#')) {
+      // Same-page fragment.
+      const id = decodeURIComponent(raw.slice(1));
+      if (id && !idsOf(page).has(id)) {
+        broken.push(`${page}  ->  ${raw}  (no such id on this page)`);
+      }
+      continue;
+    }
+    if (/^https?:\/\//i.test(raw) || raw.startsWith('//')) {
+      const url = raw.startsWith('//') ? 'https:' + raw : raw;
+      // orm.st absolute links are our own pages; check them as internal.
+      const self = url.match(/^https?:\/\/orm\.st(\/.*)?$/i);
+      if (self) {
+        const [p, frag] = (self[1] || '/').split('#');
+        checkInternal(page, p, frag, raw);
+      } else {
+        if (!externals.has(url)) externals.set(url, new Set());
+        externals.get(url).add(page);
+      }
+      continue;
+    }
+
+    // Root-relative or document-relative.
+    const [pathPart, frag] = raw.split('#');
+    const pathname = pathPart.startsWith('/')
+      ? pathPart
+      : posix.normalize(posix.join(pageDir, pathPart || '.'));
+    checkInternal(page, pathname, frag, raw);
+  }
+}
+
+function checkInternal(page, pathname, frag, raw) {
+  // The Javadoc/KDoc trees under /api are generated by the deploy workflow and
+  // copied into the build there, so they are legitimately missing from a local
+  // `npm run build`. Their absence is not a broken link in this repository.
+  if (pathname.replace(/^\/+/, '').startsWith('api/')) return;
+  const target = resolveTarget(pathname.split('?')[0]);
+  if (!target) {
+    broken.push(`${page}  ->  ${raw}  (no such page or asset)`);
+    return;
+  }
+  if (frag && target.endsWith('.html')) {
+    const id = decodeURIComponent(frag);
+    if (!idsOf(target).has(id)) {
+      broken.push(`${page}  ->  ${raw}  (page exists, #${id} does not)`);
+    }
+  }
+}
+
+console.log(
+  `Checked ${pages.length} pages · ${externals.size} distinct external URLs`
+);
+
+if (CHECK_EXTERNAL) {
+  const urls = [...externals.keys()];
+  // Deliberately low: the bulk of the external set is github.com, which starts
+  // returning 429 to an unauthenticated client well before this is a bottleneck.
+  const CONCURRENCY = 4;
+  let cursor = 0;
+  const failures = [];
+
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  async function probe(url) {
+    // "Edit this page" targets are write-action endpoints: they require auth
+    // and answer 404 for a signed-out client even when the file exists. Probe
+    // the equivalent blob view instead, which validates the thing that
+    // actually matters — that the file is really at that path.
+    const target = url.replace(
+      /^(https:\/\/github\.com\/[^/]+\/[^/]+)\/edit\//,
+      '$1/blob/'
+    );
+    // HEAD first (cheap); some hosts answer 403/405 to HEAD but serve GET, so
+    // fall back rather than reporting a link that works in a browser.
+    for (const method of ['HEAD', 'GET']) {
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          const res = await fetch(target, {
+            method,
+            redirect: 'follow',
+            headers: {'user-agent': 'storm-docs-link-check'},
+            signal: AbortSignal.timeout(20000),
+          });
+          if (res.ok) return null;
+          // Rate limiting is a property of the checker, not of the link.
+          if (res.status === 429 || res.status === 503) {
+            await sleep(2000 * (attempt + 1));
+            continue;
+          }
+          if (method === 'GET') return `HTTP ${res.status}`;
+          break;
+        } catch (e) {
+          if (method === 'GET' && attempt === 2) {
+            return e.name === 'TimeoutError' ? 'timeout' : e.message;
+          }
+          await sleep(1000 * (attempt + 1));
+        }
+      }
+    }
+    return 'unreachable';
+  }
+
+  await Promise.all(
+    Array.from({length: CONCURRENCY}, async () => {
+      while (cursor < urls.length) {
+        const url = urls[cursor++];
+        const problem = await probe(url);
+        if (problem) {
+          const from = [...externals.get(url)].slice(0, 3).join(', ');
+          failures.push(`${url}  (${problem})  from: ${from}`);
+        }
+      }
+    })
+  );
+
+  if (failures.length) {
+    console.error(`\n${failures.length} external link(s) failed:`);
+    for (const f of failures.sort()) console.error('  ' + f);
+  } else {
+    console.log(`All ${urls.length} external URLs responded OK.`);
+  }
+  broken.push(...failures.map((f) => 'external: ' + f));
+}
+
+if (broken.length) {
+  console.error(`\n${broken.length} broken link(s):`);
+  for (const b of broken.sort()) console.error('  ' + b);
+  process.exit(1);
+}
+
+console.log('No broken links.');

--- a/website/scripts/generate-llms-full.sh
+++ b/website/scripts/generate-llms-full.sh
@@ -17,11 +17,13 @@ OUTPUT="$WEBSITE_DIR/static/llms-full.txt"
 # Documentation files in sidebar order.
 DOCS=(
   index.md
-  # Core Concepts
+  # Getting Started
   getting-started.md
   installation.md
   first-entity.md
   first-query.md
+  glossary.md
+  # Core Concepts
   entities.md
   projections.md
   relationships.md
@@ -68,7 +70,6 @@ DOCS=(
   faq.md
   migration-from-jpa.md
   jpa-cascades-vs-write-sets.md
-  glossary.md
   ai.md
   ai-reference.md
   database-and-mcp.md

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -1,13 +1,34 @@
 import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 
+// The reading order of the documentation. Keep it in sync with the DOCS list in
+// website/scripts/generate-llms-full.sh, which publishes the same pages in the
+// same order for AI consumers and fails the build on drift.
+//
+// Every page under docs/ belongs in exactly one place here. A page that is
+// published but absent from the sidebar is reachable only by a lucky inbound
+// link, which is how installation, first-entity, first-query, glossary,
+// error-handling and string-templates went unlisted for several releases.
 const sidebars: SidebarsConfig = {
   docs: [
     'index',
     {
       type: 'category',
-      label: 'Core Concepts',
+      label: 'Getting Started',
+      // Collapsed by default everywhere else; the entry path stays open so the
+      // first thing a new reader sees is the route from install to first query.
+      collapsed: false,
       items: [
         'getting-started',
+        'installation',
+        'first-entity',
+        'first-query',
+        'glossary',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Core Concepts',
+      items: [
         'entities',
         'projections',
         'relationships',
@@ -55,6 +76,7 @@ const sidebars: SidebarsConfig = {
           label: 'Internals',
           items: [
             'sql-templates',
+            'string-templates',
             'hydration',
             'dirty-checking',
             'entity-cache',
@@ -69,6 +91,7 @@ const sidebars: SidebarsConfig = {
             'sql-logging',
             'metrics',
             'security',
+            'error-handling',
             'performance',
           ],
         },

--- a/website/src/components/tutorial/tutorialTheme.js
+++ b/website/src/components/tutorial/tutorialTheme.js
@@ -12,6 +12,16 @@ import Head from '@docusaurus/Head';
 const esc = (s) =>
   s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
+// The canonical repository. Every "GitHub" affordance on the site points here;
+// the organization's repository list is a different destination and is only
+// linked where that breadth is the point (e.g. the example-project index).
+export const GH = 'https://github.com/storm-orm/storm-framework';
+
+// The community server. A permanent invite (no expiry, no use limit): Discord's
+// default invites lapse after seven days, and a dead invite in the footer of
+// every page would go unnoticed for a long time.
+export const DISCORD = 'https://discord.gg/SgQpcweUJD';
+
 // Token helpers for hand-highlighted code, same classes/colors as the landing
 // editor: K keyword, T type, S string, C comment, F function, N number,
 // A annotation, P plain, M muted.
@@ -288,17 +298,17 @@ export function TutorialPage({title, description, slug, body}) {
 
 export const navHtml = (active) => `
 <nav><div class="wrap nav">
-  <div class="brand"><a class="bhome" href="/"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span></a><span class="tech-tag">Kotlin 2.0–2.4 · Apache 2.0</span></div>
-  <input type="checkbox" id="storm-nav-toggle" class="nav-toggle-cb" aria-hidden="true" />
-  <label for="storm-nav-toggle" class="nav-toggle" aria-label="Toggle navigation menu"><span></span><span></span><span></span></label>
+  <div class="brand"><a class="bhome" href="/"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span></a><span class="tech-tag">Kotlin 2.0–2.4</span></div>
+  <input type="checkbox" id="storm-nav-toggle" class="nav-toggle-cb" aria-label="Toggle navigation menu" />
+  <label for="storm-nav-toggle" class="nav-toggle" aria-hidden="true"><span></span><span></span><span></span></label>
   <div class="nav-links">
     <a href="/tutorials/"${active === 'tutorials' ? ' class="on"' : ''}>Tutorials</a>
     <a href="/examples/"${active === 'examples' ? ' class="on"' : ''}>Examples</a>
     <a href="/comparison"${active === 'comparison' ? ' class="on"' : ''}>Comparison</a>
     <a href="/benchmarks"${active === 'benchmarks' ? ' class="on"' : ''}>Benchmarks</a>
     <a href="/blog/"${active === 'blog' ? ' class="on"' : ''}>Blog</a>
-    <a href="/docs/"${active === 'docs' ? ' class="on"' : ''}>Docs</a>
-    <a class="gh" href="https://github.com/orgs/storm-orm/repositories" target="_blank" rel="noopener">GitHub</a>
+    <a href="/docs/"${active === 'docs' ? ' class="on"' : ''}>Documentation</a>
+    <a class="gh" href="${GH}" target="_blank" rel="noopener">GitHub</a>
     <a href="/quickstart" class="btn primary" style="height:36px">Get started</a>
   </div>
 </div></nav>`;
@@ -329,7 +339,7 @@ export const heroArt = (page, {priority = false} = {}) => `
 export const FOOT_HTML = `
 <footer><div class="wrap foot">
   <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /></div>
-  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/comparison">Comparison</a><a href="/benchmarks">Benchmarks</a><a href="/blog/">Blog</a><a href="https://github.com/storm-orm/storm-framework" target="_blank" rel="noopener">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
+  <div class="links"><a href="/">orm.st</a><a href="/quickstart">Quickstart</a><a href="/docs/">Documentation</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/comparison">Comparison</a><a href="/benchmarks">Benchmarks</a><a href="/blog/">Blog</a><a href="${GH}" target="_blank" rel="noopener">GitHub</a><a href="${DISCORD}" target="_blank" rel="noopener">Discord</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
 </div></footer>`;
 
 export const TUT_CSS = `
@@ -338,7 +348,7 @@ export const TUT_CSS = `
     --border:#20202a; --border-soft:#17171f;
     --text:#eaeaf0; --muted:#8a8a96; --faint:#565662; --body:#b7b8c2;
     --accent:#818cf8; --accent-2:#a78bfa; --green:#5eead4;
-    --kw:#c4b5fd; --type:#7dd3fc; --str:#86efac; --com:#5a616e; --fn:#f0abfc; --num:#fcd34d; --anno:#fbbf24; --plain:#cfd0d8;
+    --kw:#c4b5fd; --type:#7dd3fc; --str:#86efac; --com:#767e8f; --fn:#f0abfc; --num:#fcd34d; --anno:#fbbf24; --plain:#cfd0d8;
     --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
     --sans:"Inter",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
   }
@@ -360,7 +370,13 @@ export const TUT_CSS = `
   .storm-tut .nav-links a:hover{color:var(--text)}
   .storm-tut .nav-links a.on{color:var(--text)}
   .storm-tut .nav-toggle{display:none}
+  /* Off entirely above the breakpoint, where the links are always visible and a
+     toggle would only add a dead tab stop. */
   .storm-tut .nav-toggle-cb{display:none}
+  /* One focus ring for every interactive control on the page. Keyboard-only
+     (:focus-visible), so it never fires on a mouse click. */
+  .storm-tut a:focus-visible,.storm-tut button:focus-visible,.storm-tut select:focus-visible,
+  .storm-tut .nav-toggle-cb:focus-visible + .nav-toggle{outline:2px solid var(--accent);outline-offset:3px;border-radius:6px}
   .storm-tut .btn{display:inline-flex;align-items:center;gap:8px;height:40px;padding:0 18px;border-radius:9px;font-size:14.5px;
     font-weight:550;border:1px solid var(--border);background:var(--panel);transition:.16s;cursor:pointer}
   .storm-tut .btn:hover{border-color:#34343d;transform:translateY(-1px)}
@@ -370,13 +386,13 @@ export const TUT_CSS = `
 
   /* article shell */
   .storm-tut .art{max-width:860px;margin:0 auto;padding:54px 24px 48px}
-  .storm-tut .crumbs{font-family:var(--mono);font-size:12px;color:var(--faint);letter-spacing:.04em}
-  .storm-tut .crumbs a:hover{color:var(--muted)}
+  .storm-tut .crumbs{font-family:var(--mono);font-size:12px;color:var(--muted);letter-spacing:.04em}
+  .storm-tut .crumbs a:hover{color:var(--text)}
   .storm-tut .crumbs .sep{margin:0 9px;color:#2c2c36}
   .storm-tut h1{font-size:clamp(34px,5vw,52px);line-height:1.05;letter-spacing:-.035em;font-weight:800;margin:18px 0 0}
   .storm-tut .dek{color:var(--muted);font-size:17.5px;line-height:1.66;margin:20px 0 0;max-width:700px}
   .storm-tut .meta{display:flex;gap:8px;margin-top:24px;flex-wrap:wrap}
-  .storm-tut .meta span{font-family:var(--mono);font-size:11.5px;color:var(--faint);border:1px solid var(--border-soft);border-radius:999px;padding:5px 13px}
+  .storm-tut .meta span{font-family:var(--mono);font-size:11.5px;color:var(--muted);border:1px solid var(--border-soft);border-radius:999px;padding:5px 13px}
   .storm-tut h2{font-size:25px;letter-spacing:-.02em;font-weight:700;margin:62px 0 0}
   .storm-tut h2 .hno{font-family:var(--mono);font-size:14px;font-weight:500;color:var(--accent);margin-right:12px}
   .storm-tut p{color:var(--body);font-size:15.5px;line-height:1.75;margin:16px 0 0}
@@ -464,6 +480,18 @@ export const TUT_CSS = `
      through. */
   .storm-tut table.cmp{width:100%;border-collapse:separate;border-spacing:0;margin:26px 0 0;font-size:14px;
     background:var(--panel-2);border:1px solid var(--border);border-radius:12px;overflow:hidden}
+  /* A wide matrix (the /comparison page's six columns) cannot shrink to a phone
+     and stay readable, and the overflow:hidden above — which is what rounds the
+     card's corners — clips the right-hand columns out of sight instead of
+     letting them scroll. Where a table is wrapped in .cmp-scroll the wrapper
+     takes the card chrome and does the scrolling, and the table keeps a legible
+     minimum width. Narrow .cmp tables (two or three columns, used in the
+     tutorials) are left alone: they fit, and wrapping them would add a
+     scrollbar for nothing. */
+  .storm-tut .cmp-scroll{margin:26px 0 0;border:1px solid var(--border);border-radius:12px;
+    background:var(--panel-2);overflow-x:auto;-webkit-overflow-scrolling:touch}
+  .storm-tut .cmp-scroll:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+  .storm-tut .cmp-scroll table.cmp{margin:0;border:0;border-radius:0;min-width:820px}
   .storm-tut .cmp th,.storm-tut .cmp td{border:0;text-align:left;padding:13px 16px;vertical-align:top;line-height:1.55}
   .storm-tut .cmp thead th{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;
     color:var(--muted);background:rgba(255,255,255,.022);border-bottom:1px solid var(--border);white-space:nowrap}
@@ -598,11 +626,16 @@ export const TUT_CSS = `
 
   .storm-tut footer{border-top:1px solid var(--border-soft);margin-top:70px;padding:36px 0;color:var(--faint);font-size:13.5px}
   .storm-tut .foot{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px}
-  .storm-tut .foot .links{display:flex;gap:22px;font-family:var(--mono)}.storm-tut .foot a{color:var(--muted)}.storm-tut .foot a:hover{color:var(--text)}
+  .storm-tut .foot .links{display:flex;gap:22px;font-family:var(--mono);flex-wrap:wrap}.storm-tut .foot a{color:var(--muted)}.storm-tut .foot a:hover{color:var(--text)}
   @media(max-width:920px){.storm-tut .tech-tag{display:none}}
   /* Mobile: replace the row of links with a hamburger that drops down a full
      menu (CSS-only via a hidden checkbox, so no JS is needed on any page). */
   @media(max-width:760px){
+    /* The menu is CSS-only (a checkbox drives the drop-down), so the checkbox is
+       the control a keyboard reaches: clipped to 1px rather than display:none,
+       which would take it out of the tab order and leave the mobile menu
+       keyboard-unreachable. Clicks land on the label, which forwards them. */
+    .storm-tut .nav-toggle-cb{display:block;position:absolute;width:1px;height:1px;margin:0;padding:0;opacity:0;pointer-events:none}
     .storm-tut .nav-toggle{display:flex;flex-direction:column;justify-content:center;gap:5px;width:40px;height:38px;padding:9px 8px;cursor:pointer;border:1px solid var(--border);border-radius:9px;background:var(--panel)}
     .storm-tut .nav-toggle span{display:block;height:2px;width:100%;background:var(--text);border-radius:2px;transition:transform .2s,opacity .2s}
     .storm-tut .nav-toggle-cb:checked ~ .nav-toggle span:nth-child(1){transform:translateY(7px) rotate(45deg)}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -64,10 +64,134 @@
   --docusaurus-highlighted-code-line-bg: rgba(129, 140, 248, 0.14);
 }
 
-/* Navbar: subtle bottom rule like the marketing nav. */
+/* Navbar: subtle bottom rule like the marketing nav, and the same translucent
+   backdrop, so moving between /quickstart and /docs does not change the chrome. */
 [data-theme='dark'] .navbar {
   border-bottom: 1px solid #17171f;
   box-shadow: none;
+  background: rgba(7, 7, 9, 0.7);
+  backdrop-filter: blur(12px);
+}
+
+/* Logo: the marketing pages give the mark an indigo glow; match it so the
+   brand reads the same on both sides of the site. */
+.navbar__logo img {
+  filter: drop-shadow(0 0 10px rgba(129, 140, 248, 0.35));
+}
+
+/* Brand wordmark: the marketing nav sets "ST/ORM" tight and semibold. */
+.navbar__title {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* Navbar links: quiet by default, full-strength on hover and for the active
+   item — the same treatment as the hand-built nav. */
+[data-theme='dark'] .navbar__link {
+  color: #8a8a96;
+}
+[data-theme='dark'] .navbar__link:hover,
+[data-theme='dark'] .navbar__link--active {
+  color: #eaeaf0;
+}
+
+/* One focus ring across the docs chrome, matching the marketing pages:
+   keyboard-only, indigo, offset clear of the control. Infima's default is a
+   faint box-shadow that disappears on the dark background. */
+.navbar__link:focus-visible,
+.navbar__brand:focus-visible,
+.menu__link:focus-visible,
+.pagination-nav__link:focus-visible,
+.table-of-contents__link:focus-visible,
+.breadcrumbs__link:focus-visible,
+.footer__link-item:focus-visible,
+.navbar__toggle:focus-visible,
+.clean-btn:focus-visible,
+.button:focus-visible,
+.markdown a:focus-visible,
+.theme-code-block button:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
+/* Buttons: the marketing .btn is a 9px-radius pill on the panel color with an
+   indigo fill for the primary action. Map Infima's buttons onto it. */
+.button {
+  border-radius: 9px;
+  font-weight: 600;
+}
+[data-theme='dark'] .button--secondary {
+  background: #0f0f14;
+  border-color: #20202a;
+  color: #eaeaf0;
+}
+[data-theme='dark'] .button--secondary:hover {
+  background: #17171f;
+  border-color: #34343d;
+  color: #eaeaf0;
+}
+
+/* Code blocks: the marketing editor sits on a panel fill inside a soft border
+   with a 12px radius. Infima's default is a flatter, borderless block. */
+[data-theme='dark'] .theme-code-block {
+  border: 1px solid #17171f;
+  border-radius: 12px;
+}
+
+
+/* Sidebar rhythm: a little more air between items and a rounded active state,
+   so the long Core Concepts list scans as groups rather than a wall. */
+.menu__link {
+  border-radius: 8px;
+  line-height: 1.45;
+}
+.menu__list-item-collapsible {
+  border-radius: 8px;
+}
+[data-theme='dark'] .menu__list .menu__list {
+  border-left: 1px solid #17171f;
+  margin-left: 0.55rem;
+  padding-left: 0.35rem;
+}
+
+/* Search: the local index ships with Infima's default light-ish input. Bring it
+   onto the panel/border tokens so it belongs in the dark navbar. */
+[data-theme='dark'] .navbar__search-input {
+  background-color: #0f0f14;
+  border: 1px solid #20202a;
+  color: #eaeaf0;
+}
+[data-theme='dark'] .navbar__search-input:focus {
+  border-color: rgba(129, 140, 248, 0.5);
+  outline: none;
+}
+[data-theme='dark'] .navbar__search-input::placeholder {
+  color: #565662;
+}
+[data-theme='dark'] .search-result-match {
+  color: var(--ifm-color-primary-lightest);
+  background: rgba(129, 140, 248, 0.14);
+}
+
+/* The row the keyboard cursor is on is filled with the primary indigo, and the
+   plugin's default text on it is white: 2.98:1, under the 4.5:1 minimum, on
+   precisely the row a keyboard user is reading. Both are plugin-provided custom
+   properties, so darken the text rather than fight the hashed module classes.
+   Near-black on the indigo measures 6.6:1, and matches the marketing primary
+   button, which is the same fill with the same dark label. */
+[data-theme='dark'] {
+  --search-local-highlight-color: #818cf8;
+  --search-local-hit-active-color: #0a0a0f;
+}
+
+/* Long inline code (fully qualified class names, Gradle coordinates) is the
+   usual cause of a horizontal page scrollbar on a phone. Let it wrap instead;
+   fenced blocks keep their own scroller. */
+.markdown p code,
+.markdown li code,
+.markdown td code {
+  overflow-wrap: anywhere;
 }
 
 /* Inline code chips: match the marketing --panel/--border-soft look. */

--- a/website/src/pages/benchmarks.js
+++ b/website/src/pages/benchmarks.js
@@ -1528,7 +1528,7 @@ const BM_CSS = `
     opacity:0;transform:translateY(3px);pointer-events:none;transition:opacity .12s ease,transform .12s ease;
     box-shadow:0 6px 18px rgba(0,0,0,.45);z-index:6}
   .bm-val[data-range]:hover::after{opacity:1;transform:translateY(0)}
-  .bm-delta{font-family:var(--mono);font-size:11px;color:var(--faint);justify-self:end;white-space:nowrap}
+  .bm-delta{font-family:var(--mono);font-size:11px;color:var(--muted);justify-self:end;white-space:nowrap}
   .bm-row.win .bm-delta{background:linear-gradient(100deg,#fcd34d,#eda921 55%,#d98a26);-webkit-background-clip:text;background-clip:text;color:transparent;font-weight:600}
   .bm-note{margin:10px 0 0;color:var(--faint);font-size:12px}
   .bm-card:not(.bm-loc) .bm-note{font-size:10.5px}
@@ -1550,7 +1550,7 @@ const BM_CSS = `
   .bm-lc{border:1px solid var(--border);border-radius:14px;background:#050507;margin:22px 0 10px;padding:20px 20px 14px}
   .bm-lc-head{display:flex;justify-content:space-between;align-items:baseline;gap:16px;flex-wrap:wrap;margin-bottom:8px}
   .storm-tut .art .bm-lc h3{margin:0;font-size:14.5px;color:var(--body)}
-  .bm-lc-hint{font-family:var(--mono);font-size:11px;color:var(--faint)}
+  .bm-lc-hint{font-family:var(--mono);font-size:11px;color:var(--muted)}
   .bm-lc svg{display:block;width:100%;height:auto}
   .bm-lc-grid{stroke:#1c1c24;stroke-width:1}
   .bm-lc-baseline{stroke:#8a8c9a;stroke-width:1.3;stroke-dasharray:2 5;opacity:.8}
@@ -1581,7 +1581,7 @@ const BM_CSS = `
   .bm-lc-lg.storm .sw{background:linear-gradient(90deg,#a78bfa,#7dd3fc)}
   .bm-lc-lg.off{opacity:.35}
   .bm-lc-lg.off .sw{background:#33333d !important}
-  .bm-lc-note{font-family:var(--mono);font-size:10.5px;color:var(--faint);margin-left:auto}
+  .bm-lc-note{font-family:var(--mono);font-size:10.5px;color:var(--muted);margin-left:auto}
   .bm-row.win .bm-name{width:fit-content;background:linear-gradient(100deg,#fcd34d,#eda921 55%,#d98a26);-webkit-background-clip:text;background-clip:text;color:transparent;font-weight:600}
   .bm-row.win .bm-bar{background:linear-gradient(90deg,#fcd34d,#eda921 55%,#d98a26)}
   .bm-scroll{overflow-x:auto;margin:6px 0 26px}
@@ -1611,6 +1611,14 @@ const BM_CSS = `
   .bm-loc .bm-row{grid-template-columns:250px 1fr 90px;margin:9px 0}
   .bm-loc .bm-note{margin-top:16px}
   .bm-loc .bm-name{white-space:normal}
+  /* On a phone the fixed 250px label column plus the 90px value column and the
+     gaps exceed the content lane, and the value column is what spills: the page
+     picks up a horizontal scrollbar. Make the label column elastic and size the
+     value column to its content instead. */
+  @media(max-width:760px){
+    .bm-loc .bm-row{grid-template-columns:minmax(0,1fr) minmax(48px,.55fr) auto;gap:10px}
+    .bm-loc .bm-name{overflow-wrap:anywhere}
+  }
   .bm-tag{display:inline-block;font-style:normal;font-size:9.5px;line-height:1;padding:3px 7px;margin-left:6px;border:1px solid var(--border);border-radius:999px;color:var(--muted);white-space:nowrap;vertical-align:1px}
   .bm-limits{border:1px solid var(--border);border-left:3px solid var(--accent);border-radius:12px;background:var(--panel-2);padding:16px 20px;margin:8px 0 24px}
   .storm-tut .art .bm-limits h3{margin:0 0 6px;font-size:15px}

--- a/website/src/pages/comparison.js
+++ b/website/src/pages/comparison.js
@@ -65,7 +65,12 @@ const FRAMEWORKS = [
 ];
 
 function buildBody() {
+  // The matrix is six columns wide, so on a phone it has to scroll sideways
+  // rather than squeeze. The wrapper is the scroller and carries the card
+  // chrome; it is focusable and labelled, because a scrollable region a
+  // keyboard cannot reach is a region a keyboard user cannot read.
   const matrix = `
+<div class="cmp-scroll" tabindex="0" role="region" aria-label="Framework comparison matrix">
 <table class="cmp cmp-brand">
   <thead><tr>
     <th>Feature</th><th>Storm</th><th>JPA / Hibernate</th><th>jOOQ</th><th>Exposed</th><th>Ktorm</th>
@@ -85,7 +90,8 @@ function buildBody() {
     <tr><td>Languages</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin + Java</td><td>Kotlin only</td><td>Kotlin only</td></tr>
     <tr><td>License</td><td>Apache 2.0</td><td>LGPL 2.1</td><td>Commercial for some DBs</td><td>Apache 2.0</td><td>Apache 2.0</td></tr>
   </tbody>
-</table>`;
+</table>
+</div>`;
 
   return `
 ${navHtml('comparison')}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,11 +1,27 @@
 import React, {useEffect} from 'react';
 import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-// The Storm landing page. The markup/CSS/JS are kept verbatim from the
-// hand-built design (landing-drafts/2-live.html) and mounted here so it serves
-// at `/`, in front of the docs (which now live under `/docs`). The <style> is
-// rendered inside the component so it only applies while this page is mounted
-// and never leaks into the docs theme.
+// The Storm landing page. The markup/CSS/JS are kept close to the hand-built
+// design (landing-drafts/2-live.html) and mounted here so it serves at `/`, in
+// front of the docs (which now live under `/docs`). The <style> is rendered
+// inside the component so it only applies while this page is mounted and never
+// leaks into the docs theme.
+//
+// Motion budget: the page carries exactly one automatic animation above the
+// fold, the editor typing its first snippet once on mount. The headline is
+// static, the benchmark comparison changes only when the visitor picks a
+// framework, and nothing loops. Under `prefers-reduced-motion: reduce` every
+// element renders in its finished state instead of a slower animation.
+
+const GH = 'https://github.com/storm-orm/storm-framework';
+
+// The community server. A permanent invite (no expiry, no use limit): Discord's
+// default invites lapse after seven days, and a dead invite in the footer of
+// every page would go unnoticed for a long time. Kept out of the production
+// evaluation section by design — that block answers "can I adopt this?" with
+// facts a reader can check, and a chat link is a different kind of claim.
+const DISCORD = 'https://discord.gg/SgQpcweUJD';
 
 const CSS = `
   :root{
@@ -13,7 +29,7 @@ const CSS = `
     --border:#20202a; --border-soft:#17171f;
     --text:#eaeaf0; --muted:#8a8a96; --faint:#565662;
     --accent:#818cf8; --accent-2:#a78bfa; --green:#5eead4;
-    --kw:#c4b5fd; --type:#7dd3fc; --str:#86efac; --com:#5a616e; --fn:#f0abfc; --num:#fcd34d; --anno:#fbbf24; --plain:#cfd0d8;
+    --kw:#c4b5fd; --type:#7dd3fc; --str:#86efac; --com:#767e8f; --fn:#f0abfc; --num:#fcd34d; --anno:#fbbf24; --plain:#cfd0d8;
     --mono:"JetBrains Mono",ui-monospace,SFMono-Regular,Menlo,monospace;
     --sans:"Inter",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
   }
@@ -23,6 +39,11 @@ const CSS = `
   .storm-home a{color:inherit;text-decoration:none}
   .storm-home *{box-sizing:border-box}
   .storm-home .wrap{max-width:1120px;margin:0 auto;padding:0 24px}
+  /* One focus ring for every interactive control on the page: links, buttons,
+     the scene tabs and the benchmark chips. Keyboard-only (:focus-visible), so
+     it never fires on a mouse click. */
+  .storm-home a:focus-visible,.storm-home button:focus-visible,.storm-home [tabindex]:focus-visible,
+  .storm-home .nav-toggle-cb:focus-visible + .nav-toggle{outline:2px solid var(--accent);outline-offset:3px;border-radius:6px}
 
   .storm-home nav{position:sticky;top:0;z-index:20;backdrop-filter:blur(12px);background:rgba(7,7,9,.7);border-bottom:1px solid var(--border-soft)}
   .storm-home .nav{display:flex;align-items:center;justify-content:space-between;height:62px}
@@ -33,6 +54,8 @@ const CSS = `
   .storm-home .nav-links{display:flex;align-items:center;gap:24px;font-size:14px;color:var(--muted)}
   .storm-home .nav-links a:hover{color:var(--text)}
   .storm-home .nav-toggle{display:none}
+  /* Off entirely above the breakpoint, where the links are always visible and a
+     toggle would only add a dead tab stop. */
   .storm-home .nav-toggle-cb{display:none}
   .storm-home .btn{display:inline-flex;align-items:center;gap:8px;height:40px;padding:0 18px;border-radius:9px;font-size:14.5px;
     font-weight:550;border:1px solid var(--border);background:var(--panel);transition:.16s;cursor:pointer}
@@ -80,78 +103,61 @@ const CSS = `
     .storm-home .heroart{animation:storm-hero-fade .9s ease both}
   }
   @keyframes storm-hero-fade{from{opacity:0}to{opacity:1}}
+  /* Static two-line headline. The whole proposition is on screen at once rather
+     than swapping, so nothing above the fold moves on a timer and the line the
+     visitor started reading is still there when they finish. Two lines rather
+     than three keeps the original hero scale: at 78px the proposition and the
+     product name each sit comfortably inside the 1072px lane. */
   .storm-home h1{font-size:clamp(42px,7vw,78px);line-height:.97;letter-spacing:-.04em;font-weight:800;margin:0}
+  .storm-home h1 .hline{display:block}
   .storm-home .grad{background:linear-gradient(100deg,#a78bfa,#818cf8 50%,#7dd3fc);-webkit-background-clip:text;background-clip:text;color:transparent}
+  /* Inter's solidus descends below the baseline; raise it so it sits centered
+     on the caps in "ST/ORM." */
+  .storm-home h1 .slash{vertical-align:.06em}
   .storm-home .vs-chips{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:18px}
-  .storm-home .vs-label{font-size:12.5px;color:var(--faint);margin-right:2px}
-  .storm-home .vs-chips button{font-family:var(--mono);font-size:11.5px;color:var(--faint);border:1px solid transparent;border-radius:999px;padding:6px 12px;cursor:pointer;transition:color .15s ease,box-shadow .15s ease;
+  /* --muted, not --faint: at this size these are normal-size text, and --faint
+     measures 2.7:1 on the page background, under the 4.5:1 minimum. --muted
+     clears it at 5.9:1 while staying quieter than the body copy. The same
+     applies to the scene tabs and the section labels below. */
+  .storm-home .vs-label{font-size:12.5px;color:var(--muted);margin-right:2px}
+  .storm-home .vs-chips button{font-family:var(--mono);font-size:11.5px;color:var(--muted);border:1px solid transparent;border-radius:999px;padding:6px 12px;cursor:pointer;transition:color .15s ease,box-shadow .15s ease;
     background:linear-gradient(var(--bg),var(--bg)) padding-box,linear-gradient(150deg,#5c5233 0%,#4a4026 22%,#382e15 46%,#2e2610 54%,#443a22 74%,#574d31 92%,#3c3319 100%) border-box}
-  .storm-home .vs-chips button:hover{color:var(--muted);box-shadow:0 0 6px rgba(251,191,36,.05)}
-  .storm-home .vs-chips button.on{color:#feeeb0;font-weight:700;box-shadow:0 0 8px rgba(251,191,36,.09);
+  .storm-home .vs-chips button:hover{color:#c9c9d4;box-shadow:0 0 6px rgba(251,191,36,.05)}
+  .storm-home .vs-chips button[aria-pressed="true"]{color:#feeeb0;font-weight:700;box-shadow:0 0 8px rgba(251,191,36,.09);
     background:linear-gradient(#1c1608,#1c1608) padding-box,linear-gradient(150deg,#ad9b63 0%,#8a6e30 22%,#6a531b 48%,#5f4c18 54%,#8a7030 74%,#ab965c 92%,#715e24 100%) border-box}
   .storm-home .vs-bench{margin-left:auto;font-size:12.5px;font-weight:600;color:#fbbf24;text-decoration:none;white-space:nowrap}
   .storm-home .vs-bench:hover{text-decoration:underline;color:#feeeb0}
   .storm-home .card.bcard{padding:18px 22px}
+  /* Reserved height: the three cards carry captions of different lengths, and
+     the visitor switches between them in place. Without a floor the row would
+     resize under the pointer as the copy changes. */
   .storm-home .bcard.bench{min-height:186px}
   .storm-home .bcard{position:relative;overflow:hidden}
   .storm-home .bcard .bback p{font-size:12.5px;line-height:1.5}
   .storm-home .bcard .bback h3{font-size:15.5px;margin-bottom:7px}
-  .storm-home .bface{transition:opacity .55s ease,transform .55s ease}
-  .storm-home .bcard:nth-child(2) .bface{transition-delay:.12s}
-  .storm-home .bcard:nth-child(3) .bface{transition-delay:.24s}
   .storm-home .bback{position:relative;inset:auto;padding:0;opacity:1;transform:none;pointer-events:auto}
   .storm-home .bnum{font-size:42px;font-weight:800;line-height:1;margin-bottom:8px;letter-spacing:-.02em;background:linear-gradient(100deg,#feeeb0,#fbbf24 55%,#f59e0b);-webkit-background-clip:text;background-clip:text;color:transparent}
   .storm-home .bback a{color:var(--accent);text-decoration:none;font-weight:600;white-space:nowrap}
   .storm-home .bback a:hover{text-decoration:underline}
-  /* Rotating hero line: all taglines live in the DOM, stacked in one grid cell
-     so the line never reflows; the JS toggles the .in class to fade one in at a
-     time. nowrap keeps each tagline on a single line, and the font scales with
-     the viewport so the longest one still fits. */
-  .storm-home .hero-rot{display:inline-grid;justify-items:start;vertical-align:top}
-  /* Direct children only ( > ): the ST/ORM copies contain a nested .slash span
-     that must not be hidden or animated as if it were a line of its own. */
-  .storm-home .hero-rot>span{grid-area:1/1;white-space:nowrap;font-size:clamp(30px,7vw,78px);font-weight:800;letter-spacing:-.04em;line-height:1.2;padding-bottom:.14em;
-    opacity:0;transform:translateY(10px);transition:opacity .55s ease,transform .55s ease;pointer-events:none}
-  /* The two "ST/ORM." copies (.travel on the bottom line, .ko on the top)
-     hide at each other's position, so toggling .in reads as one line of text
-     travelling between the hero rows while its color crossfades between white
-     and the gradient. --hero-gap (line distance) and --hero-up/--hero-down
-     (font-size ratio between the rows) are measured by the rotator JS since
-     they depend on the viewport. */
-  .storm-home .hero-rot>span.travel{transform:translateY(calc(var(--hero-gap,64px) * -1)) scale(var(--hero-up,1));transform-origin:left top}
-  .storm-home .hero-rot>span.in{opacity:1;transform:none;pointer-events:auto}
-  /* Each tagline is a door: the visible line (pointer-events on .in only) links
-     to quickstart, the comparison, or GitHub. Underline color is set explicitly
-     because the gradient text itself is transparent. */
-  .storm-home .hero-rot a:hover{text-decoration:underline;text-decoration-color:#a5b4fc;text-decoration-thickness:3px;text-underline-offset:7px}
-  /* Top hero line swaps in sync with the rotator: "Radically Simple." while the
-     bottom line reads "ST/ORM.", then "ST/ORM." moves up while the
-     taglines cycle below, so the product name is always on screen. Font metrics
-     inherit from the h1 (unlike .hero-rot, which scales down for long lines).
-     "Radically Simple." exits and re-enters from above, matching the direction
-     the travelling line pushes it. */
-  .storm-home .hero-swap{display:inline-grid;justify-items:start;vertical-align:top}
-  .storm-home .hero-swap>span{grid-area:1/1;white-space:nowrap;opacity:0;transform:translateY(-12px);transition:opacity .55s ease,transform .55s ease;pointer-events:none}
-  .storm-home .hero-swap>span.ko{transform:translateY(var(--hero-gap,64px)) scale(var(--hero-down,1));transform-origin:left top}
-  .storm-home .hero-swap>span.in{opacity:1;transform:none}
-  /* Inter's solidus descends below the baseline; raise it so it sits centered
-     on the caps in "ST/ORM." */
-  .storm-home h1 .slash{vertical-align:.06em}
-  @media(prefers-reduced-motion:reduce){.storm-home .hero-rot>span,.storm-home .hero-swap>span{transition:none}}
-  /* On small screens the h1 min (42px) is too large for the longer principles to
-     stay on one line, so scale the rotating line down a little below the hero. */
   @media(max-width:600px){
-    .storm-home .hero-rot>span{font-size:clamp(20px,6vw,30px)}
     /* Tighten the fold: campaign traffic is ~100% mobile and the hero CTA must
        be tappable without scrolling, so shrink the header spacing and sub copy
        and stack the buttons full-width. */
+    .storm-home h1{font-size:clamp(26px,6.8vw,36px);line-height:1.06}
     .storm-home header{padding:30px 0 26px}
     .storm-home .sub{font-size:15.5px;margin-top:18px}
+    .storm-home .sub-lead{font-size:16.5px;margin-top:16px}
     .storm-home .hero-cta{margin-top:20px}
     .storm-home .hero-cta .btn{flex:1 1 100%;justify-content:center;height:44px}
     .storm-home .stage{margin-top:34px}
   }
   .storm-home .sub{max-width:600px;margin:24px 0 0;color:var(--muted);font-size:18px;line-height:1.62}
+  /* Three tiers under the headline: what it is called (h1), what category it is
+     in (.sub-lead), then what makes it different (.sub). The lead sits a shade
+     brighter than the detail so the break reads as hierarchy rather than as a
+     paragraph that happens to be short. */
+  .storm-home .sub-lead{color:#c9c9d4;font-size:19.5px;margin-top:22px}
+  .storm-home .sub-lead + .sub{margin-top:10px}
   .storm-home .sub a{color:var(--accent);text-decoration:underline;text-underline-offset:3px}
   .storm-home .sub a:hover{color:#9aa3ff}
   .storm-home .cta{display:flex;gap:14px;margin-top:32px;flex-wrap:wrap}
@@ -168,9 +174,9 @@ const CSS = `
   .storm-home .fname{margin-left:10px;font-family:var(--mono);font-size:12.5px;color:var(--faint)}
   .storm-home .langtag{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--faint);letter-spacing:.05em}
   .storm-home .sqlbtn{margin-left:auto;display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:11.5px;
-    color:var(--accent);border:1px solid rgba(129,140,248,.3);border-radius:7px;padding:4px 10px;cursor:pointer;transition:.16s;user-select:none}
+    color:var(--accent);background:transparent;border:1px solid rgba(129,140,248,.3);border-radius:7px;padding:4px 10px;cursor:pointer;transition:.16s;user-select:none}
   .storm-home .sqlbtn:hover{background:rgba(129,140,248,.12);border-color:rgba(129,140,248,.5)}
-  .storm-home .sqlbtn.on{background:rgba(129,140,248,.16);color:#aab2ff}
+  .storm-home .sqlbtn[aria-expanded="true"]{background:rgba(129,140,248,.16);color:#aab2ff}
   .storm-home .sqlbtn .ico{width:13px;height:13px;opacity:.9}
   .storm-home .sqlconsole{display:none;border-top:1px solid var(--border-soft);background:var(--statusbg)}
   .storm-home .editor.show-sql .sqlconsole{display:block}
@@ -188,7 +194,10 @@ const CSS = `
   .storm-home .sqlq{color:var(--num)}
   .storm-home .sqlc{color:var(--com)}
 
-  .storm-home .codearea{display:flex;min-height:352px;background:linear-gradient(180deg,var(--panel),var(--panel-2))}
+  /* The floor matches the tallest snippet (scene 1, 13 lines), so the editor is
+     the same height from first paint through every scene the visitor opens: the
+     typewriter never grows the box and the tab row below it never moves. */
+  .storm-home .codearea{display:flex;min-height:372px;background:linear-gradient(180deg,var(--panel),var(--panel-2))}
   .storm-home .gutter{padding:22px 0;width:48px;text-align:right;color:#3b3b46;font-family:var(--mono);font-size:13px;
     line-height:26px;user-select:none;border-right:1px solid var(--border-soft);flex:none}
   .storm-home .gutter div{padding-right:15px}
@@ -220,11 +229,11 @@ const CSS = `
   .storm-home .statusbar .right{color:var(--faint);letter-spacing:.05em}
 
   .storm-home .scenes{display:flex;gap:8px;margin-top:22px;flex-wrap:wrap}
-  .storm-home .scenes .s{font-family:var(--mono);font-size:11.5px;color:var(--faint);border:1px solid transparent;
+  .storm-home .scenes .s{font-family:var(--mono);font-size:11.5px;color:var(--muted);border:1px solid transparent;appearance:none;
     border-radius:999px;padding:5px 13px;transition:color .2s ease,box-shadow .2s ease;cursor:pointer;
     background:linear-gradient(var(--bg),var(--bg)) padding-box,linear-gradient(150deg,#4a4e74 0%,#3c3e62 22%,#2d2e47 46%,#27273d 54%,#383a62 74%,#454877 92%,#313352 100%) border-box}
-  .storm-home .scenes .s:hover{color:var(--muted);box-shadow:0 0 8px rgba(129,140,248,.10)}
-  .storm-home .scenes .s.on{color:#f2ecff;box-shadow:0 0 10px rgba(129,140,248,.14);
+  .storm-home .scenes .s:hover{color:#c9c9d4;box-shadow:0 0 8px rgba(129,140,248,.10)}
+  .storm-home .scenes .s[aria-selected="true"]{color:#f2ecff;box-shadow:0 0 10px rgba(129,140,248,.14);
     background:linear-gradient(#131028,#131028) padding-box,linear-gradient(150deg,#7a80be 0%,#6167a2 22%,#4a4f80 46%,#434877 54%,#6167a2 74%,#7c82c0 92%,#545a90 100%) border-box}
 
   .storm-home .code-k{color:var(--kw)}.storm-home .code-t{color:var(--type)}.storm-home .code-s{color:var(--str)}.storm-home .code-c{color:var(--com)}
@@ -232,7 +241,7 @@ const CSS = `
 
   .storm-home section{padding:92px 0}
   .storm-home .dbstrip{padding:30px 0}
-  .storm-home .db-label{text-align:center;font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--faint);margin-bottom:18px}
+  .storm-home .db-label{text-align:center;font-family:var(--mono);font-size:11px;letter-spacing:.16em;text-transform:uppercase;color:var(--muted);margin-bottom:18px}
   .storm-home .dbs{display:flex;flex-wrap:wrap;gap:10px;justify-content:center}
   .storm-home .dbs span{font-family:var(--mono);font-size:13px;color:var(--muted);border:1px solid transparent;border-radius:8px;padding:7px 14px;
     background:linear-gradient(var(--panel-2),var(--panel-2)) padding-box,linear-gradient(150deg,#5c6069 0%,#474b53 24%,#33363d 48%,#2c2f36 54%,#42464e 74%,#565a62 92%,#383b43 100%) border-box;
@@ -246,15 +255,56 @@ const CSS = `
   .storm-home .card p{margin:0;color:var(--muted);font-size:14.5px;line-height:1.65}
   .storm-home .card .ic{width:34px;height:34px;border-radius:9px;display:grid;place-items:center;color:var(--accent);
     background:rgba(129,140,248,.1);border:1px solid rgba(129,140,248,.2);margin-bottom:16px}
-  .storm-home .endcta{text-align:center}
-  .storm-home .endcta h2{font-size:clamp(32px,5vw,54px);letter-spacing:-.035em;font-weight:800;margin:0 0 18px}
+
+  /* Production evaluation: the closing section answers "can I adopt this?"
+     rather than restating the pitch. Facts first (release, license, runtime),
+     then scope, then the places to verify each claim. */
+  .storm-home .adopt h2{font-size:clamp(28px,4vw,40px);letter-spacing:-.03em;font-weight:800;margin:0}
+  /* Full lane width, matching the card grid below it, so the deck does not sit
+     as a narrow ragged block above three full-width cards. */
+  .storm-home .adopt .lede{color:var(--muted);font-size:17px;line-height:1.62;margin:16px 0 0}
+  .storm-home .facts{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin-top:34px}
+  .storm-home .fact{border:1px solid var(--border-soft);border-radius:14px;padding:22px 24px;background:var(--panel-2)}
+  .storm-home .fact .flabel{font-family:var(--mono);font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted)}
+  .storm-home .fact .fval{font-size:27px;font-weight:750;letter-spacing:-.02em;margin-top:10px;color:var(--text)}
+  /* Same affordance as the scope cards below, so a card that carries a source
+     always shows it the same way. */
+  .storm-home .fact .flink{display:inline-block;margin-top:12px;color:var(--accent);font-size:14px;font-weight:600}
+  .storm-home .fact .flink:hover{text-decoration:underline}
+  .storm-home .fact .fnote{color:var(--muted);font-size:13.5px;line-height:1.6;margin-top:9px}
+  .storm-home .scope{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin-top:20px}
+  .storm-home .scope h3{margin:0 0 9px;font-size:16px;font-weight:650;letter-spacing:-.01em}
+  .storm-home .scope p{margin:0;color:var(--muted);font-size:14px;line-height:1.65}
+  /* A card naming two integrations links to both. Wrapping rather than one row:
+     the two labels together are within a few pixels of the card's inner width,
+     so they stack instead of clipping when the measure tightens. */
+  .storm-home .scope a{display:inline-block;margin-top:12px;margin-right:18px;color:var(--accent);font-size:14px;font-weight:600}
+  .storm-home .scope a:last-child{margin-right:0}
+  .storm-home .scope a:hover{text-decoration:underline}
+  .storm-home .verify{margin-top:34px;border-top:1px solid var(--border-soft);padding-top:22px}
+  .storm-home .verify .vlabel{font-family:var(--mono);font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted)}
+  .storm-home .verify .vlinks{display:flex;flex-wrap:wrap;gap:8px;margin-top:14px}
+  .storm-home .verify .vlinks a{font-family:var(--mono);font-size:12px;color:var(--muted);border:1px solid var(--border-soft);border-radius:999px;padding:6px 14px;transition:.16s}
+  .storm-home .verify .vlinks a:hover{color:var(--accent);border-color:rgba(129,140,248,.4)}
+
   .storm-home footer{border-top:1px solid var(--border-soft);padding:36px 0;color:var(--faint);font-size:13.5px}
   .storm-home .foot{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:14px}
-  .storm-home .foot .links{display:flex;gap:22px;font-family:var(--mono)}.storm-home .foot a{color:var(--muted)}.storm-home .foot a:hover{color:var(--text)}
-  @media(max-width:920px){.storm-home .tech-tag{display:none}}
+  .storm-home .foot .links{display:flex;gap:22px;font-family:var(--mono);flex-wrap:wrap}.storm-home .foot a{color:var(--muted)}.storm-home .foot a:hover{color:var(--text)}
+  @media(max-width:920px){
+    .storm-home .tech-tag{display:none}
+    .storm-home .facts,.storm-home .scope{grid-template-columns:1fr}
+  }
   @media(max-width:760px){
     .storm-home .three{grid-template-columns:1fr}
     .storm-home .bgrid{grid-template-columns:repeat(2,1fr)}
+    /* Wrapped code is taller than the desktop floor and every scene wraps to a
+       different height, so the reserved height is released here. */
+    .storm-home .codearea{min-height:0}
+    /* The menu is CSS-only (a checkbox drives the drop-down), so the checkbox is
+       the control a keyboard reaches: clipped to 1px rather than display:none,
+       which would take it out of the tab order and leave the mobile menu
+       keyboard-unreachable. Clicks land on the label, which forwards them. */
+    .storm-home .nav-toggle-cb{display:block;position:absolute;width:1px;height:1px;margin:0;padding:0;opacity:0;pointer-events:none}
     .storm-home .nav-toggle{display:flex;flex-direction:column;justify-content:center;gap:5px;width:40px;height:38px;padding:9px 8px;cursor:pointer;border:1px solid var(--border);border-radius:9px;background:var(--panel)}
     .storm-home .nav-toggle span{display:block;height:2px;width:100%;background:var(--text);border-radius:2px;transition:transform .2s,opacity .2s}
     .storm-home .nav-toggle-cb:checked ~ .nav-toggle span:nth-child(1){transform:translateY(7px) rotate(45deg)}
@@ -274,21 +324,236 @@ const CSS = `
     .storm-home #code{white-space:pre-wrap;overflow-wrap:break-word;overflow-x:visible;font-size:12.5px;line-height:22px;padding:18px 16px}
     .storm-home #sqlpanel{white-space:pre-wrap;overflow-wrap:break-word;overflow-x:visible}
   }
+  /* Reduced motion: the page must arrive finished, not slowed down. The hero
+     art fade is already opt-in above; this retires the caret blink, the tile
+     reveal and the status fade so every element renders in its end state. */
+  @media(prefers-reduced-motion:reduce){
+    .storm-home .cursor{animation:none}
+    .storm-home .bcell,.storm-home #status,.storm-home .btn{transition:none}
+  }
 `;
 
-const BODY = `
+const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const K = (x) => ({x, c: 'code-k'}),
+  T = (x) => ({x, c: 'code-t'}),
+  S = (x) => ({x, c: 'code-s'}),
+  C = (x) => ({x, c: 'code-c'}),
+  F = (x) => ({x, c: 'code-f'}),
+  N = (x) => ({x, c: 'code-n'}),
+  A = (x) => ({x, c: 'code-a'}),
+  P = (x) => ({x, c: 'code-pl'});
+
+const SCENES = [
+  { name:'1 · entities', file:'Entities.kt',
+    caption:"the most concise way to define your entities",
+    code:[ K("data class "),T("City"),P("(\n"),
+      P("    "),A("@PK"),P(" "),K("val "),P("id: "),T("Int"),P(" = "),N("0"),P(",\n"),
+      P("    "),K("val "),P("name: "),T("String"),P(",\n"),
+      P("    "),K("val "),P("population: "),T("Int"),P(",\n"),
+      P("    "),K("val "),P("country: "),T("String"),P("\n"),
+      P(") : "),T("Entity"),P("<"),T("Int"),P(">\n\n"),
+      K("data class "),T("User"),P("(\n"),
+      P("    "),A("@PK"),P(" "),K("val "),P("id: "),T("Int"),P(" = "),N("0"),P(",\n"),
+      P("    "),K("val "),P("email: "),T("String"),P(",\n"),
+      P("    "),K("val "),P("name: "),T("String"),P(",\n"),
+      P("    "),A("@FK"),P(" "),K("val "),P("city: "),T("City"),P("   "),C("// foreign entities are available in queries and results\n"),
+      P(") : "),T("Entity"),P("<"),T("Int"),P(">") ] },
+
+  { name:'2 · query', file:'UserService.kt',
+    caption:"one-line queries to get all the data you need · no N+1",
+    code:[ C("// A user's city is loaded in the same query.\n"),
+      K("val "),P("user = userRepository."),F("getById"),P("("),N("1"),P(")\n"),
+      K("val "),P("cityName = user.city.name"),P("   "),C('// already loaded: no N+1, no lazy-init\n\n'),
+      C("// Filter across the graph, fully type-safe using the static metamodel.\n"),
+      K("val "),P("users = userRepository."),F("findAll"),P("(User_.city.name "),K("eq "),S('"Sunnyvale"'),P(")") ] },
+
+  { name:'3 · repository', file:'UserRepository.kt',
+    caption:"your own type-safe queries · CRUD inherited",
+    code:[ C("// Custom return types are just records. Define them in-place.\n"),
+      K("data class "),T("CityCount"),P("("),K("val "),P("city: "),T("City"),P(", "),K("val "),P("count: "),T("Long"),P(")\n\n"),
+      C("// Extend EntityRepository: all CRUD comes for free.\n"),
+      K("interface "),T("UserRepository"),P(" : "),T("EntityRepository"),P("<"),T("User"),P(", "),T("Int"),P("> {\n"),
+      P("    "),K("fun "),F("findByCity"),P("(city: "),T("City"),P(") = "),F("findAll"),P("(User_.city "),K("eq "),P("city)\n\n"),
+      P("    "),K("fun "),F("usersPerCity"),P("(country: "),T("String"),P(") =\n"),
+      P("        "),F("select"),P("<"),T("CityCount"),P(", _, _> { "),S('"${City::class}, COUNT(*)"'),P(" }"),P("   "),C("// SQL template\n"),
+      P("            ."),F("where"),P("(User_.city.country "),K("eq "),P("country)\n"),
+      P("            ."),F("groupBy"),P("(User_.city)\n"),
+      P("            .resultList\n"),
+      P("}") ] },
+
+  { name:'4 · transactions', file:'Transactions.kt',
+    caption:"full control with programmatic tx · Spring's declarative tx also supported",
+    code:[ C("// Writes are explicit. One transaction.\n"),
+      F("transaction"),P(" {\n"),
+      P("    "),K("val "),P("city = orm "),K("insert "),T("City"),P("(name = "),S('"Sunnyvale"'),P(", population = "),N("161_884"),P(", country = "),S('"US"'),P(")\n"),
+      P("    orm "),K("insert "),T("User"),P("(email = "),S('"bob@acme.io"'),P(", name = "),S('"Bob"'),P(", city = city)\n"),
+      P("}\n"),
+      P("\n"),
+      C("// Full control when you need it: propagation, isolation, timeout, plus post-tx hooks.\n"),
+      F("transaction"),P("(propagation = "),T("REQUIRES_NEW"),P(", isolation = "),T("REPEATABLE_READ"),P(", timeoutSeconds = "),N("5"),P(") {\n"),
+      P("    "),K("val "),P("city = orm "),K("insert "),T("City"),P("(name = "),S('"San Jose"'),P(", population = "),N("1_013_240"),P(", country = "),S('"US"'),P(")\n"),
+      P("    "),K("val "),P("user = orm "),K("insert "),T("User"),P("(email = "),S('"alice@acme.io"'),P(", name = "),S('"Alice"'),P(", city = city)\n"),
+      P("\n"),
+      P("    "),F("onCommit"),P(" { events."),F("publish"),P("("),T("UserCreated"),P("(user)) }"),P("   "),C("// runs only after successful commit\n"),
+      P("}") ] },
+
+  { name:'5 · sql', file:'UserService.kt',
+    caption:"full SQL when you want it, never locked in",
+    code:[ C("// Full control of SQL, with typed columns and tables; rows map to any data class.\n"),
+      K("data class "),T("RankedCity"),P("("),K("val "),P("name: "),T("String"),P(", "),K("val "),P("rank: "),T("Long"),P(")\n\n"),
+      K("val "),P("ranked = orm."),F("query"),P(" { "),S('"""'),P("\n"),
+      P("    "),K("SELECT "),T("${City_.name}"),P(", RANK() "),K("OVER"),P(" ("),K("ORDER BY "),T("${City_.population}"),P(" "),K("DESC"),P(")\n"),
+      P("    "),K("FROM "),T("${City::class}"),P("\n"),
+      P("    "),K("WHERE "),T("${City_.country}"),P(" = "),T("$country"),P("   "),C("-- typed columns · bound value\n"),
+      S('"""'),P(" }."),F("resultList"),P("<"),T("RankedCity"),P(">()") ] },
+
+  { name:'6 · principles', file:'Core Principles',
+    caption:"the core principles",
+    grid:[
+      { t:"Enjoyable", d:"Write code that's a pleasure to read and maintain." },
+      { t:"Minimalist", d:"Concise entities and one-line queries. No ceremony." },
+      { t:"Modern", d:"Keeps pace with modern language features, e.g. coroutine-aware tx." },
+      { t:"Predictable", d:"All database calls are explicit. No surprises like hidden N+1 queries." },
+      { t:"Type-Safe", d:"Columns and types verified at compile time." },
+      { t:"Secure", d:"Interpolated values become bind variables, preventing SQL injection." },
+      { t:"Immutable", d:"Plain data classes and records, safe to share." },
+      { t:"Stateless", d:"No session, flush, or transaction-bound proxies." },
+      { t:"Portable", d:"Database specifics offered in a portable way, across all major databases." },
+      { t:"Flexible", d:"From a simple DSL to full SQL templates when you need them." },
+      { t:"Fast", d:"Optimized for performance, e.g. generated code instead of reflection." },
+      { t:"Efficient", d:"Low memory footprint, no heavyweight runtime, no external dependencies." },
+    ] },
+];
+
+// Generated SQL per scene (index-aligned with SCENES). Shown via the "Show SQL" toggle.
+const SQL = [
+  null, // entities: no query, so the Show SQL button is hidden for this scene
+
+  '<span class="sqlc">-- getById(1): joins the city graph, no N+1</span>\n'+
+  '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
+  '<span class="sqlk">FROM</span> "user" u\n'+
+  '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
+  '<span class="sqlk">WHERE</span> u.id = <span class="sqlq">?</span>\n\n'+
+  '<span class="sqlc">-- findAll(User_.city.name eq "Sunnyvale")</span>\n'+
+  '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
+  '<span class="sqlk">FROM</span> "user" u\n'+
+  '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
+  '<span class="sqlk">WHERE</span> c.name = <span class="sqlq">?</span>',
+
+  '<span class="sqlc">-- findByCity(city)</span>\n'+
+  '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
+  '<span class="sqlk">FROM</span> "user" u\n'+
+  '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
+  '<span class="sqlk">WHERE</span> u.city_id = <span class="sqlq">?</span>\n\n'+
+  '<span class="sqlc">-- usersPerCity(country)</span>\n'+
+  '<span class="sqlk">SELECT</span> c.id, c.name, c.population, c.country, <span class="sqlk">COUNT</span>(*)\n'+
+  '<span class="sqlk">FROM</span> "user" u\n'+
+  '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
+  '<span class="sqlk">WHERE</span> c.country = <span class="sqlq">?</span>\n'+
+  '<span class="sqlk">GROUP BY</span> u.city_id',
+
+  '<span class="sqlc">-- the second block wraps these two inserts in one configured transaction:</span>\n'+
+  '<span class="sqlc">-- transaction(REQUIRES_NEW, REPEATABLE_READ, timeoutSeconds = 5)</span>\n'+
+  '<span class="sqlk">SET TRANSACTION ISOLATION LEVEL REPEATABLE READ</span>\n'+
+  '<span class="sqlk">BEGIN</span>\n'+
+  '<span class="sqlk">INSERT INTO</span> city (name, population, country) <span class="sqlk">VALUES</span> (<span class="sqlq">?</span>, <span class="sqlq">?</span>, <span class="sqlq">?</span>)\n'+
+  '<span class="sqlk">INSERT INTO</span> "user" (email, name, city_id) <span class="sqlk">VALUES</span> (<span class="sqlq">?</span>, <span class="sqlq">?</span>, <span class="sqlq">?</span>)\n'+
+  '<span class="sqlk">COMMIT</span>\n'+
+  '<span class="sqlc">-- onCommit hook runs here, only after COMMIT succeeds</span>',
+
+  '<span class="sqlc">-- typed columns resolve to the city alias · $country becomes ?</span>\n'+
+  '<span class="sqlk">SELECT</span> c.name, <span class="sqlk">RANK</span>() <span class="sqlk">OVER</span> (<span class="sqlk">ORDER BY</span> c.population <span class="sqlk">DESC</span>)\n'+
+  '<span class="sqlk">FROM</span> city c\n'+
+  '<span class="sqlk">WHERE</span> c.country = <span class="sqlq">?</span>',
+];
+
+// Storm-vs-X figures from the published 5-fork benchmark run of 2026-07-25
+// (median fork; differences within 2% count as level). Hibernate is the default
+// because it is the framework most visitors are coming from; the rest are one
+// click away. Nothing here changes on a timer.
+const VS = {
+  hibernate: {
+    label: 'Hibernate',
+    speed: ['9 of 12', 'workloads faster than Hibernate', 'Level on two more; behind only on projection, by 2.4%.'],
+    entities: ['78%', 'fewer entity lines', 'The five-table model: 31 lines in Storm, 141 in Hibernate.'],
+    queries: ['14%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 188 in Hibernate, with no query strings.'],
+  },
+  jooq: {
+    label: 'jOOQ',
+    speed: ['11 of 12', 'workloads faster than jOOQ', 'jOOQ takes only the object graph, with a clever JSON-aggregate query; Storm leads the other eleven, including all four writes.'],
+    entities: ['31 lines', 'instead of manual mapping', 'jOOQ maps results by hand into DTOs; Storm turns one 31-line model into typed rows everywhere.'],
+    queries: ['17%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 194 in jOOQ, no hand-written row mapping.'],
+  },
+  exposed: {
+    label: 'Exposed',
+    speed: ['10 of 12', 'workloads faster than Exposed', 'Level on the other two; Storm never trails it, and leads by up to 1.9x.'],
+    entities: ['47%', 'fewer entity lines', 'The five-table model: 31 lines in Storm, 58 lines of Exposed table objects and data classes.'],
+    queries: ['16%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 191 in Exposed, no hand-written row mapping.'],
+  },
+  exposedDao: {
+    label: 'Exposed DAO',
+    speed: ['12 of 12', 'workloads faster than Exposed DAO', 'Faster on all twelve workloads, from 6% to 2.5x ahead.'],
+    entities: ['58%', 'fewer entity lines', 'One data class per table in Storm; Exposed DAO needs the table object, the DAO class and a DTO.'],
+    queries: ['15%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 190 in Exposed DAO.'],
+  },
+  ktorm: {
+    label: 'Ktorm',
+    speed: ['11 of 12', 'workloads faster than Ktorm', 'Level on projection; ahead on the other eleven, peaking at 2.4x.'],
+    entities: ['48%', 'fewer entity lines', 'The five-table model: 31 lines in Storm, 60 lines of Ktorm tables and entity interfaces.'],
+    queries: ['9%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 177 in Ktorm.'],
+  },
+  jimmer: {
+    label: 'Jimmer',
+    speed: ['11 of 12', 'workloads faster than Jimmer', 'Level on projection; faster on the other eleven, peaking at 2.3x.'],
+    entities: ['46%', 'fewer entity lines', 'The five-table model: 31 lines of data classes in Storm, 57 lines of interfaces in Jimmer.'],
+    queries: ['40%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 270 in Jimmer.'],
+  },
+  jdbc: {
+    label: 'JDBC',
+    speed: ['Within 15%', 'of hand-written JDBC speed', 'averaged across the twelve workloads; the next-closest framework averages 31%. The trade: typed entities and compile-checked queries instead of strings and hand-mapped rows.'],
+    entities: ['31 lines', 'instead of manual mapping', 'JDBC has no entities: every row stays untyped until you map it by hand.'],
+    queries: ['59%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 395 of hand-written JDBC and mapping.'],
+  },
+};
+const VS_ORDER = ['hibernate', 'jooq', 'exposed', 'exposedDao', 'ktorm', 'jimmer', 'jdbc'];
+const VS_DEFAULT = 'hibernate';
+
+function buildBody(version) {
+  const chips = VS_ORDER.map(
+    (key) =>
+      `<button type="button" data-vs="${key}" aria-pressed="${key === VS_DEFAULT}">${esc(VS[key].label)}</button>`
+  ).join('');
+
+  // The tab row is rendered here rather than built by the effect, so the
+  // control exists on first paint and the row below the editor never jumps.
+  const tabs = SCENES.map(
+    (s, i) =>
+      `<button type="button" class="s" role="tab" id="stab-${i}" aria-controls="scene-panel"` +
+      ` aria-selected="${i === 0}" tabindex="${i === 0 ? 0 : -1}">${esc(s.name)}</button>`
+  ).join('');
+
+  const d = VS[VS_DEFAULT];
+  const card = (slot) =>
+    `<div class="card bcard bench"><div class="bface bback" data-slot="${slot}">` +
+    `<div class="bnum">${esc(d[slot][0])}</div>` +
+    `<h3>${esc(d[slot][1])}</h3>` +
+    `<p><span class="btext">${esc(d[slot][2])}</span></p>` +
+    `</div></div>`;
+
+  return `
 <nav><div class="wrap nav">
-  <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span><span class="tech-tag">Kotlin 2.0–2.4 · Apache 2.0</span></div>
-  <input type="checkbox" id="storm-nav-toggle" class="nav-toggle-cb" aria-hidden="true" />
-  <label for="storm-nav-toggle" class="nav-toggle" aria-label="Toggle navigation menu"><span></span><span></span><span></span></label>
+  <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /><span>ST<b>/ORM</b></span><span class="tech-tag">Kotlin 2.0–2.4</span></div>
+  <input type="checkbox" id="storm-nav-toggle" class="nav-toggle-cb" aria-label="Toggle navigation menu" />
+  <label for="storm-nav-toggle" class="nav-toggle" aria-hidden="true"><span></span><span></span><span></span></label>
   <div class="nav-links">
     <a href="/tutorials/">Tutorials</a>
     <a href="/examples/">Examples</a>
     <a href="/comparison">Comparison</a>
     <a href="/benchmarks">Benchmarks</a>
     <a href="/blog/">Blog</a>
-    <a href="/docs/">Docs</a>
-    <a class="gh" href="https://github.com/orgs/storm-orm/repositories" target="_blank" rel="noopener">GitHub</a>
+    <a href="/docs/">Documentation</a>
+    <a class="gh" href="${GH}" target="_blank" rel="noopener">GitHub</a>
     <a href="/quickstart" class="btn primary" style="height:36px">Get started</a>
   </div>
 </div></nav>
@@ -301,12 +566,12 @@ const BODY = `
   <img src="/img/hero/orm-home-desktop.webp" alt="" width="1600" height="900" decoding="async" fetchpriority="high" />
 </picture>
 <div class="wrap">
-  <h1><span class="hero-swap" id="heroTop">
-    <span class="in">Radically Simple.</span>
-    <span>Measurably Fast.</span>
-  </span><br><span class="hero-rot"><span class="grad in">ST<span class="slash">/</span>ORM for Kotlin.</span></span></h1>
-  <p class="sub" style="max-width:940px">What would an ORM look like if you designed it for Kotlin today?</p>
-  <p class="sub" style="max-width:940px;margin-top:14px">Immutable data-class entities. Concise queries checked at compile time. No proxies, persistence context, or accidental N+1 queries. ST/ORM is a modern alternative to Hibernate and Exposed.</p>
+  <h1>
+    <span class="hline">Radically Simple. Fast.</span>
+    <span class="hline grad">ST<span class="slash">/</span>ORM for Kotlin.</span>
+  </h1>
+  <p class="sub sub-lead">A modern alternative to Hibernate and Exposed.</p>
+  <p class="sub" style="max-width:940px">Immutable data-class entities. Concise queries checked at compile time. No proxies, persistence context, or accidental N+1 queries.</p>
   <div class="cta hero-cta">
     <a href="/quickstart" class="btn primary go">Try it in 5 minutes →</a>
     <a href="/comparison" class="btn">Compare with your ORM</a>
@@ -317,49 +582,31 @@ const BODY = `
       <div class="ebar">
         <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
         <span class="fname" id="fname">Entities.kt</span>
-        <span class="sqlbtn" id="sqlbtn"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/></svg><span id="sqlbtntext">Show SQL</span></span>
+        <button type="button" class="sqlbtn" id="sqlbtn" aria-expanded="false" aria-controls="sqlpanel" style="display:none"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/></svg><span id="sqlbtntext">Show SQL</span></button>
       </div>
-      <div class="codearea">
+      <div class="codearea" id="scene-panel" role="tabpanel" aria-labelledby="stab-0" tabindex="0">
         <div class="gutter" id="gutter"></div>
         <pre id="code"></pre>
         <div id="benefits" class="bgrid"></div>
       </div>
       <div class="statusbar">
-        <span id="status"><svg class="ck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M20 6 9 17l-5-5"/></svg><span id="statustext"></span></span>
+        <span id="status"><svg class="ck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg><span id="statustext"></span></span>
         <span class="sqllabel"><span class="ar">↳</span> generated sql</span>
       </div>
       <div class="sqlconsole">
         <pre id="sqlpanel"></pre>
       </div>
     </div>
-    <div class="scenes" id="scenes"></div>
+    <div class="scenes" id="scenes" role="tablist" aria-label="Code examples">${tabs}</div>
   </div>
 </div></header>
 
 <section style="padding-top:48px;padding-bottom:30px"><div class="wrap">
-  <div class="vs-chips"><span class="vs-label">Benchmark against</span><button data-vs="hibernate">Hibernate</button><button data-vs="jooq">jOOQ</button><button data-vs="exposed">Exposed</button><button data-vs="exposedDao">Exposed DAO</button><button data-vs="ktorm">Ktorm</button><button data-vs="jimmer">Jimmer</button><button data-vs="jdbc">JDBC</button><a class="vs-bench" href="/benchmarks">See the benchmarks →</a></div>
-  <div class="three">
-    <div class="card bcard bench">
-      <div class="bface bback" data-slot="speed">
-        <div class="bnum">9 of 12</div>
-        <h3>workloads faster than Hibernate</h3>
-        <p><span class="btext">Level on two more; behind only on projection, by 2.4%.</span></p>
-      </div>
-    </div>
-    <div class="card bcard bench">
-      <div class="bface bback" data-slot="entities">
-        <div class="bnum">78%</div>
-        <h3>fewer entity lines</h3>
-        <p><span class="btext">The five-table model: 31 lines in Storm, 141 in Hibernate.</span></p>
-      </div>
-    </div>
-    <div class="card bcard bench">
-      <div class="bface bback" data-slot="queries">
-        <div class="bnum">14%</div>
-        <h3>fewer query lines</h3>
-        <p><span class="btext">All twelve workloads: 161 lines in Storm, 188 in Hibernate, with no query strings.</span></p>
-      </div>
-    </div>
+  <div class="vs-chips" role="group" aria-labelledby="vs-label"><span class="vs-label" id="vs-label">Benchmark against</span>${chips}<a class="vs-bench" href="/benchmarks">See the benchmarks →</a></div>
+  <div class="three" aria-live="polite">
+    ${card('speed')}
+    ${card('entities')}
+    ${card('queries')}
   </div>
 </div></section>
 
@@ -380,67 +627,89 @@ const BODY = `
   </div>
 </div>
 
-<section class="endcta" style="padding-top:64px"><div class="wrap">
-  <h2>Write code worth reading.</h2>
-  <p class="sub" style="margin:0 auto 30px;text-align:center;max-width:940px">Concise entities and one-line queries keep you productive. Immutable records simplify your architecture by letting the same types flow through your application layers. Storm is built for engineers who care about beautiful code.</p>
-  <div class="cta" style="justify-content:center;margin-top:56px">
-    <a href="/quickstart" class="btn primary go">Try it in 5 minutes →</a>
-    <a href="/comparison" class="btn">Compare with your ORM</a>
-    <a href="https://github.com/storm-orm/storm-framework" target="_blank" rel="noopener" class="btn">Star on GitHub</a>
+<section class="adopt" style="padding-top:64px"><div class="wrap">
+  <h2>Evaluating Storm for production</h2>
+  <p class="lede">Storm is developed and maintained as an independent open-source project. Applications built with Storm have been running in commercial production since May 2024, supporting services delivered to some of the world’s largest technology companies.</p>
+
+  <div class="facts">
+    <div class="fact">
+      <div class="flabel">Current release</div>
+      <div class="fval">${esc(version)}</div>
+      <div class="fnote">Published to Maven Central as <code>st.orm:storm-bom</code>.</div>
+      <a class="flink" href="https://central.sonatype.com/artifact/st.orm/storm-bom" target="_blank" rel="noopener">View on Maven Central →</a>
+    </div>
+    <div class="fact">
+      <div class="flabel">License</div>
+      <div class="fval">Apache 2.0</div>
+      <div class="fnote">One license for the whole framework, database dialects included. No commercial tier and no separate terms per database.</div>
+      <a class="flink" href="${GH}/blob/main/LICENSE.txt" target="_blank" rel="noopener">Read the license →</a>
+    </div>
+    <div class="fact">
+      <div class="flabel">Runtime</div>
+      <div class="fval">JDK 21+</div>
+      <div class="fnote">Kotlin 2.0 through 2.4. Runs on any JVM 21 or later.</div>
+    </div>
+  </div>
+
+  <div class="scope">
+    <div class="card">
+      <h3>Databases</h3>
+      <p>Dialect modules for PostgreSQL, MySQL, MariaDB, Oracle, SQL Server, SQLite and H2, each with its own upsert, paging and identity handling. Any other JDBC database runs on the generic dialect.</p>
+      <a href="/docs/dialects">Dialect support →</a>
+    </div>
+    <div class="card">
+      <h3>Integrations</h3>
+      <p>Spring Boot 3 and 4 (starter, auto-configuration, repository scanning, test slices), Ktor (plugin, coroutine-native transactions), GraalVM native images, Micrometer metrics, Jackson and kotlinx.serialization.</p>
+      <a href="/docs/spring-integration">Spring integration →</a>
+      <a href="/docs/ktor-integration">Ktor integration →</a>
+    </div>
+    <div class="card">
+      <h3>Questions and feedback</h3>
+      <p>Ask in Discord for a quick answer, or open a discussion when it is worth keeping searchable. Feedback on the docs and the quickstart is especially welcome.</p>
+      <a href="${DISCORD}" target="_blank" rel="noopener">Join the Discord →</a>
+      <a href="${GH}/discussions" target="_blank" rel="noopener">Discussions →</a>
+    </div>
+  </div>
+
+  <div class="verify">
+    <div class="vlabel">Check it yourself</div>
+    <div class="vlinks">
+      <a href="${GH}/releases" target="_blank" rel="noopener">Releases</a>
+      <a href="${GH}/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a>
+      <a href="${GH}/issues" target="_blank" rel="noopener">Open issues</a>
+      <a href="${GH}/discussions" target="_blank" rel="noopener">Discussions</a>
+      <a href="https://github.com/storm-orm/storm-benchmarks" target="_blank" rel="noopener">Benchmark sources</a>
+      <a href="https://central.sonatype.com/namespace/st.orm" target="_blank" rel="noopener">Maven Central</a>
+      <a href="${GH}/blob/main/SECURITY.md" target="_blank" rel="noopener">Security policy</a>
+      <a href="${GH}/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
+    </div>
   </div>
 </div></section>
 
 <footer><div class="wrap foot">
   <div class="brand"><img class="logo" src="/img/storm-light.png" alt="Storm" /></div>
-  <div class="links"><a href="/">orm.st</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/comparison">Comparison</a><a href="/benchmarks">Benchmarks</a><a href="/blog/">Blog</a><a href="https://github.com/storm-orm/storm-framework" target="_blank" rel="noopener">GitHub</a><a href="https://central.sonatype.com/namespace/st.orm">Maven Central</a></div>
+  <div class="links"><a href="/">orm.st</a><a href="/quickstart">Quickstart</a><a href="/docs/">Documentation</a><a href="/tutorials/">Tutorials</a><a href="/examples/">Examples</a><a href="/comparison">Comparison</a><a href="/benchmarks">Benchmarks</a><a href="/blog/">Blog</a><a href="${GH}" target="_blank" rel="noopener">GitHub</a><a href="${DISCORD}" target="_blank" rel="noopener">Discord</a></div>
 </div></footer>
 `;
+}
+
+const TITLE = 'ST/ORM · The type-safe Kotlin ORM';
+const DESC =
+  'Storm is a type-safe, SQL-first Kotlin ORM. Immutable data-class entities, ' +
+  'one-line queries checked at compile time, no proxies, no N+1. Try it in 5 minutes.';
 
 export default function Home() {
+  const {siteConfig} = useDocusaurusContext();
+  const version = siteConfig.customFields?.stormVersion || '0.0.0';
+
   useEffect(() => {
-    // Pick your ORM: the feature cards show Storm-vs-X figures from the published 5-fork run of
-    // 2026-07-25 (median fork; differences within 2% count as level).
-    const VS = {
-      hibernate: {
-        speed: ['9 of 12', 'workloads faster than Hibernate', 'Level on two more; behind only on projection, by 2.4%.'],
-        entities: ['78%', 'fewer entity lines', 'The five-table model: 31 lines in Storm, 141 in Hibernate.'],
-        queries: ['14%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 188 in Hibernate, with no query strings.'],
-      },
-      jooq: {
-        speed: ['11 of 12', 'workloads faster than jOOQ', 'jOOQ takes only the object graph, with a clever JSON-aggregate query; Storm leads the other eleven, including all four writes.'],
-        entities: ['31 lines', 'instead of manual mapping', 'jOOQ maps results by hand into DTOs; Storm turns one 31-line model into typed rows everywhere.'],
-        queries: ['17%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 194 in jOOQ, no hand-written row mapping.'],
-      },
-      exposed: {
-        speed: ['10 of 12', 'workloads faster than Exposed', 'Level on the other two; Storm never trails it, and leads by up to 1.9x.'],
-        entities: ['47%', 'fewer entity lines', 'The five-table model: 31 lines in Storm, 58 lines of Exposed table objects and data classes.'],
-        queries: ['16%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 191 in Exposed, no hand-written row mapping.'],
-      },
-      exposedDao: {
-        speed: ['12 of 12', 'workloads faster than Exposed DAO', 'Faster on all twelve workloads, from 6% to 2.5x ahead.'],
-        entities: ['58%', 'fewer entity lines', 'One data class per table in Storm; Exposed DAO needs the table object, the DAO class and a DTO.'],
-        queries: ['15%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 190 in Exposed DAO.'],
-      },
-      ktorm: {
-        speed: ['11 of 12', 'workloads faster than Ktorm', 'Level on projection; ahead on the other eleven, peaking at 2.4x.'],
-        entities: ['48%', 'fewer entity lines', 'The five-table model: 31 lines in Storm, 60 lines of Ktorm tables and entity interfaces.'],
-        queries: ['9%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 177 in Ktorm.'],
-      },
-      jimmer: {
-        speed: ['11 of 12', 'workloads faster than Jimmer', 'Level on projection; faster on the other eleven, peaking at 2.3x.'],
-        entities: ['46%', 'fewer entity lines', 'The five-table model: 31 lines of data classes in Storm, 57 lines of interfaces in Jimmer.'],
-        queries: ['40%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 270 in Jimmer.'],
-      },
-      jdbc: {
-        speed: ['Within 15%', 'of hand-written JDBC speed', 'averaged across the twelve workloads; the next-closest framework averages 31%. The trade: typed entities and compile-checked queries instead of strings and hand-mapped rows.'],
-        entities: ['31 lines', 'instead of manual mapping', 'JDBC has no entities: every row stays untyped until you map it by hand.'],
-        queries: ['59%', 'fewer query lines', 'All twelve workloads: 161 lines in Storm, 395 of hand-written JDBC and mapping.'],
-      },
-    };
+    // ---- benchmark comparison: manual selection only, Hibernate by default ----
     const vsCards = [...document.querySelectorAll('.storm-home .bcard')];
     const vsChips = [...document.querySelectorAll('.storm-home .vs-chips button')];
     function applyVs(key) {
-      vsChips.forEach((chip) => chip.classList.toggle('on', chip.dataset.vs === key));
+      vsChips.forEach((chip) =>
+        chip.setAttribute('aria-pressed', chip.dataset.vs === key ? 'true' : 'false')
+      );
       const data = VS[key];
       vsCards.forEach((card) => {
         const back = card.querySelector('.bback');
@@ -448,163 +717,21 @@ export default function Home() {
         back.querySelector('.bnum').textContent = num;
         back.querySelector('h3').textContent = cap;
         back.querySelector('.btext').textContent = text;
-        card.classList.add('bench');
       });
     }
-    // Cycle through the comparisons until the visitor picks one; hovering pauses the cycle.
-    const vsOrder = ['hibernate', 'jooq', 'exposed', 'exposedDao', 'ktorm', 'jimmer', 'jdbc'];
-    let vsIdx = 0;
-    const vsSection = document.querySelector('.storm-home .vs-chips');
-    const vsAuto = setInterval(() => {
-      if (vsCards.some((card) => card.matches(':hover')) || (vsSection && vsSection.matches(':hover'))) return;
-      vsIdx = (vsIdx + 1) % vsOrder.length;
-      applyVs(vsOrder[vsIdx]);
-    }, 7000);
     const vsChipHandlers = vsChips.map((chip) => {
-      const onChipClick = () => {
-        clearInterval(vsAuto);
-        applyVs(chip.dataset.vs);
-      };
+      const onChipClick = () => applyVs(chip.dataset.vs);
       chip.addEventListener('click', onChipClick);
       return [chip, onChipClick];
     });
-    applyVs('hibernate');
 
-    const K=(x)=>({x,c:'code-k'}),T=(x)=>({x,c:'code-t'}),S=(x)=>({x,c:'code-s'}),C=(x)=>({x,c:'code-c'}),
-          F=(x)=>({x,c:'code-f'}),N=(x)=>({x,c:'code-n'}),A=(x)=>({x,c:'code-a'}),P=(x)=>({x,c:'code-pl'});
-
-    const SCENES=[
-      { name:'1 · entities', file:'Entities.kt',
-        caption:"the most concise way to define your entities",
-        code:[ K("data class "),T("City"),P("(\n"),
-          P("    "),A("@PK"),P(" "),K("val "),P("id: "),T("Int"),P(" = "),N("0"),P(",\n"),
-          P("    "),K("val "),P("name: "),T("String"),P(",\n"),
-          P("    "),K("val "),P("population: "),T("Int"),P(",\n"),
-          P("    "),K("val "),P("country: "),T("String"),P("\n"),
-          P(") : "),T("Entity"),P("<"),T("Int"),P(">\n\n"),
-          K("data class "),T("User"),P("(\n"),
-          P("    "),A("@PK"),P(" "),K("val "),P("id: "),T("Int"),P(" = "),N("0"),P(",\n"),
-          P("    "),K("val "),P("email: "),T("String"),P(",\n"),
-          P("    "),K("val "),P("name: "),T("String"),P(",\n"),
-          P("    "),A("@FK"),P(" "),K("val "),P("city: "),T("City"),P("   "),C("// foreign entities are available in queries and results\n"),
-          P(") : "),T("Entity"),P("<"),T("Int"),P(">") ] },
-
-      { name:'2 · query', file:'UserService.kt',
-        caption:"one-line queries to get all the data you need · no N+1",
-        code:[ C("// A user's city is loaded in the same query.\n"),
-          K("val "),P("user = userRepository."),F("getById"),P("("),N("1"),P(")\n"),
-          K("val "),P("cityName = user.city.name"),P("   "),C('// already loaded: no N+1, no lazy-init\n\n'),
-          C("// Filter across the graph, fully type-safe using the static metamodel.\n"),
-          K("val "),P("users = userRepository."),F("findAll"),P("(User_.city.name "),K("eq "),S('"Sunnyvale"'),P(")") ] },
-
-      { name:'3 · repository', file:'UserRepository.kt',
-        caption:"your own type-safe queries · CRUD inherited",
-        code:[ C("// Custom return types are just records. Define them in-place.\n"),
-          K("data class "),T("CityCount"),P("("),K("val "),P("city: "),T("City"),P(", "),K("val "),P("count: "),T("Long"),P(")\n\n"),
-          C("// Extend EntityRepository: all CRUD comes for free.\n"),
-          K("interface "),T("UserRepository"),P(" : "),T("EntityRepository"),P("<"),T("User"),P(", "),T("Int"),P("> {\n"),
-          P("    "),K("fun "),F("findByCity"),P("(city: "),T("City"),P(") = "),F("findAll"),P("(User_.city "),K("eq "),P("city)\n\n"),
-          P("    "),K("fun "),F("usersPerCity"),P("(country: "),T("String"),P(") =\n"),
-          P("        "),F("select"),P("<"),T("CityCount"),P(", _, _> { "),S('"${City::class}, COUNT(*)"'),P(" }"),P("   "),C("// SQL template\n"),
-          P("            ."),F("where"),P("(User_.city.country "),K("eq "),P("country)\n"),
-          P("            ."),F("groupBy"),P("(User_.city)\n"),
-          P("            .resultList\n"),
-          P("}") ] },
-
-      { name:'4 · transactions', file:'Transactions.kt',
-        caption:"full control with programmatic tx · Spring's declarative tx also supported",
-        code:[ C("// Writes are explicit. One transaction.\n"),
-          F("transaction"),P(" {\n"),
-          P("    "),K("val "),P("city = orm "),K("insert "),T("City"),P("(name = "),S('"Sunnyvale"'),P(", population = "),N("161_884"),P(", country = "),S('"US"'),P(")\n"),
-          P("    orm "),K("insert "),T("User"),P("(email = "),S('"bob@acme.io"'),P(", name = "),S('"Bob"'),P(", city = city)\n"),
-          P("}\n"),
-          P("\n"),
-          C("// Full control when you need it: propagation, isolation, timeout, plus post-tx hooks.\n"),
-          F("transaction"),P("(propagation = "),T("REQUIRES_NEW"),P(", isolation = "),T("REPEATABLE_READ"),P(", timeoutSeconds = "),N("5"),P(") {\n"),
-          P("    "),K("val "),P("city = orm "),K("insert "),T("City"),P("(name = "),S('"San Jose"'),P(", population = "),N("1_013_240"),P(", country = "),S('"US"'),P(")\n"),
-          P("    "),K("val "),P("user = orm "),K("insert "),T("User"),P("(email = "),S('"alice@acme.io"'),P(", name = "),S('"Alice"'),P(", city = city)\n"),
-          P("\n"),
-          P("    "),F("onCommit"),P(" { events."),F("publish"),P("("),T("UserCreated"),P("(user)) }"),P("   "),C("// runs only after successful commit\n"),
-          P("}") ] },
-
-      { name:'5 · sql', file:'UserService.kt',
-        caption:"full SQL when you want it, never locked in",
-        code:[ C("// Full control of SQL, with typed columns and tables; rows map to any data class.\n"),
-          K("data class "),T("RankedCity"),P("("),K("val "),P("name: "),T("String"),P(", "),K("val "),P("rank: "),T("Long"),P(")\n\n"),
-          K("val "),P("ranked = orm."),F("query"),P(" { "),S('"""'),P("\n"),
-          P("    "),K("SELECT "),T("${City_.name}"),P(", RANK() "),K("OVER"),P(" ("),K("ORDER BY "),T("${City_.population}"),P(" "),K("DESC"),P(")\n"),
-          P("    "),K("FROM "),T("${City::class}"),P("\n"),
-          P("    "),K("WHERE "),T("${City_.country}"),P(" = "),T("$country"),P("   "),C("-- typed columns · bound value\n"),
-          S('"""'),P(" }."),F("resultList"),P("<"),T("RankedCity"),P(">()") ] },
-
-      { name:'6 · principles', file:'Core Principles',
-        caption:"the core principles",
-        grid:[
-          { t:"Enjoyable", d:"Write code that's a pleasure to read and maintain." },
-          { t:"Minimalist", d:"Concise entities and one-line queries. No ceremony." },
-          { t:"Modern", d:"Keeps pace with modern language features, e.g. coroutine-aware tx." },
-          { t:"Predictable", d:"All database calls are explicit. No surprises like hidden N+1 queries." },
-          { t:"Type-Safe", d:"Columns and types verified at compile time." },
-          { t:"Secure", d:"Interpolated values become bind variables, preventing SQL injection." },
-          { t:"Immutable", d:"Plain data classes and records, safe to share." },
-          { t:"Stateless", d:"No session, flush, or transaction-bound proxies." },
-          { t:"Portable", d:"Database specifics offered in a portable way, across all major databases." },
-          { t:"Flexible", d:"From a simple DSL to full SQL templates when you need them." },
-          { t:"Fast", d:"Optimized for performance, e.g. generated code instead of reflection." },
-          { t:"Efficient", d:"Low memory footprint, no heavyweight runtime, no external dependencies." },
-        ] },
-    ];
-
-    // Generated SQL per scene (index-aligned with SCENES). Shown via the "Show SQL" toggle.
-    const SQL=[
-      null, // entities: no query, so the Show SQL button is hidden for this scene
-
-      '<span class="sqlc">-- getById(1): joins the city graph, no N+1</span>\n'+
-      '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
-      '<span class="sqlk">FROM</span> "user" u\n'+
-      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
-      '<span class="sqlk">WHERE</span> u.id = <span class="sqlq">?</span>\n\n'+
-      '<span class="sqlc">-- findAll(User_.city.name eq "Sunnyvale")</span>\n'+
-      '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
-      '<span class="sqlk">FROM</span> "user" u\n'+
-      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
-      '<span class="sqlk">WHERE</span> c.name = <span class="sqlq">?</span>',
-
-      '<span class="sqlc">-- findByCity(city)</span>\n'+
-      '<span class="sqlk">SELECT</span> u.id, u.email, u.name, c.id, c.name, c.population, c.country\n'+
-      '<span class="sqlk">FROM</span> "user" u\n'+
-      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
-      '<span class="sqlk">WHERE</span> u.city_id = <span class="sqlq">?</span>\n\n'+
-      '<span class="sqlc">-- usersPerCity(country)</span>\n'+
-      '<span class="sqlk">SELECT</span> c.id, c.name, c.population, c.country, <span class="sqlk">COUNT</span>(*)\n'+
-      '<span class="sqlk">FROM</span> "user" u\n'+
-      '<span class="sqlk">INNER JOIN</span> city c <span class="sqlk">ON</span> u.city_id = c.id\n'+
-      '<span class="sqlk">WHERE</span> c.country = <span class="sqlq">?</span>\n'+
-      '<span class="sqlk">GROUP BY</span> u.city_id',
-
-      '<span class="sqlc">-- the second block wraps these two inserts in one configured transaction:</span>\n'+
-      '<span class="sqlc">-- transaction(REQUIRES_NEW, REPEATABLE_READ, timeoutSeconds = 5)</span>\n'+
-      '<span class="sqlk">SET TRANSACTION ISOLATION LEVEL REPEATABLE READ</span>\n'+
-      '<span class="sqlk">BEGIN</span>\n'+
-      '<span class="sqlk">INSERT INTO</span> city (name, population, country) <span class="sqlk">VALUES</span> (<span class="sqlq">?</span>, <span class="sqlq">?</span>, <span class="sqlq">?</span>)\n'+
-      '<span class="sqlk">INSERT INTO</span> "user" (email, name, city_id) <span class="sqlk">VALUES</span> (<span class="sqlq">?</span>, <span class="sqlq">?</span>, <span class="sqlq">?</span>)\n'+
-      '<span class="sqlk">COMMIT</span>\n'+
-      '<span class="sqlc">-- onCommit hook runs here, only after COMMIT succeeds</span>',
-
-      '<span class="sqlc">-- typed columns resolve to the city alias · $country becomes ?</span>\n'+
-      '<span class="sqlk">SELECT</span> c.name, <span class="sqlk">RANK</span>() <span class="sqlk">OVER</span> (<span class="sqlk">ORDER BY</span> c.population <span class="sqlk">DESC</span>)\n'+
-      '<span class="sqlk">FROM</span> city c\n'+
-      '<span class="sqlk">WHERE</span> c.country = <span class="sqlq">?</span>',
-    ];
-
-    const esc=s=>s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
     const codeEl=document.getElementById('code'), gutEl=document.getElementById('gutter'),
           fnameEl=document.getElementById('fname'), scenesEl=document.getElementById('scenes'),
           statusEl=document.getElementById('status'), statusTextEl=document.getElementById('statustext'),
-          benefitsEl=document.getElementById('benefits'), codeareaEl=document.querySelector('.storm-home .codearea');
+          benefitsEl=document.getElementById('benefits'), codeareaEl=document.getElementById('scene-panel');
     if(!codeEl) return;
 
-    // "Show SQL" toggle: reveals the generated SQL for the current scene.
+    // ---- "Show SQL": reveals the generated SQL for the current scene ----
     const editorEl=document.querySelector('.storm-home .editor'), sqlBtn=document.getElementById('sqlbtn'),
           sqlBtnText=document.getElementById('sqlbtntext'), sqlPanel=document.getElementById('sqlpanel');
     let showSql=false, curIdx=0;
@@ -612,15 +739,14 @@ export default function Home() {
     function onSqlClick(){
       showSql=!showSql;
       editorEl.classList.toggle('show-sql',showSql);
-      sqlBtn.classList.toggle('on',showSql);
+      sqlBtn.setAttribute('aria-expanded',showSql?'true':'false');
       sqlBtnText.textContent=showSql?'Hide SQL':'Show SQL';
       if(showSql) renderSql();
     }
     sqlBtn.addEventListener('click',onSqlClick);
 
-    SCENES.forEach((s,i)=>{const d=document.createElement('span');d.className='s';d.textContent=s.name;
-      d.addEventListener('click',()=>runFrom(i,true));scenesEl.appendChild(d);});
-    const tabs=[...scenesEl.children];
+    // ---- scene tabs ----
+    const tabs=[...scenesEl.querySelectorAll('[role="tab"]')];
 
     const fullText=(t)=>t.map(x=>x.x).join('');
     function render(tokens,n,cursor){
@@ -637,11 +763,13 @@ export default function Home() {
     function setGutter(text){const lines=text.split('\n').length;let g='';for(let i=1;i<=lines;i++)g+='<div>'+i+'</div>';gutEl.innerHTML=g;}
 
     const reduce=window.matchMedia&&window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    // `gen` invalidates an in-flight animation when the visitor picks another
+    // scene (or the page unmounts) mid-type.
     let timer=null, gen=0;
     const wait=(ms)=>new Promise(res=>{const g=gen;timer=setTimeout(()=>{if(g===gen)res();},ms);});
 
-    // Length-independent fast write (~500ms) driven by rAF, so a tab click
-    // fills the snippet in a fixed time regardless of how long it is.
+    // Length-independent write driven by rAF, so a tab click fills the snippet
+    // in a fixed time regardless of how long it is.
     function typeFast(tokens,text,duration){
       return new Promise(resolve=>{
         const g=gen, start=performance.now();
@@ -654,45 +782,51 @@ export default function Home() {
       });
     }
 
-    async function play(idx,fast){
-      const myGen=gen;
+    // Renders one scene and stops there. Nothing schedules a successor: the
+    // editor holds the finished snippet until the visitor opens another tab.
+    async function play(idx,{fast=false, animate=true}={}){
+      const myGen=++gen;
+      clearTimeout(timer);
       const sc=SCENES[idx];
       curIdx=idx;
       const hasSql=!!SQL[idx];
       sqlBtn.style.display=hasSql?'':'none';
-      sqlBtn.classList.toggle('on',showSql);
+      sqlBtn.setAttribute('aria-expanded',hasSql&&showSql?'true':'false');
       sqlBtnText.textContent=showSql?'Hide SQL':'Show SQL';
       editorEl.classList.toggle('show-sql',hasSql&&showSql);
       if(hasSql&&showSql) renderSql();
-      tabs.forEach((t,i)=>t.classList.toggle('on',i===idx));
+      tabs.forEach((t,i)=>{
+        t.setAttribute('aria-selected',i===idx?'true':'false');
+        t.tabIndex=i===idx?0:-1;
+      });
+      codeareaEl.setAttribute('aria-labelledby','stab-'+idx);
       fnameEl.textContent=sc.file;
       statusEl.classList.remove('show');
 
-      // Benefits scene: render the core-benefits grid instead of typed code.
+      // Principles scene: render the grid of tiles instead of typed code.
       if(sc.grid){
         codeareaEl.classList.add('show-benefits');
-        benefitsEl.innerHTML=sc.grid.map(b=>'<div class="bcell"><span class="bt">'+b.t+'</span><span class="bd">'+b.d+'</span></div>').join('');
+        benefitsEl.innerHTML=sc.grid.map(b=>'<div class="bcell"><span class="bt">'+esc(b.t)+'</span><span class="bd">'+esc(b.d)+'</span></div>').join('');
         const cells=[...benefitsEl.children];
-        if(reduce){
+        if(reduce||!animate){
           cells.forEach(c=>c.classList.add('in'));
         } else {
           // Reveal the tiles one by one, top-left to bottom-right (DOM order = row-major).
           for(const cell of cells){
             if(myGen!==gen) return;
             cell.classList.add('in');
-            await wait(fast?70:120);
+            await wait(70);
           }
         }
         if(myGen!==gen) return;
         statusTextEl.textContent=sc.caption;statusEl.classList.add('show');
-        await wait(fast?30000:8000);
         return;
       }
       codeareaEl.classList.remove('show-benefits');
 
       const text=fullText(sc.code);
       setGutter(text);
-      // Rewind the horizontal scroller before typing. Desktop resets it for
+      // Rewind the horizontal scroller before writing. Desktop resets it for
       // free (the near-empty first render collapses scrollWidth, clamping
       // scrollLeft to 0), but iOS Safari keeps the stale offset when content
       // shrinks, so one touch pan (even an accidental diagonal swipe while
@@ -700,7 +834,9 @@ export default function Home() {
       // each line cut off.
       codeEl.scrollLeft=0;
 
-      if(reduce){
+      // Reduced motion (and any non-animated switch) lands on the finished
+      // snippet immediately: complete content, not a slower animation.
+      if(reduce||!animate){
         codeEl.innerHTML=render(sc.code,text.length,false);
         statusTextEl.textContent=sc.caption;statusEl.classList.add('show');
         return;
@@ -709,60 +845,62 @@ export default function Home() {
       if(fast){
         await typeFast(sc.code,text,500);
       } else {
+        // Keystroke rhythm, paced so the snippet is finished and readable in
+        // roughly four seconds. It plays once per visit, so the visitor should
+        // not be waiting on it to find out what the page is showing them.
         for(let n=0;n<=text.length;n++){
           codeEl.innerHTML=render(sc.code,n,true);
           const ch=text[n-1];
-          let d=12+Math.random()*22;
-          if(ch==='\n')d=120; else if(ch===' ')d=8; else if('(){}.,'.includes(ch))d=46;
+          let d=6+Math.random()*10;
+          if(ch==='\n')d=55; else if(ch===' ')d=4; else if('(){}.,'.includes(ch))d=22;
           await wait(d);
         }
       }
       if(myGen!==gen) return;
       codeEl.innerHTML=render(sc.code,text.length,false);
       codeEl.scrollLeft=0; // settle the finished snippet at its line starts
-      await wait(fast?160:360);
+      await wait(360);
       if(myGen!==gen) return;
       statusTextEl.textContent=sc.caption;statusEl.classList.add('show');
-      await wait(fast?30000:4800); // 30s dwell on a clicked scene, else normal auto-advance
     }
 
-    async function runFrom(start,fast){
-      const g=++gen; clearTimeout(timer);
-      let i=start, first=true;
-      while(g===gen){ await play(i, fast&&first); if(g!==gen) return; first=false; i=(i+1)%SCENES.length; }
+    // Roving tabindex: Left/Right (and Home/End) move between tabs and open the
+    // one that lands, which is what the tabs pattern expects.
+    function selectTab(i,{focus=false}={}){
+      play(i,{fast:true});
+      if(focus) tabs[i].focus();
     }
-    runFrom(0);
-
-    // Rotate the hero taglines, one at a time. While a tagline is showing, the
-    // top hero line swaps from "Radically Simple." to "ST/ORM." so the
-    // product name never leaves the screen. The two "ST/ORM." copies hide
-    // at each other's position (.travel/.ko in the CSS), which makes the swap
-    // look like the line physically moving between the hero rows; the distance
-    // and font-size ratio depend on the viewport, so measure them here.
-    const heroTop = document.getElementById('heroTop');
-    // Two taglines share the top line: Radically Simple. and Seriously Fast. alternate
-    // over the static brand line below.
-    let valuesTimer = null;
-    if (heroTop) {
-      const topItems = heroTop.querySelectorAll(':scope > span');
-      let topIndex = 0;
-      const advance = () => {
-        topItems[topIndex].classList.remove('in');
-        topIndex = 1 - topIndex;
-        topItems[topIndex].classList.add('in');
-        valuesTimer = setTimeout(advance, 6000);
+    const tabHandlers = tabs.map((tab, i) => {
+      const onClick = () => selectTab(i);
+      const onKey = (e) => {
+        const last = tabs.length - 1;
+        let next = null;
+        if (e.key === 'ArrowRight') next = i === last ? 0 : i + 1;
+        else if (e.key === 'ArrowLeft') next = i === 0 ? last : i - 1;
+        else if (e.key === 'Home') next = 0;
+        else if (e.key === 'End') next = last;
+        if (next === null) return;
+        e.preventDefault();
+        selectTab(next, {focus: true});
       };
-      valuesTimer = setTimeout(advance, 6000);
-    }
+      tab.addEventListener('click', onClick);
+      tab.addEventListener('keydown', onKey);
+      return [tab, onClick, onKey];
+    });
 
-    // Stop the loop and undo DOM mutations when the page unmounts.
+    // The one automatic animation on the page: the first snippet types itself
+    // once, then the editor rests. Under reduced motion it is simply there.
+    play(0);
+
+    // Stop any in-flight animation and undo DOM mutations when the page unmounts.
     return () => {
       gen++;
       clearTimeout(timer);
-      clearTimeout(valuesTimer);
-      clearInterval(vsAuto);
       vsChipHandlers.forEach(([chip, handler]) => chip.removeEventListener('click', handler));
-      if(scenesEl) scenesEl.innerHTML='';
+      tabHandlers.forEach(([tab, onClick, onKey]) => {
+        tab.removeEventListener('click', onClick);
+        tab.removeEventListener('keydown', onKey);
+      });
       if(sqlBtn) sqlBtn.removeEventListener('click',onSqlClick);
     };
   }, []);
@@ -771,11 +909,9 @@ export default function Home() {
     <>
       <Head>
         <html lang="en" />
-        <title>ST/ORM · The type-safe Kotlin ORM</title>
-        <meta
-          name="description"
-          content="Storm is a type-safe, SQL-first Kotlin ORM. Immutable data-class entities, one-line queries checked at compile time, no proxies, no N+1. Try it in 5 minutes."
-        />
+        <title>{TITLE}</title>
+        <meta name="description" content={DESC} />
+        <link rel="canonical" href="https://orm.st/" />
         <meta
           name="keywords"
           content="Kotlin ORM, type-safe ORM, SQL-first ORM, Kotlin database library, Hibernate alternative, JPA alternative, Exposed alternative, Storm ORM"
@@ -784,22 +920,11 @@ export default function Home() {
             ("Storm Framework") and og:description is absent, so set the
             keyword-rich title + description used when the page is shared. */}
         <meta property="og:type" content="website" />
-        <meta
-          property="og:title"
-          content={'ST/ORM · The type-safe Kotlin ORM'}
-        />
-        <meta
-          property="og:description"
-          content="Storm is a type-safe, SQL-first Kotlin ORM. Immutable data-class entities, one-line queries checked at compile time, no proxies, no N+1. Try it in 5 minutes."
-        />
-        <meta
-          name="twitter:title"
-          content={'ST/ORM · The type-safe Kotlin ORM'}
-        />
-        <meta
-          name="twitter:description"
-          content="Storm is a type-safe, SQL-first Kotlin ORM. Immutable data-class entities, one-line queries checked at compile time, no proxies, no N+1. Try it in 5 minutes."
-        />
+        <meta property="og:url" content="https://orm.st/" />
+        <meta property="og:title" content={TITLE} />
+        <meta property="og:description" content={DESC} />
+        <meta name="twitter:title" content={TITLE} />
+        <meta name="twitter:description" content={DESC} />
         {/* Structured data so search engines can identify Storm as a
             developer tool for Kotlin/Java and consolidate it with its GitHub
             and Maven Central listings (helps knowledge-graph + rich results). */}
@@ -811,6 +936,8 @@ export default function Home() {
             alternateName: ['Storm ORM', 'Storm Kotlin ORM'],
             applicationCategory: 'DeveloperApplication',
             operatingSystem: 'JVM (Kotlin, Java)',
+            softwareVersion: version,
+            license: 'https://www.apache.org/licenses/LICENSE-2.0',
             description:
               'Storm is a type-safe, SQL-first Kotlin ORM. Define concise, immutable data-class entities and write one-line queries. Nested predicates and entity graphs compile to a single efficient query, eliminating accidental hidden N+1 queries. Drop to full SQL templates whenever you want; never locked in.',
             featureList: [
@@ -823,7 +950,7 @@ export default function Home() {
             ],
             url: 'https://orm.st',
             sameAs: [
-              'https://github.com/storm-orm/storm-framework',
+              GH,
               'https://central.sonatype.com/namespace/st.orm',
             ],
             offers: {'@type': 'Offer', price: '0', priceCurrency: 'USD'},
@@ -842,7 +969,7 @@ export default function Home() {
         />
       </Head>
       <style dangerouslySetInnerHTML={{__html: CSS}} />
-      <div className="storm-home" dangerouslySetInnerHTML={{__html: BODY}} />
+      <div className="storm-home" dangerouslySetInnerHTML={{__html: buildBody(version)}} />
     </>
   );
 }

--- a/website/src/pages/quickstart.js
+++ b/website/src/pages/quickstart.js
@@ -9,6 +9,7 @@ import {
   wireSqlToggles,
   KOTLIN_VARIANTS,
   DATABASE_VARIANTS,
+  DISCORD,
   K, T, S, C, F, N, A, P, QK, QQ, QC,
 } from '../components/tutorial/tutorialTheme';
 
@@ -161,7 +162,7 @@ ${navHtml('')}
 
   <div class="cta">
     <a href="/tutorials/build-a-rest-api" class="btn primary">Build a real app →</a>
-    <p class="starline">Five minutes well spent? Give us a <a href="https://github.com/storm-orm/storm-framework" target="_blank" rel="noopener" class="grad star">Star on GitHub</a>.</p>
+    <p class="starline">Something not work, or not make sense? Tell us on <a href="${DISCORD}" target="_blank" rel="noopener" class="grad star">Discord</a>.</p>
   </div>
 </div>
 

--- a/website/versioned_docs/version-1.10.0/index.md
+++ b/website/versioned_docs/version-1.10.0/index.md
@@ -249,4 +249,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.11.0/index.md
+++ b/website/versioned_docs/version-1.11.0/index.md
@@ -253,4 +253,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.11.1/index.md
+++ b/website/versioned_docs/version-1.11.1/index.md
@@ -267,4 +267,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.11.2/index.md
+++ b/website/versioned_docs/version-1.11.2/index.md
@@ -267,4 +267,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.11.3/index.md
+++ b/website/versioned_docs/version-1.11.3/index.md
@@ -267,4 +267,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.11.4/index.md
+++ b/website/versioned_docs/version-1.11.4/index.md
@@ -267,4 +267,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.11.5/index.md
+++ b/website/versioned_docs/version-1.11.5/index.md
@@ -259,4 +259,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.11.6/index.md
+++ b/website/versioned_docs/version-1.11.6/index.md
@@ -259,4 +259,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.12.0/index.md
+++ b/website/versioned_docs/version-1.12.0/index.md
@@ -259,4 +259,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.12.1/index.md
+++ b/website/versioned_docs/version-1.12.1/index.md
@@ -259,4 +259,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.13.0/index.md
+++ b/website/versioned_docs/version-1.13.0/index.md
@@ -257,4 +257,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.13.1/index.md
+++ b/website/versioned_docs/version-1.13.1/index.md
@@ -244,4 +244,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.9.0/index.md
+++ b/website/versioned_docs/version-1.9.0/index.md
@@ -244,4 +244,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).

--- a/website/versioned_docs/version-1.9.1/index.md
+++ b/website/versioned_docs/version-1.9.1/index.md
@@ -244,4 +244,4 @@ New to Storm's terminology? See the [Glossary](glossary.md) for definitions of k
 
 ## License
 
-Storm is released under the [Apache 2.0 License](https://github.com/storm-repo/storm-framework/blob/main/LICENSE).
+Storm is released under the [Apache 2.0 License](https://github.com/storm-orm/storm-framework/blob/main/LICENSE.txt).


### PR DESCRIPTION
Keeps the dark visual system, the code-first landing page, the quickstart's Show SQL interaction, the fair comparison language and the benchmark methodology. What changes is how much of the page moves, whether a technical lead can answer "can we adopt this", and how many places a newcomer can start from.

## Less competing motion

Four automatic animations ran above the fold at once: a swapping headline, a typing code demo, a rotating benchmark comparison, and background detail. None of them could be read to completion. There is now one: the editor types its first snippet once, in about three seconds, and stops.

The headline is static and states the whole proposition. The benchmark comparison changes only on a click, from a stable default. Nothing loops.

This also retires a bug. Under `prefers-reduced-motion` the scene renderer returned immediately while its caller kept advancing, so scenes flipped as fast as the runtime allowed: reduced motion produced *more* motion than the default. Reduced mode now renders finished content and holds it.

## A production-evaluation section

The repetitive closing section is replaced by one that answers whether Storm can be adopted: current release (read from the existing version source rather than duplicated), license, runtime, databases, integrations, where to ask, and the sources behind each claim. No star count, no testimonials.

## One way in

`/quickstart`, an embedded quick start in the documentation index, and a Get Started page that read as a second quickstart were three starting points for the same journey. `/quickstart` is now the canonical five-minute route, named identically everywhere and listed first in the documentation navigation. The index leads with a short Start Here table, drops the duplicated install snippets, and puts the AI-assisted section after the install-model-query path instead of interrupting it. Get Started becomes Set Up Your Project: prerequisites, the four setup routes, and how to verify the wiring. All existing routes still resolve.

Six published pages were reachable only by a lucky inbound link: `installation`, `first-entity`, `first-query`, `glossary`, `error-handling` and `string-templates`. They are in the sidebar now.

The prerequisites tables stated the JDK 21 pin for the Java path without saying why or for how long, which reads as Java being a lesser path. Both now note that the pin belongs to the platform, that it lifts when the JDK ships a stable successor to String Templates, and that only `storm-java21` is affected.

## Two broken links, both user-visible

**The Apache 2.0 link 404'd on every documentation version.** The file is `LICENSE.txt`, not `LICENSE`, and the released snapshots still carried the former `storm-repo` owner. Fixed in all fifteen files as a URL-only change, one line each. The snapshots are otherwise frozen, but `/docs/` serves the latest one, which is where the broken link was actually visible.

**Every "Edit this page" link on the released docs pointed at a path that does not exist.** The string `editUrl` appends to the docs plugin's `path`, producing `docs/versioned_docs/version-X/<file>` — so GitHub offered to create a new file rather than edit the existing one. A function form maps each version to its real source. The "GitHub" navigation target also went to the organization's repository list rather than this repository.

## Search and a link checker

Documentation search is built from the docs at build time and shipped as a static index: it works offline and sends nothing to a third party. No hosted service, no API key.

`npm run check-links` walks the emitted HTML rather than the route table. `onBrokenLinks: 'throw'` only sees links Docusaurus routed itself, and the landing page, quickstart, comparison, benchmarks, tutorials and blog are all rendered from raw HTML strings — which is why both link breaks above survived. `check-links:external` also probes external URLs.

## Accessibility and responsive fixes found while verifying

- The scene selector was a row of `<span>`s with click handlers, so no keyboard could reach it. It is a tablist now, with roving tabindex and arrow-key navigation; Show SQL is a button with `aria-expanded`.
- The mobile menu checkbox was `display:none`, which took the only control that opens the menu out of the tab order.
- The keyboard-highlighted search result was white on indigo at **2.98:1**. Code comments, benchmark deltas, chart hints and breadcrumbs were also under 4.5:1.
- The benchmarks page scrolled horizontally at 390px, and the six-column comparison matrix was clipped by the card's rounded overflow instead of scrolling.

## Verification

Production build, `tsc --noEmit`, and the `llms-full` drift guard all pass. Link check: **859 pages, 0 broken internal links, 111/111 external URLs reachable.** Rendered at 390px, tablet and 1280px across `/`, `/quickstart`, `/comparison`, `/benchmarks`, `/docs/` and `/docs/getting-started`: no horizontal overflow, no console errors, correct tab order and visible focus, in both motion modes. Metadata and canonicals verified on all six.

## Notes for the reviewer

- The documentation changes land in `docs/`, so they appear at `/docs/next` and reach `/docs/` at the next release, which re-snapshots them. The two link repairs are the deliberate exception, since the break was visible on the released snapshots.
- No `MAINTAINERS.md`, `GOVERNANCE.md` or `CODEOWNERS` exists, so the evaluation section carries no maintainer, governance or support-guarantee content.
- `check-links` is not wired into CI. Adding it to `website-pr.yml` after the build step is a two-line change; the external variant is network-dependent and is better kept manual.
