### PR TITLE
docs: released snapshots state their own version, and Gradle leads the install snippets

### DIFF
--- a/docs/dialects.md
+++ b/docs/dialects.md
@@ -21,6 +21,56 @@ Storm works with any JDBC-compatible database using standard SQL. However, datab
 
 Add the dialect dependency for your database. Dialects are runtime-only dependencies: they do not affect your compile-time code or entity definitions. Your entity classes, repositories, and queries are written against Storm's core API, not against any specific dialect. This means you can switch databases by changing a single dependency without modifying application code.
 
+### Gradle (Kotlin DSL)
+
+```kotlin
+// Oracle
+runtimeOnly("st.orm:storm-oracle:@@STORM_VERSION@@")
+
+// MS SQL Server
+runtimeOnly("st.orm:storm-mssqlserver:@@STORM_VERSION@@")
+
+// PostgreSQL
+runtimeOnly("st.orm:storm-postgresql:@@STORM_VERSION@@")
+
+// MySQL
+runtimeOnly("st.orm:storm-mysql:@@STORM_VERSION@@")
+
+// MariaDB
+runtimeOnly("st.orm:storm-mariadb:@@STORM_VERSION@@")
+
+// SQLite
+runtimeOnly("st.orm:storm-sqlite:@@STORM_VERSION@@")
+
+// H2
+runtimeOnly("st.orm:storm-h2:@@STORM_VERSION@@")
+```
+
+### Gradle (Groovy DSL)
+
+```groovy
+// Oracle
+runtimeOnly 'st.orm:storm-oracle:@@STORM_VERSION@@'
+
+// MS SQL Server
+runtimeOnly 'st.orm:storm-mssqlserver:@@STORM_VERSION@@'
+
+// PostgreSQL
+runtimeOnly 'st.orm:storm-postgresql:@@STORM_VERSION@@'
+
+// MySQL
+runtimeOnly 'st.orm:storm-mysql:@@STORM_VERSION@@'
+
+// MariaDB
+runtimeOnly 'st.orm:storm-mariadb:@@STORM_VERSION@@'
+
+// SQLite
+runtimeOnly 'st.orm:storm-sqlite:@@STORM_VERSION@@'
+
+// H2
+runtimeOnly 'st.orm:storm-h2:@@STORM_VERSION@@'
+```
+
 ### Maven
 
 ```xml
@@ -79,56 +129,6 @@ Add the dialect dependency for your database. Dialects are runtime-only dependen
     <version>@@STORM_VERSION@@</version>
     <scope>runtime</scope>
 </dependency>
-```
-
-### Gradle (Groovy DSL)
-
-```groovy
-// Oracle
-runtimeOnly 'st.orm:storm-oracle:@@STORM_VERSION@@'
-
-// MS SQL Server
-runtimeOnly 'st.orm:storm-mssqlserver:@@STORM_VERSION@@'
-
-// PostgreSQL
-runtimeOnly 'st.orm:storm-postgresql:@@STORM_VERSION@@'
-
-// MySQL
-runtimeOnly 'st.orm:storm-mysql:@@STORM_VERSION@@'
-
-// MariaDB
-runtimeOnly 'st.orm:storm-mariadb:@@STORM_VERSION@@'
-
-// SQLite
-runtimeOnly 'st.orm:storm-sqlite:@@STORM_VERSION@@'
-
-// H2
-runtimeOnly 'st.orm:storm-h2:@@STORM_VERSION@@'
-```
-
-### Gradle (Kotlin DSL)
-
-```kotlin
-// Oracle
-runtimeOnly("st.orm:storm-oracle:@@STORM_VERSION@@")
-
-// MS SQL Server
-runtimeOnly("st.orm:storm-mssqlserver:@@STORM_VERSION@@")
-
-// PostgreSQL
-runtimeOnly("st.orm:storm-postgresql:@@STORM_VERSION@@")
-
-// MySQL
-runtimeOnly("st.orm:storm-mysql:@@STORM_VERSION@@")
-
-// MariaDB
-runtimeOnly("st.orm:storm-mariadb:@@STORM_VERSION@@")
-
-// SQLite
-runtimeOnly("st.orm:storm-sqlite:@@STORM_VERSION@@")
-
-// H2
-runtimeOnly("st.orm:storm-h2:@@STORM_VERSION@@")
 ```
 
 ## Automatic Detection

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,6 +113,14 @@ dependencies {
 </TabItem>
 <TabItem value="java" label="Java">
 
+**Gradle (Kotlin DSL):**
+
+```kotlin
+dependencies {
+    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
+}
+```
+
 **Maven:**
 
 ```xml
@@ -127,14 +135,6 @@ dependencies {
         </dependency>
     </dependencies>
 </dependencyManagement>
-```
-
-**Gradle (Kotlin DSL):**
-
-```kotlin
-dependencies {
-    implementation(platform("st.orm:storm-bom:@@STORM_VERSION@@"))
-}
 ```
 
 </TabItem>

--- a/docs/json.md
+++ b/docs/json.md
@@ -15,7 +15,13 @@ Works with both Kotlin and Java projects. Two variants are available, matching t
 
 **Jackson 2** (requires Jackson 2.17+):
 
+```groovy
+// Gradle (Groovy DSL)
+implementation 'st.orm:storm-jackson2:@@STORM_VERSION@@'
+```
+
 ```xml
+<!-- Maven -->
 <dependency>
     <groupId>st.orm</groupId>
     <artifactId>storm-jackson2</artifactId>
@@ -23,13 +29,15 @@ Works with both Kotlin and Java projects. Two variants are available, matching t
 </dependency>
 ```
 
-```groovy
-implementation 'st.orm:storm-jackson2:@@STORM_VERSION@@'
-```
-
 **Jackson 3** (requires Jackson 3.0+):
 
+```groovy
+// Gradle (Groovy DSL)
+implementation 'st.orm:storm-jackson3:@@STORM_VERSION@@'
+```
+
 ```xml
+<!-- Maven -->
 <dependency>
     <groupId>st.orm</groupId>
     <artifactId>storm-jackson3</artifactId>
@@ -37,11 +45,7 @@ implementation 'st.orm:storm-jackson2:@@STORM_VERSION@@'
 </dependency>
 ```
 
-```groovy
-implementation 'st.orm:storm-jackson3:@@STORM_VERSION@@'
-```
-
-The two modules are mutually exclusive on the classpath, one of the four paired-module choices listed in [One Per Classpath](installation.md#one-per-classpath). Both provide the same public API (`st.orm.jackson` package), so switching between them requires only changing the Maven dependency.
+The two modules are mutually exclusive on the classpath, one of the four paired-module choices listed in [One Per Classpath](installation.md#one-per-classpath). Both provide the same public API (`st.orm.jackson` package), so switching between them requires only changing the dependency.
 
 ### Kotlinx Serialization (Kotlin)
 

--- a/docs/spring-integration.md
+++ b/docs/spring-integration.md
@@ -33,6 +33,11 @@ implementation("st.orm:storm-kotlin-spring-boot-starter:@@STORM_VERSION@@")
 </TabItem>
 <TabItem value="java" label="Java">
 
+```kotlin
+// Gradle (Kotlin DSL)
+implementation("st.orm:storm-spring-boot-starter:@@STORM_VERSION@@")
+```
+
 ```xml
 <!-- Maven -->
 <dependency>
@@ -40,11 +45,6 @@ implementation("st.orm:storm-kotlin-spring-boot-starter:@@STORM_VERSION@@")
     <artifactId>storm-spring-boot-starter</artifactId>
     <version>@@STORM_VERSION@@</version>
 </dependency>
-```
-
-```kotlin
-// Gradle (Kotlin DSL)
-implementation("st.orm:storm-spring-boot-starter:@@STORM_VERSION@@")
 ```
 
 </TabItem>
@@ -74,6 +74,11 @@ implementation("st.orm:storm-kotlin-spring:@@STORM_VERSION@@")
 </TabItem>
 <TabItem value="java" label="Java">
 
+```kotlin
+// Gradle (Kotlin DSL)
+implementation("st.orm:storm-spring:@@STORM_VERSION@@")
+```
+
 ```xml
 <!-- Maven -->
 <dependency>
@@ -81,11 +86,6 @@ implementation("st.orm:storm-kotlin-spring:@@STORM_VERSION@@")
     <artifactId>storm-spring</artifactId>
     <version>@@STORM_VERSION@@</version>
 </dependency>
-```
-
-```kotlin
-// Gradle (Kotlin DSL)
-implementation("st.orm:storm-spring:@@STORM_VERSION@@")
 ```
 
 </TabItem>

--- a/docs/string-templates.md
+++ b/docs/string-templates.md
@@ -222,7 +222,16 @@ Only `storm-java21` depends on this preview feature. The core framework and the 
 Enable preview features in your Java compiler configuration:
 
 <Tabs groupId="build">
-<TabItem value="maven" label="Maven" default>
+<TabItem value="gradle" label="Gradle (Kotlin DSL)" default>
+
+```kotlin
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("--enable-preview")
+}
+```
+
+</TabItem>
+<TabItem value="maven" label="Maven">
 
 ```xml
 <plugin>
@@ -234,15 +243,6 @@ Enable preview features in your Java compiler configuration:
         </compilerArgs>
     </configuration>
 </plugin>
-```
-
-</TabItem>
-<TabItem value="gradle" label="Gradle (Kotlin DSL)">
-
-```kotlin
-tasks.withType<JavaCompile> {
-    options.compilerArgs.add("--enable-preview")
-}
 ```
 
 </TabItem>

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,6 +18,12 @@ Spring Boot applications additionally have the [`@DataStormTest` slice](spring-i
 
 Add `storm-test` as a test dependency.
 
+**Gradle (Kotlin DSL):**
+
+```kotlin
+testImplementation("st.orm:storm-test")
+```
+
 **Maven:**
 
 ```xml
@@ -26,12 +32,6 @@ Add `storm-test` as a test dependency.
     <artifactId>storm-test</artifactId>
     <scope>test</scope>
 </dependency>
-```
-
-**Gradle (Kotlin DSL):**
-
-```kotlin
-testImplementation("st.orm:storm-test")
 ```
 
 The module uses H2 as its default in-memory database. To use H2, add it as a test dependency if it is not already present:

--- a/website/plugins/remark-storm-version.js
+++ b/website/plugins/remark-storm-version.js
@@ -1,7 +1,23 @@
 /**
- * Remark plugin that replaces @@STORM_VERSION@@ placeholders in markdown
- * with the actual Storm version.
+ * Remark plugin that replaces @@STORM_VERSION@@ placeholders in markdown with
+ * the Storm version the page documents.
+ *
+ * A released snapshot states its own version: a reader on /docs/1.12.1 gets
+ * install snippets for 1.12.1, matching the banner above them, instead of
+ * coordinates for whatever release happens to be current. The version is read
+ * from the snapshot's directory name (versioned_docs/version-<version>), which
+ * `docusaurus docs:version` names after the release it captures.
+ *
+ * The current docs (docs/, served at /docs and /docs/next) have no version of
+ * their own and fall back to the resolved release version, so their snippets
+ * stay installable rather than pointing at an unpublished revision.
  */
+
+// Snapshot directories are named after the release, e.g. version-1.13.1. Only
+// a version-shaped name is usable as a coordinate; anything else (a named
+// branch of the docs, say) falls back rather than producing an artifact
+// version that was never published.
+const SNAPSHOT_DIR = /\/versioned_docs\/version-(\d+\.\d+\.\d+[^/]*)\//;
 
 function visitNode(node, replacer) {
   if (node.type === 'text' || node.type === 'code' || node.type === 'inlineCode') {
@@ -16,10 +32,17 @@ function visitNode(node, replacer) {
   }
 }
 
+function versionFor(file, fallback) {
+  const filePath = file?.path ?? file?.history?.[file.history.length - 1] ?? '';
+  // Windows separators, so the snapshot is recognized on every platform.
+  const match = String(filePath).replaceAll('\\', '/').match(SNAPSHOT_DIR);
+  return match ? match[1] : fallback;
+}
+
 const plugin = (options) => {
   const version = options?.version || '0.0.0';
-  return (tree) => {
-    visitNode(tree, version);
+  return (tree, file) => {
+    visitNode(tree, versionFor(file, version));
   };
 };
 

--- a/website/src/pages/tutorials/auditing.js
+++ b/website/src/pages/tutorials/auditing.js
@@ -37,7 +37,7 @@ const CODE_REGISTER = [
   C('// Registration is explicit and immutable: a new template, callback applied\n'),
   K('val '), P('orm = dataSource.orm.'), F('withEntityCallback'), P('('), T('AuditCallback'), P('())\n\n'),
   C('// From here, every insert and update flows through the hooks\n'),
-  K('val '), P('article = orm '), K('insert '), T('Article'), P('(title = '), S('"Storm 1.11"'), P(')\n'),
+  K('val '), P('article = orm '), K('insert '), T('Article'), P('(title = '), S('"Immutable entities"'), P(')\n'),
   C('// article.createdAt and updatedAt are set'),
 ].join('');
 


### PR DESCRIPTION
Started as an audit of version references on orm.st. Every user-facing surface already resolved to 1.13.1 (homepage, quickstart, `/docs/*`, `/docs/next`, `llms.txt`, the skills files, and the Javadoc header), so this fixes the two places that did not, and applies the Gradle-first ordering to the docs.

## Archived snapshots stated the wrong version

`@@STORM_VERSION@@` resolved to one version for the whole build, so every released snapshot rendered coordinates for the current release. `/docs/1.12.1/installation` carried a "no longer actively maintained" banner directly above `platform("st.orm:storm-bom:1.13.1")`. All snapshots from 1.11.1 onward did this.

`remark-storm-version` now reads the version from the snapshot directory (`versioned_docs/version-<version>`), which `docusaurus docs:version` names after the release it captures. Only a version-shaped directory name is used as a coordinate; anything else falls back. The current docs have no version of their own and keep the resolved release version, so `/docs/next` snippets stay installable.

Verified against a cleared build:

| Route | Before | After |
|---|---|---|
| `/docs/installation` (latest) | 1.13.1 | 1.13.1 |
| `/docs/next/installation` | 1.13.1 | 1.13.1 |
| `/docs/1.13.0/installation` | 1.13.1 | 1.13.0 |
| `/docs/1.12.1/installation` | 1.13.1 | 1.12.1 |
| `/docs/1.11.1/installation` | 1.13.1 | 1.11.1 |
| `/docs/1.11.0/installation` | 1.11.0 | 1.11.0 |

## Gradle leads the build snippets

Six pages put Maven first: `dialects` (opening section), `json` and `spring-integration` (first of a code-block pair), `testing` (labelled pair), `installation` (Java tab of the BOM section), and `string-templates` (default tab for the preview flags). The `json` dependency pairs were unlabelled, so they now carry the `// Gradle` and `<!-- Maven -->` comments the other pages use.

`README.md`, `llms.txt`, and the skills files were already Gradle-first and are unchanged.

## Sample data

The auditing tutorial inserted an article titled "Storm 1.11", which read as a stale version reference on a page that has nothing to do with versioning.

## Notes

- The docs changes are in `docs/` only, so they appear at `/docs/next` until the next release cuts a snapshot. The plugin change takes effect on every version immediately.
- The 1.9.0 and 1.9.1 snapshots predate the placeholder and hardcode `1.10.0` as literals, so the plugin cannot reach them. Every artifact they reference was published at 1.9.x, so correcting them is mechanical, but it means editing frozen snapshot files and is left out here.
- Several dependency snippets are Maven-only (`api-java`, the dialect list in `error-handling`, H2 and `storm-kotlin-test` in `testing`). Adding Gradle equivalents is new content rather than reordering, so it is not in this PR.
- `json` uses the Groovy DSL while the rest of the docs use the Kotlin DSL. Left as is.

Local verification: `npm run build` from a cleared cache, and `npm run check-links` (859 pages, 111 external URLs, no broken links).