### PR TITLE
test: cover the API defaults, block DSL and Spring wiring that no test reached

### DIFF
--- a/storm-core/src/test/java/st/orm/core/SqlLogIntegrationTest.java
+++ b/storm-core/src/test/java/st/orm/core/SqlLogIntegrationTest.java
@@ -4,12 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static st.orm.Operator.EQUALS;
 import static st.orm.Operator.IN;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -33,6 +35,7 @@ import st.orm.core.template.JpaTemplate;
 import st.orm.core.template.ORMTemplate;
 import st.orm.core.template.SqlLog;
 import st.orm.core.template.StatementOrigin;
+import st.orm.core.template.impl.SqlInterceptorManager;
 import st.orm.core.template.impl.SqlLogRenderer;
 
 /**
@@ -98,6 +101,37 @@ public class SqlLogIntegrationTest {
         var summary = summaries.getFirst();
         assertEquals(1, summary.statementCount());
         assertEquals(0, summary.count(StatementOrigin.FETCH));
+    }
+
+    @Test
+    public void testACheckedExceptionPropagatesFromRecordThrowingAndIsStillSummarized() {
+        var orm = ORMTemplate.of(dataSource);
+        List<SqlLog.Summary> summaries = new ArrayList<>();
+        var thrown = assertThrows(IOException.class,
+                () -> SqlLog.recordThrowing("checked", () -> {
+                    orm.entity(City.class).getById(1);
+                    throw new IOException("disk full");
+                }, summaries::add));
+        assertEquals("disk full", thrown.getMessage());
+        // The default limit applies: the one statement executed before the failure is recorded, not merely counted.
+        assertEquals(1, summaries.getFirst().statementCount());
+        assertEquals(1, summaries.getFirst().statements().size());
+    }
+
+    @Test
+    public void testARecorderInstalledAsListenerObservesTheStatementsWithinItsLimit() {
+        var orm = ORMTemplate.of(dataSource);
+        // The recorder is the building block behind record and open: installed as a listener it counts every
+        // statement and keeps up to its limit; a summary built from it reports both figures.
+        var recorder = SqlLog.recorder(1);
+        SqlInterceptorManager.listen(recorder).run(() -> {
+            orm.entity(City.class).getById(1);
+            orm.entity(City.class).getById(2);
+        });
+        var summary = SqlLog.summary("recorded", recorder, 42L);
+        assertEquals("recorded", summary.name());
+        assertEquals(2, summary.statementCount());
+        assertEquals(1, summary.statements().size(), summary.statements().toString());
     }
 
     @Test

--- a/storm-foundation/src/test/java/st/orm/AbstractNavigableMetamodelTest.java
+++ b/storm-foundation/src/test/java/st/orm/AbstractNavigableMetamodelTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the navigation-only metamodel node that generated metamodels use past a {@code Ref} boundary: it locates a
+ * column through root, table and path exactly as a full metamodel does, and compares equal to the full metamodel of
+ * the same field, without offering value extraction.
+ */
+class AbstractNavigableMetamodelTest {
+
+    record Owner(int id, Address address) implements Data {}
+    record Address(String street, City city) implements Data {}
+    record City(int id, String name) implements Data {}
+
+    /** A navigable node; the base class needs no override, so a plain subclass stands in for a generated one. */
+    static class Node<E> extends AbstractNavigableMetamodel<Owner, E> {
+        Node(Class<E> fieldType, String path, String field, boolean inline, Navigable<Owner, ?> parent) {
+            super(fieldType, path, field, inline, parent);
+        }
+    }
+
+    /** The full metamodel of the same field, the counterpart a navigable node must compare equal to. */
+    static class FullMetamodel<E> extends AbstractMetamodel<Owner, E, E> {
+        FullMetamodel(Class<E> fieldType, String path, String field, boolean inline, Metamodel<Owner, ?> parent) {
+            super(fieldType, path, field, inline, parent);
+        }
+
+        @Override
+        public E getValue(Owner record) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isIdentical(Owner a, Owner b) {
+            return a == b;
+        }
+
+        @Override
+        public boolean isSame(Owner a, Owner b) {
+            return a.equals(b);
+        }
+    }
+
+    private final Node<Owner> owner = new Node<>(Owner.class, "", "", false, null);
+    private final Node<Address> address = new Node<>(Address.class, "", "address", true, owner);
+    private final Node<City> city = new Node<>(City.class, "address", "city", false, address);
+    private final Node<String> cityName = new Node<>(String.class, "address.city", "name", false, city);
+
+    @Test
+    void rootIsTheRootOfTheChainAndTheFieldTypeOfARootNode() {
+        assertEquals(Owner.class, owner.root());
+        assertEquals(Owner.class, cityName.root());
+        assertEquals(Owner.class, owner.fieldType());
+        assertEquals(String.class, cityName.fieldType());
+    }
+
+    @Test
+    void tableIsTheNodeItselfForARootAndTheNearestNonInlineParentOtherwise() {
+        assertSame(owner, owner.table());
+        // The inline address record contributes no table of its own, so its columns belong to the owner table.
+        assertSame(owner, address.table());
+        assertSame(owner, city.table());
+        assertSame(city, cityName.table());
+        assertEquals(City.class, cityName.tableType());
+    }
+
+    @Test
+    void inlineAndColumnFollowTheConstructorArguments() {
+        assertTrue(address.isInline());
+        assertFalse(address.isColumn(), "an inline component is not a column");
+        assertFalse(owner.isColumn(), "a root node names no field and is not a column");
+        assertFalse(city.isInline());
+        assertTrue(city.isColumn());
+        assertEquals("address.city.name", cityName.fieldPath());
+    }
+
+    @Test
+    void equalsAndHashCodeFollowTableTypePathAndField() {
+        Node<String> sameField = new Node<>(String.class, "address.city", "name", false, city);
+        assertEquals(cityName, cityName);
+        assertEquals(cityName, sameField);
+        assertEquals(cityName.hashCode(), sameField.hashCode());
+        assertEquals(cityName.hashCode(), cityName.hashCode(), "the hash is cached and stable");
+        assertNotEquals(cityName, new Node<>(Integer.class, "address.city", "id", false, city));
+        assertNotEquals(cityName, new Node<>(String.class, "city", "name", false, city));
+        assertNotEquals(cityName, "address.city.name");
+    }
+
+    @Test
+    void equalsAFullMetamodelOfTheSameField() {
+        // The full metamodel of owner.address.city.name reaches the same field through the same path, so a
+        // predicate built on either finds the same column. Equality is checked from the navigable side: a full
+        // metamodel only recognizes other full metamodels.
+        FullMetamodel<Owner> ownerMetamodel = new FullMetamodel<>(Owner.class, "", "", false, null);
+        FullMetamodel<Address> addressMetamodel = new FullMetamodel<>(Address.class, "", "address", true, ownerMetamodel);
+        FullMetamodel<City> cityMetamodel = new FullMetamodel<>(City.class, "address", "city", false, addressMetamodel);
+        FullMetamodel<String> cityNameMetamodel =
+                new FullMetamodel<>(String.class, "address.city", "name", false, cityMetamodel);
+        assertEquals(cityName, cityNameMetamodel);
+        assertEquals(cityName.hashCode(), cityNameMetamodel.hashCode());
+    }
+
+    @Test
+    void toStringNamesRootTypePathAndField() {
+        assertEquals("Navigable{root=Owner, type=String, path='address.city', field='name'}", cityName.toString());
+    }
+}

--- a/storm-java21/pom.xml
+++ b/storm-java21/pom.xml
@@ -68,6 +68,9 @@
                         --add-opens storm.java/st.orm.template.impl=ALL-UNNAMED
                         --add-opens storm.java/st.orm.template.model=ALL-UNNAMED
                         --add-opens storm.java/st.orm.template.model=storm.core
+                        <!-- Tests are patched into storm.java, which requires nothing of the logging backend;
+                             asserting on what a logger emitted reads the backend directly. -->
+                        --add-reads storm.java=org.slf4j,ch.qos.logback.classic,ch.qos.logback.core
                         -Dstorm.ansi_escaping=true
                     </argLine>
                 </configuration>

--- a/storm-java21/src/test/java/st/orm/template/RepositoryTest.java
+++ b/storm-java21/src/test/java/st/orm/template/RepositoryTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
@@ -17,6 +18,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.NoResultException;
+import st.orm.NonUniqueResultException;
 import st.orm.Page;
 import st.orm.Pageable;
 import st.orm.Ref;
@@ -24,12 +27,14 @@ import st.orm.Scrollable;
 import st.orm.Window;
 import st.orm.repository.EntityRepository;
 import st.orm.repository.ProjectionRepository;
+import st.orm.template.model.Address;
 import st.orm.template.model.City;
 import st.orm.template.model.City_;
 import st.orm.template.model.Owner;
 import st.orm.template.model.OwnerView;
 import st.orm.template.model.OwnerView_;
 import st.orm.template.model.Pet;
+import st.orm.template.model.PetType;
 import st.orm.template.model.Pet_;
 import st.orm.template.model.Visit;
 
@@ -920,5 +925,219 @@ public class RepositoryTest {
         assertFalse(views.isEmpty());
         assertTrue(views.stream().allMatch(view -> view.firstName().equals("George")));
         assertTrue(ownerViews.existsBy(OwnerView_.firstName, "George"));
+    }
+
+    // Field-based finder methods matching a referenced value (the Ref overloads on EntityRepository).
+
+    @Test
+    public void testFindByRefValue() {
+        // Owner 1 has exactly one pet (Leo), so the single-result finder resolves; owner 3 has two, so the same
+        // finder reports the ambiguity instead of picking one.
+        var pets = orm.entity(Pet.class);
+        Optional<Pet> pet = pets.findBy(Pet_.owner, Ref.of(Owner.class, 1));
+        assertTrue(pet.isPresent());
+        assertEquals("Leo", pet.get().name());
+        assertTrue(pets.findBy(Pet_.owner, Ref.of(Owner.class, 999)).isEmpty());
+        assertThrows(NonUniqueResultException.class, () -> pets.findBy(Pet_.owner, Ref.of(Owner.class, 3)));
+    }
+
+    @Test
+    public void testGetByRefValue() {
+        var pets = orm.entity(Pet.class);
+        Pet pet = pets.getBy(Pet_.owner, Ref.of(Owner.class, 1));
+        assertEquals("Leo", pet.name());
+        assertThrows(NoResultException.class, () -> pets.getBy(Pet_.owner, Ref.of(Owner.class, 999)));
+    }
+
+    @Test
+    public void testFindRefByRefValue() {
+        var pets = orm.entity(Pet.class);
+        Optional<Ref<Pet>> ref = pets.findRefBy(Pet_.owner, Ref.of(Owner.class, 1));
+        assertTrue(ref.isPresent());
+        assertEquals("Leo", ref.get().fetch().name());
+        assertTrue(pets.findRefBy(Pet_.owner, Ref.of(Owner.class, 999)).isEmpty());
+    }
+
+    @Test
+    public void testGetRefByRefValue() {
+        var pets = orm.entity(Pet.class);
+        Ref<Pet> ref = pets.getRefBy(Pet_.owner, Ref.of(Owner.class, 1));
+        assertEquals("Leo", ref.fetch().name());
+        assertThrows(NoResultException.class, () -> pets.getRefBy(Pet_.owner, Ref.of(Owner.class, 999)));
+    }
+
+    @Test
+    public void testFindAllRefByFieldMultipleValues() {
+        var cities = orm.entity(City.class);
+        List<Ref<City>> refs = cities.findAllRefBy(City_.name, List.of("Madison", "Monona"));
+        assertEquals(2, refs.size());
+        assertTrue(refs.stream().map(Ref::fetch).map(City::name).toList().containsAll(List.of("Madison", "Monona")));
+        assertTrue(cities.findAllRefBy(City_.name, List.of()).isEmpty());
+    }
+
+    @Test
+    public void testFindAllRefByRefField() {
+        // Owners 1 and 6 own one and two pets: three refs, and only refs to those pets.
+        var pets = orm.entity(Pet.class);
+        List<Ref<Pet>> refs = pets.findAllRefByRef(Pet_.owner, List.of(Ref.of(Owner.class, 1), Ref.of(Owner.class, 6)));
+        assertEquals(3, refs.size());
+        assertTrue(refs.stream().map(Ref::fetch).allMatch(pet -> List.of(1, 6).contains(pet.owner().id())));
+    }
+
+    @Test
+    public void testExistsByRefValue() {
+        var pets = orm.entity(Pet.class);
+        assertTrue(pets.existsBy(Pet_.owner, Ref.of(Owner.class, 1)));
+        assertFalse(pets.existsBy(Pet_.owner, Ref.of(Owner.class, 999)));
+    }
+
+    @Test
+    public void testRemoveAllByRefValue() {
+        var pets = orm.entity(Pet.class);
+        var owners = orm.entity(Owner.class);
+        City city = orm.entity(City.class).getById(1);
+        Owner owner = owners.insertAndFetch(new Owner(null, "Removable", "Owner", new Address("1 Main St.", city), null, 0));
+        // Pet type 1, not 0: an identity-generated key of 0 is the value Storm reads as "not yet persisted", so a
+        // reference to it is rejected before it reaches the database.
+        PetType petType = orm.entity(PetType.class).getById(1);
+        pets.insert(new Pet(null, "Removable", LocalDate.of(2024, 1, 1), petType, owner));
+        pets.insert(new Pet(null, "Removable Too", LocalDate.of(2024, 1, 2), petType, owner));
+        int removed = pets.removeAllBy(Pet_.owner, Ref.of(Owner.class, owner.id()));
+        assertEquals(2, removed);
+        assertFalse(pets.existsBy(Pet_.owner, Ref.of(Owner.class, owner.id())));
+        // Nothing left to remove; the count reports that rather than failing.
+        assertEquals(0, pets.removeAllBy(Pet_.owner, Ref.of(Owner.class, owner.id())));
+    }
+
+    @Test
+    public void testRemoveAllByFieldMultipleValues() {
+        var cities = orm.entity(City.class);
+        cities.insert(new City(null, "RemoveMultiA"));
+        cities.insert(new City(null, "RemoveMultiB"));
+        int removed = cities.removeAllBy(City_.name, List.of("RemoveMultiA", "RemoveMultiB", "RemoveMultiMissing"));
+        assertEquals(2, removed);
+        assertFalse(cities.existsBy(City_.name, "RemoveMultiA"));
+        assertFalse(cities.existsBy(City_.name, "RemoveMultiB"));
+    }
+
+    @Test
+    public void testRemoveAllByRefField() {
+        var pets = orm.entity(Pet.class);
+        var owners = orm.entity(Owner.class);
+        City city = orm.entity(City.class).getById(1);
+        PetType petType = orm.entity(PetType.class).getById(1);
+        Owner first = owners.insertAndFetch(new Owner(null, "First", "Removable", new Address("1 Main St.", city), null, 0));
+        Owner second = owners.insertAndFetch(new Owner(null, "Second", "Removable", new Address("2 Main St.", city), null, 0));
+        pets.insert(new Pet(null, "Of First", LocalDate.of(2024, 1, 1), petType, first));
+        pets.insert(new Pet(null, "Of Second", LocalDate.of(2024, 1, 2), petType, second));
+        int removed = pets.removeAllByRef(Pet_.owner, List.of(Ref.of(Owner.class, first.id()), Ref.of(Owner.class, second.id())));
+        assertEquals(2, removed);
+        assertFalse(pets.existsBy(Pet_.owner, Ref.of(Owner.class, first.id())));
+        assertFalse(pets.existsBy(Pet_.owner, Ref.of(Owner.class, second.id())));
+    }
+
+    // Field-based finder methods on ProjectionRepository; the owner view's address carries the city reference.
+
+    @Test
+    public void testProjectionFindByField() {
+        var ownerViews = orm.projection(OwnerView.class);
+        Optional<OwnerView> view = ownerViews.findBy(OwnerView_.lastName, "Franklin");
+        assertTrue(view.isPresent());
+        assertEquals("George", view.get().firstName());
+        assertTrue(ownerViews.findBy(OwnerView_.lastName, "Nobody").isEmpty());
+        // Two owners share the last name Davis; a single-result finder must not pick one silently.
+        assertThrows(NonUniqueResultException.class, () -> ownerViews.findBy(OwnerView_.lastName, "Davis"));
+    }
+
+    @Test
+    public void testProjectionFindByRefValue() {
+        // Sun Prairie (city 1) hosts owner 1 only; Madison (city 2) hosts four owners.
+        var ownerViews = orm.projection(OwnerView.class);
+        Optional<OwnerView> view = ownerViews.findBy(OwnerView_.address.city, Ref.of(City.class, 1));
+        assertTrue(view.isPresent());
+        assertEquals(1, view.get().id());
+        assertTrue(ownerViews.findBy(OwnerView_.address.city, Ref.of(City.class, 999)).isEmpty());
+        assertThrows(NonUniqueResultException.class,
+                () -> ownerViews.findBy(OwnerView_.address.city, Ref.of(City.class, 2)));
+    }
+
+    @Test
+    public void testProjectionGetByField() {
+        var ownerViews = orm.projection(OwnerView.class);
+        assertEquals("George", ownerViews.getBy(OwnerView_.lastName, "Franklin").firstName());
+        assertThrows(NoResultException.class, () -> ownerViews.getBy(OwnerView_.lastName, "Nobody"));
+        assertEquals(1, ownerViews.getBy(OwnerView_.address.city, Ref.of(City.class, 1)).id());
+        assertThrows(NoResultException.class, () -> ownerViews.getBy(OwnerView_.address.city, Ref.of(City.class, 999)));
+    }
+
+    @Test
+    public void testProjectionFindAllByRefValue() {
+        var ownerViews = orm.projection(OwnerView.class);
+        List<OwnerView> inMadison = ownerViews.findAllBy(OwnerView_.address.city, Ref.of(City.class, 2));
+        assertEquals(4, inMadison.size());
+        assertTrue(inMadison.stream().allMatch(view -> view.address().city().id() == 2));
+        assertTrue(ownerViews.findAllBy(OwnerView_.address.city, Ref.of(City.class, 999)).isEmpty());
+    }
+
+    @Test
+    public void testProjectionFindAllByFieldMultipleValues() {
+        var ownerViews = orm.projection(OwnerView.class);
+        List<OwnerView> views = ownerViews.findAllBy(OwnerView_.lastName, List.of("Franklin", "Davis"));
+        assertEquals(3, views.size());
+        assertTrue(ownerViews.findAllBy(OwnerView_.lastName, List.of()).isEmpty());
+    }
+
+    @Test
+    public void testProjectionFindAllByRefField() {
+        // Cities 1 and 6 host one owner each.
+        var ownerViews = orm.projection(OwnerView.class);
+        List<OwnerView> views = ownerViews.findAllByRef(OwnerView_.address.city,
+                List.of(Ref.of(City.class, 1), Ref.of(City.class, 6)));
+        assertEquals(2, views.size());
+        assertTrue(views.stream().allMatch(view -> List.of(1, 6).contains(view.address().city().id())));
+    }
+
+    @Test
+    public void testProjectionFindRefByField() {
+        var ownerViews = orm.projection(OwnerView.class);
+        Optional<Ref<OwnerView>> ref = ownerViews.findRefBy(OwnerView_.lastName, "Franklin");
+        assertTrue(ref.isPresent());
+        assertEquals("George", ref.get().fetch().firstName());
+        assertTrue(ownerViews.findRefBy(OwnerView_.lastName, "Nobody").isEmpty());
+        Optional<Ref<OwnerView>> byCity = ownerViews.findRefBy(OwnerView_.address.city, Ref.of(City.class, 1));
+        assertTrue(byCity.isPresent());
+        assertEquals(1, byCity.get().fetch().id());
+    }
+
+    @Test
+    public void testProjectionGetRefByField() {
+        var ownerViews = orm.projection(OwnerView.class);
+        assertEquals("George", ownerViews.getRefBy(OwnerView_.lastName, "Franklin").fetch().firstName());
+        assertThrows(NoResultException.class, () -> ownerViews.getRefBy(OwnerView_.lastName, "Nobody"));
+        assertEquals(1, ownerViews.getRefBy(OwnerView_.address.city, Ref.of(City.class, 1)).fetch().id());
+        assertThrows(NoResultException.class,
+                () -> ownerViews.getRefBy(OwnerView_.address.city, Ref.of(City.class, 999)));
+    }
+
+    @Test
+    public void testProjectionFindAllRefByField() {
+        var ownerViews = orm.projection(OwnerView.class);
+        assertEquals(2, ownerViews.findAllRefBy(OwnerView_.lastName, "Davis").size());
+        assertEquals(4, ownerViews.findAllRefBy(OwnerView_.address.city, Ref.of(City.class, 2)).size());
+        List<Ref<OwnerView>> byNames = ownerViews.findAllRefBy(OwnerView_.lastName, List.of("Franklin", "Davis"));
+        assertEquals(3, byNames.size());
+        List<Ref<OwnerView>> byCities = ownerViews.findAllRefByRef(OwnerView_.address.city,
+                List.of(Ref.of(City.class, 1), Ref.of(City.class, 6)));
+        assertEquals(2, byCities.size());
+        assertTrue(byCities.stream().map(Ref::fetch).allMatch(view -> List.of(1, 6).contains(view.address().city().id())));
+    }
+
+    @Test
+    public void testProjectionCountAndExistsByRefValue() {
+        var ownerViews = orm.projection(OwnerView.class);
+        assertEquals(4, ownerViews.countBy(OwnerView_.address.city, Ref.of(City.class, 2)));
+        assertEquals(0, ownerViews.countBy(OwnerView_.address.city, Ref.of(City.class, 999)));
+        assertTrue(ownerViews.existsBy(OwnerView_.address.city, Ref.of(City.class, 2)));
+        assertFalse(ownerViews.existsBy(OwnerView_.address.city, Ref.of(City.class, 999)));
     }
 }

--- a/storm-java21/src/test/java/st/orm/template/SqlLogTest.java
+++ b/storm-java21/src/test/java/st/orm/template/SqlLogTest.java
@@ -1,0 +1,127 @@
+package st.orm.template;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import st.orm.template.model.City;
+
+/**
+ * Verifies the Java {@link SqlLog} facade: a scope opened around a call reports its summary under the
+ * {@code st.orm.sql.perf} logger when it closes, and records nothing when that logger is disabled, so a scope left
+ * in production code costs nothing until the logger is raised.
+ */
+@SuppressWarnings("ALL")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IntegrationConfig.class)
+@SpringBootTest
+@Sql("/data.sql")
+public class SqlLogTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private ORMTemplate orm;
+
+    private ListAppender<ILoggingEvent> capture(Level level, Runnable action) {
+        var logger = (Logger) LoggerFactory.getLogger("st.orm.sql.perf");
+        var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        logger.addAppender(appender);
+        var previous = logger.getLevel();
+        logger.setLevel(level);
+        try {
+            action.run();
+        } finally {
+            logger.setLevel(previous);
+            logger.detachAppender(appender);
+        }
+        return appender;
+    }
+
+    @Test
+    public void testAScopeReportsItsSummaryWhenClosed() {
+        var appender = capture(Level.INFO, () -> {
+            try (var scope = SqlLog.open("cities")) {
+                orm.entity(City.class).getById(1);
+                orm.entity(City.class).getById(2);
+            }
+        });
+        assertEquals(1, appender.list.size(), appender.list.toString());
+        String message = appender.list.getFirst().getFormattedMessage();
+        assertTrue(message.startsWith("SQL (cities):"), message);
+        assertTrue(message.contains("2 statement"), message);
+    }
+
+    @Test
+    public void testAScopeWithALimitStillCountsEveryStatement() {
+        var appender = capture(Level.INFO, () -> {
+            try (var scope = SqlLog.open("limited", 1)) {
+                orm.entity(City.class).getById(1);
+                orm.entity(City.class).getById(2);
+                orm.entity(City.class).getById(3);
+            }
+        });
+        String message = appender.list.getFirst().getFormattedMessage();
+        assertTrue(message.startsWith("SQL (limited):"), message);
+        assertTrue(message.contains("3 statement"), message);
+    }
+
+    @Test
+    public void testAScopeRecordingCallSitesAttributesTheStatementsAtTrace() {
+        // Call sites and statement texts only show in the detailed rendering, which the logger prints at TRACE.
+        var appender = capture(Level.TRACE, () -> {
+            try (var scope = SqlLog.open("sited", 100, true)) {
+                orm.entity(City.class).getById(1);
+            }
+        });
+        String message = appender.list.getFirst().getFormattedMessage();
+        assertTrue(message.startsWith("SQL (sited):"), message);
+        assertTrue(message.contains("SELECT c.id, c.name"), message);
+        // The frame is whatever called into Storm, here JUnit's reflective invoker rather than this method, so the
+        // assertion is that a frame was attributed at all: file and line, which only the stack walk can supply.
+        assertTrue(message.matches("(?s).*\\w+\\.java:\\d+.*"), message);
+    }
+
+    @Test
+    public void testAScopeWithoutCallSitesRecordsTheStatementsWithoutAFrame() {
+        var appender = capture(Level.TRACE, () -> {
+            try (var scope = SqlLog.open("unsited", 100)) {
+                orm.entity(City.class).getById(1);
+            }
+        });
+        String message = appender.list.getFirst().getFormattedMessage();
+        assertTrue(message.contains("SELECT c.id, c.name"), message);
+        assertFalse(message.matches("(?s).*\\w+\\.java:\\d+.*"), message);
+    }
+
+    @Test
+    public void testAScopeRecordsNothingWhileTheLoggerIsDisabled() {
+        var appender = capture(Level.OFF, () -> {
+            try (var scope = SqlLog.open("silent")) {
+                orm.entity(City.class).getById(1);
+            }
+            try (var scope = SqlLog.open("silent", 1)) {
+                orm.entity(City.class).getById(1);
+            }
+            try (var scope = SqlLog.open("silent", 1, true)) {
+                orm.entity(City.class).getById(1);
+            }
+        });
+        assertTrue(appender.list.isEmpty(), appender.list.toString());
+    }
+}

--- a/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/QueryBuilderTest.kt
@@ -2641,4 +2641,16 @@ internal open class QueryBuilderTest(
         assertThrows<NoResultException> { none.singleResult }
         none.optionalResult shouldBe null
     }
+
+    // isTrue / isFalse predicates
+
+    @Test
+    fun `isTrue and isFalse should match boolean columns and skip nulls`() {
+        // data.sql: rollout is enabled, legacy is disabled, undecided leaves the column null. Neither predicate
+        // matches the null row, which is what separates them from comparing the column to a value.
+        val flags = orm.entity(FeatureFlag::class)
+        val enabledPath = metamodel<FeatureFlag, Boolean>(flags.model, "enabled")
+        flags.select().where(enabledPath.isTrue()).resultList.map { it.name } shouldBe listOf("rollout")
+        flags.select().where(enabledPath.isFalse()).resultList.map { it.name } shouldBe listOf("legacy")
+    }
 }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/QueryDefaultsTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/QueryDefaultsTest.kt
@@ -1,0 +1,137 @@
+package st.orm.template
+
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import st.orm.Data
+import st.orm.Entity
+import st.orm.NoResultException
+import st.orm.NonUniqueResultException
+import st.orm.PK
+import st.orm.PersistenceException
+import st.orm.Ref
+import st.orm.template.model.City
+import java.util.stream.Stream
+import kotlin.reflect.KClass
+
+/**
+ * Verifies the contract the [Query] interface provides on top of its abstract stream members: the single, optional,
+ * count, list and ref-list operations derive from the streams, close them, and report a missing, ambiguous or SQL
+ * NULL single row through the typed exceptions. The module's own [Query] implementation overrides these members, so
+ * an implementation that supplies streams only, as this test's does, is what exercises the defaults.
+ */
+internal class QueryDefaultsTest {
+
+    private data class Town(@PK val id: Int, val name: String) : Entity<Int>
+
+    /**
+     * A [Query] over in-memory rows: the first column doubles as the typed result and as the ref key. Every stream
+     * records its close, so the test can hold the defaults to closing what they open.
+     */
+    private class RowsQuery(private val rows: List<Array<Any?>>) : Query {
+        val closedStreams = mutableListOf<String>()
+
+        override fun prepare(): PreparedQuery = throw UnsupportedOperationException()
+
+        override fun unsafe(): Query = this
+
+        @Suppress("UNCHECKED_CAST")
+        override val resultStream: Stream<Array<Any>>
+            get() = (rows.stream() as Stream<Array<Any>>).onClose { closedStreams += "rows" }
+
+        override fun <T : Any> getResultStream(type: KClass<T>): Stream<T> = rows.stream().map { row -> row[0]?.let { type.java.cast(it) } }.onClose { closedStreams += "typed" }
+
+        override fun <T : Data> getRefStream(type: KClass<T>, pkType: KClass<*>): Stream<Ref<T>> = rows.stream().map { row -> Ref.of(type.java, row[0]!!) }.onClose { closedStreams += "refs" }
+
+        override val versionAware: Boolean = false
+
+        override fun executeUpdate(): Int = 0
+
+        override fun executeBatch(): IntArray = IntArray(0)
+    }
+
+    private fun rows(vararg cells: Any?): List<Array<Any?>> = cells.map { arrayOf(it) }
+
+    @Test
+    fun `singleResult returns the only row and closes the stream`() {
+        val query = RowsQuery(rows("Madison"))
+        query.singleResult[0] shouldBe "Madison"
+        query.getSingleResult(String::class) shouldBe "Madison"
+        query.singleResult<String>() shouldBe "Madison"
+        query.closedStreams shouldBe listOf("rows", "typed", "typed")
+    }
+
+    @Test
+    fun `singleResult rejects no row and more than one row`() {
+        assertThrows<NoResultException> { RowsQuery(emptyList()).singleResult }
+        assertThrows<NoResultException> { RowsQuery(emptyList()).getSingleResult(String::class) }
+        assertThrows<NonUniqueResultException> { RowsQuery(rows("Madison", "Monona")).singleResult }
+        assertThrows<NonUniqueResultException> { RowsQuery(rows("Madison", "Monona")).getSingleResult(String::class) }
+    }
+
+    @Test
+    fun `singleResult reports a SQL NULL value with the COALESCE hint`() {
+        val exception = assertThrows<PersistenceException> { RowsQuery(rows(null)).getSingleResult(String::class) }
+        exception.message!! shouldContain "COALESCE"
+    }
+
+    @Test
+    fun `optionalResult returns the only row or null and closes the stream`() {
+        RowsQuery(rows("Madison")).optionalResult!![0] shouldBe "Madison"
+        RowsQuery(rows("Madison")).getOptionalResult(String::class) shouldBe "Madison"
+        RowsQuery(rows("Madison")).optionalResult<String>() shouldBe "Madison"
+        val empty = RowsQuery(emptyList())
+        empty.optionalResult shouldBe null
+        empty.getOptionalResult(String::class) shouldBe null
+        empty.closedStreams shouldBe listOf("rows", "typed")
+    }
+
+    @Test
+    fun `optionalResult rejects more than one row and a SQL NULL value`() {
+        assertThrows<NonUniqueResultException> { RowsQuery(rows("Madison", "Monona")).optionalResult }
+        assertThrows<NonUniqueResultException> { RowsQuery(rows("Madison", "Monona")).getOptionalResult(String::class) }
+        val exception = assertThrows<PersistenceException> { RowsQuery(rows(null)).getOptionalResult(String::class) }
+        exception.message!! shouldContain "COALESCE"
+    }
+
+    @Test
+    fun `resultCount counts the rows and closes the stream`() {
+        val query = RowsQuery(rows("Madison", "Monona", "Windsor"))
+        query.resultCount shouldBe 3L
+        query.closedStreams shouldBe listOf("rows")
+    }
+
+    @Test
+    fun `resultList collects the rows in both forms and closes the streams`() {
+        val query = RowsQuery(rows("Madison", "Monona"))
+        query.resultList.map { it[0] } shouldBe listOf("Madison", "Monona")
+        query.getResultList(String::class) shouldBe listOf("Madison", "Monona")
+        query.resultList<String>() shouldBe listOf("Madison", "Monona")
+        query.closedStreams shouldBe listOf("rows", "typed", "typed")
+    }
+
+    @Test
+    fun `refList collects the refs and closes the stream`() {
+        val query = RowsQuery(rows(1, 2))
+        val refs = query.getRefList(Town::class, Int::class)
+        refs shouldBe listOf(Ref.of(Town::class.java, 1), Ref.of(Town::class.java, 2))
+        refs.all { !it.isLoaded }.shouldBeTrue()
+        query.closedStreams shouldBe listOf("refs")
+    }
+
+    @Test
+    fun `typed streams and flows derive from the abstract stream member`(): Unit = runBlocking {
+        val query = RowsQuery(rows(City(id = 1, name = "Sun Prairie")))
+        query.resultStream<City>().use { stream -> stream.toList().single().id shouldBe 1 }
+        query.resultFlow<City>().toList().single().name shouldBe "Sun Prairie"
+        query.getResultFlow(City::class).toList().single().name shouldBe "Sun Prairie"
+        query.resultFlow.toList().single()[0] shouldBe City(id = 1, name = "Sun Prairie")
+        // The ref flow maps the key column: a query over towns 1 and 2 yields their refs.
+        RowsQuery(rows(1, 2)).getRefFlow(Town::class, Int::class).toList() shouldBe
+            listOf(Ref.of(Town::class.java, 1), Ref.of(Town::class.java, 2))
+    }
+}

--- a/storm-kotlin/src/test/kotlin/st/orm/template/RefsAndKeysTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/RefsAndKeysTest.kt
@@ -208,4 +208,43 @@ internal open class RefsAndKeysTest(
         owners shouldHaveSize 1
         owners[0].firstName shouldBe "Eduardo"
     }
+
+    // Ref predicates: the top-level eq/neq/inRefs/notInRefs forms and the record-list where.
+
+    @Test
+    fun `eq with Ref should filter entities by foreign key reference`() {
+        // data.sql: city 1 has one owner (Betty), the other nine live elsewhere.
+        val repo = orm.entity(Owner::class)
+        val cityPath = metamodel<Owner, City>(repo.model, "city_id")
+        val cityRef: Ref<City> = Ref.of(City::class.java, 1)
+        val inCity = repo.select().where(cityPath eq cityRef).resultList
+        inCity.map { it.firstName } shouldBe listOf("Betty")
+        val elsewhere = repo.select().where(cityPath neq cityRef).resultList
+        elsewhere shouldHaveSize 9
+        elsewhere.none { it.firstName == "Betty" } shouldBe true
+    }
+
+    @Test
+    fun `inRefs and notInRefs should partition entities by foreign key references`() {
+        // data.sql: city 1 has one owner and city 2 has four; the other five owners live in cities 3 to 6.
+        val repo = orm.entity(Owner::class)
+        val cityPath = metamodel<Owner, City>(repo.model, "city_id")
+        val cityRefs = listOf(Ref.of(City::class.java, 1), Ref.of(City::class.java, 2))
+        val inCities = repo.select().where(cityPath inRefs cityRefs).resultList
+        inCities shouldHaveSize 5
+        val outsideCities = repo.select().where(cityPath notInRefs cityRefs).resultList
+        outsideCities shouldHaveSize 5
+        (inCities.map { it.id } + outsideCities.map { it.id }).toSet() shouldBe repo.findAll().map { it.id }.toSet()
+    }
+
+    @Test
+    fun `where with path and records should match the records by their keys`() {
+        // The records identify rows by key; the names carried along play no part in the match.
+        val repo = orm.entity(Owner::class)
+        val cityPath = metamodel<Owner, City>(repo.model, "city_id")
+        val owners = repo.select()
+            .where(cityPath, listOf(City(id = 1, name = "unused"), City(id = 2, name = "unused")))
+            .resultList
+        owners shouldHaveSize 5
+    }
 }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/SqlDslTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/SqlDslTest.kt
@@ -381,4 +381,229 @@ internal open class SqlDslTest(
         cities shouldHaveSize 6
         cities[0].name shouldBe "Windsor"
     }
+
+    // Clause vocabulary parity with the chained builder (#397): the WHERE forms.
+
+    @Test
+    fun `select entity with where record in the block`() {
+        val cities = orm.entity(City::class).select {
+            where(City(id = 3, name = "McFarland"))
+        }.resultList
+        cities.map { it.id } shouldBe listOf(3)
+    }
+
+    @Test
+    fun `select entity with where ref in the block`() {
+        val ref: Ref<City> = Ref.of(City::class.java, 3)
+        val cities = orm.entity(City::class).select {
+            where(ref)
+        }.resultList
+        cities.map { it.id } shouldBe listOf(3)
+    }
+
+    @Test
+    fun `select entities with where path operator and values in the block`() {
+        val namePath = metamodel<City, String>(orm.model(City::class), "name")
+        val cities = orm.entity(City::class).select {
+            where(namePath, IN, "Madison", "Monona")
+            orderBy(namePath)
+        }.resultList
+        cities.map { it.name } shouldBe listOf("Madison", "Monona")
+    }
+
+    @Test
+    fun `select entities with where path and record in the block`() {
+        // The record identifies the row by its key. data.sql: city 2 (Madison) has four owners.
+        val cityPath = metamodel<Owner, City>(orm.model(Owner::class), "city_id")
+        val owners = orm.entity(Owner::class).select {
+            where(cityPath, City(id = 2, name = "Madison"))
+        }.resultList
+        owners shouldHaveSize 4
+    }
+
+    @Test
+    fun `select entities with where path and ref in the block`() {
+        val cityPath = metamodel<Owner, City>(orm.model(Owner::class), "city_id")
+        val owners = orm.entity(Owner::class).select {
+            where(cityPath, Ref.of(City::class.java, 2))
+        }.resultList
+        owners shouldHaveSize 4
+    }
+
+    @Test
+    fun `select entities with where template in the block`() {
+        val cities = orm.entity(City::class).select {
+            where { "${t(Templates.alias(City::class))}.id > ${t(4)}" }
+        }.resultList
+        cities.map { it.id }.toSet() shouldBe setOf(5, 6)
+    }
+
+    @Test
+    fun `select entities with whereBuilder in the block`() {
+        val namePath = metamodel<City, String>(orm.model(City::class), "name")
+        val cities = orm.entity(City::class).select {
+            whereBuilder { (namePath eq "Madison") or (namePath eq "Monona") }
+            orderBy(namePath)
+        }.resultList
+        cities.map { it.name } shouldBe listOf("Madison", "Monona")
+    }
+
+    @Test
+    fun `select entities with whereExists in the block matches the chained form`() {
+        // Both forms of the block clause, the subquery argument and the lambda, produce the chained builder's rows.
+        val chained = orm.entity(Owner::class).select().whereExists { subquery(Pet::class) }.resultList
+        val viaSubquery = orm.entity(Owner::class).select {
+            whereExists(orm.subquery(Pet::class))
+        }.resultList
+        val viaLambda = orm.entity(Owner::class).select {
+            whereExists { subquery(Pet::class) }
+        }.resultList
+        chained shouldHaveSize 10
+        viaSubquery shouldBe chained
+        viaLambda shouldBe chained
+    }
+
+    @Test
+    fun `select entities with whereNotExists in the block matches the chained form`() {
+        // data.sql: every city has an owner, so no city survives NOT EXISTS.
+        val chained = orm.entity(City::class).select().whereNotExists { subquery(Owner::class) }.resultList
+        val viaSubquery = orm.entity(City::class).select {
+            whereNotExists(orm.subquery(Owner::class))
+        }.resultList
+        val viaLambda = orm.entity(City::class).select {
+            whereNotExists { subquery(Owner::class) }
+        }.resultList
+        chained shouldHaveSize 0
+        viaSubquery shouldBe chained
+        viaLambda shouldBe chained
+    }
+
+    // Clause vocabulary parity with the chained builder (#397): the join forms.
+
+    @Test
+    fun `select entities with class joins in the block`() {
+        // data.sql: 12 of 13 pets have an owner; a left join keeps the thirteenth.
+        orm.entity<Pet>().select { innerJoin(Owner::class, Pet::class) }.resultList shouldHaveSize 12
+        orm.entity<Pet>().select { leftJoin(Owner::class, Pet::class) }.resultList shouldHaveSize 13
+        // Every owner has a pet, so the right join yields the twelve owned pets.
+        orm.entity<Pet>().select { rightJoin(Owner::class, Pet::class) }.resultList shouldHaveSize 12
+        orm.entity<Pet>().select { rightJoin<Owner, Pet>() }.resultList shouldHaveSize 12
+    }
+
+    @Test
+    fun `select entities with class joins and template ON in the block`() {
+        // City ids are 1-6, pet type ids are 0-5: five ids match; a left join keeps all six cities.
+        val cityAlias = Templates.alias(City::class)
+        val petTypeAlias = Templates.alias(PetType::class)
+        orm.entity(City::class).select {
+            innerJoin(PetType::class) { "${t(petTypeAlias)}.id = ${t(cityAlias)}.id" }
+        }.resultCount shouldBe 5L
+        orm.entity(City::class).select {
+            leftJoin<PetType> { "${t(petTypeAlias)}.id = ${t(cityAlias)}.id" }
+        }.resultCount shouldBe 6L
+        orm.entity(City::class).select {
+            leftJoin(PetType::class) { "${t(petTypeAlias)}.id = ${t(cityAlias)}.id" }
+        }.resultCount shouldBe 6L
+        // A right join keeps every pet type, the six of them, whether or not a city id matches. City and PetType
+        // are unrelated, so each alias resolves to one table; a join onto an entity the root already references
+        // needs the path that pins it instead.
+        orm.entity(City::class).select {
+            rightJoin<PetType> { "${t(petTypeAlias)}.id = ${t(cityAlias)}.id" }
+        }.resultCount shouldBe 6L
+        orm.entity(City::class).select {
+            rightJoin(PetType::class) { "${t(petTypeAlias)}.id = ${t(cityAlias)}.id" }
+        }.resultCount shouldBe 6L
+    }
+
+    @Test
+    fun `select entities with class cross join in the block`() {
+        // 6 cities times 6 cities is 36 rows, in the reified and the KClass form alike.
+        orm.entity(City::class).select { crossJoin<City>() }.resultCount shouldBe 36L
+        orm.entity(City::class).select { crossJoin(City::class) }.resultCount shouldBe 36L
+    }
+
+    // Clause vocabulary parity with the chained builder (#397): grouping, ordering and the remaining modifiers.
+
+    @Test
+    fun `select entities with having path operator and values in the block`() {
+        val idPath = metamodel<City, Int>(orm.model(City::class), "id")
+        val namePath = metamodel<City, String>(orm.model(City::class), "name")
+        val cities = orm.entity(City::class).select {
+            groupBy(idPath, namePath)
+            having(namePath, IN, "Madison", "Monona")
+            orderBy(namePath)
+        }.resultList
+        cities.map { it.name } shouldBe listOf("Madison", "Monona")
+    }
+
+    @Test
+    fun `select entities with template groupBy having and orderBy in the block`() {
+        val cityAlias = Templates.alias(City::class)
+        val cities = orm.entity(City::class).select {
+            groupBy { "${t(cityAlias)}.id, ${t(cityAlias)}.name" }
+            having { "${t(cityAlias)}.id > ${t(4)}" }
+            orderBy { "${t(cityAlias)}.name DESC" }
+        }.resultList
+        cities.map { it.id } shouldBe listOf(6, 5)
+    }
+
+    @Test
+    fun `select entities with havingExists and havingNotExists in the block`() {
+        // The subquery correlates on the grouped city key: every city has an owner, so EXISTS keeps all six groups
+        // and NOT EXISTS keeps none, through the subquery argument and the lambda alike.
+        val idPath = metamodel<City, Int>(orm.model(City::class), "id")
+        val namePath = metamodel<City, String>(orm.model(City::class), "name")
+        orm.entity(City::class).select {
+            groupBy(idPath, namePath)
+            havingExists(orm.subquery(Owner::class))
+        }.resultList shouldHaveSize 6
+        orm.entity(City::class).select {
+            groupBy(idPath, namePath)
+            havingExists { subquery(Owner::class) }
+        }.resultList shouldHaveSize 6
+        orm.entity(City::class).select {
+            groupBy(idPath, namePath)
+            havingNotExists(orm.subquery(Owner::class))
+        }.resultList shouldHaveSize 0
+        orm.entity(City::class).select {
+            groupBy(idPath, namePath)
+            havingNotExists { subquery(Owner::class) }
+        }.resultList shouldHaveSize 0
+    }
+
+    @Test
+    fun `select entities with distinct in the block`() {
+        // Six distinct cities stay six; the modifier reaches the statement.
+        val cities = orm.entity(City::class).select { distinct() }.resultList
+        cities shouldHaveSize 6
+    }
+
+    @Test
+    fun `select entity with forUpdate in the block`() {
+        val city = orm.entity(City::class).select {
+            where(1)
+            forUpdate()
+        }.singleResult
+        city.id shouldBe 1
+    }
+
+    @Test
+    fun `select entity with forShare in the block reaches the statement`() {
+        // H2 rejects FOR SHARE, so the failure proves the modifier is part of the statement, as it does for the
+        // chained builder.
+        org.junit.jupiter.api.assertThrows<st.orm.PersistenceException> {
+            orm.entity(City::class).select {
+                where(1)
+                forShare()
+            }.singleResult
+        }
+    }
+
+    @Test
+    fun `delete entities with unsafe in the block`() {
+        // data.sql inserts 14 visits; a delete without a WHERE clause needs unsafe(), as in the chained builder.
+        val affected = orm.entity(Visit::class).delete { unsafe() }.executeUpdate()
+        affected shouldBe 14
+        orm.entity(Visit::class).count() shouldBe 0
+    }
 }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/TransactionCallbackTest.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/TransactionCallbackTest.kt
@@ -17,6 +17,7 @@ import st.orm.TransactionPropagation.*
 import st.orm.repository.exists
 import st.orm.repository.removeAll
 import st.orm.template.model.Visit
+import java.util.function.Consumer
 
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [IntegrationConfig::class])
@@ -460,5 +461,56 @@ internal open class TransactionCallbackTest(
         transactionBlocking {
             onCommit { events += "commit" }
         }
+    }
+
+    // The language-neutral overloads inside a suspend block, and the suspend onCompletion inside a blocking block.
+
+    @Test
+    fun `Runnable and Consumer callbacks registered in a suspend transaction fire on commit`(): Unit = runBlocking {
+        val events = mutableListOf<String>()
+        transaction {
+            onCommit(Runnable { events += "commit" })
+            onRollback(Runnable { events += "rollback" })
+            onCompletion(Consumer { committed -> events += "completion:$committed" })
+        }
+        events shouldBe listOf("commit", "completion:true")
+    }
+
+    @Test
+    fun `Runnable and Consumer callbacks registered in a suspend transaction fire on rollback`(): Unit = runBlocking {
+        val events = mutableListOf<String>()
+        transaction {
+            onCommit(Runnable { events += "commit" })
+            onRollback(Runnable { events += "rollback" })
+            onCompletion(Consumer { committed -> events += "completion:$committed" })
+            setRollbackOnly()
+        }
+        events shouldBe listOf("rollback", "completion:false")
+    }
+
+    @Test
+    fun `isRollbackOnly reflects setRollbackOnly inside a suspend transaction`(): Unit = runBlocking {
+        val observed = mutableListOf<Boolean>()
+        transaction {
+            observed += isRollbackOnly()
+            setRollbackOnly()
+            observed += isRollbackOnly()
+        }
+        observed shouldBe listOf(false, true)
+    }
+
+    @Test
+    fun `suspend onCompletion reports the outcome of a blocking transaction`(): Unit = runBlocking {
+        var afterCommit: Boolean? = null
+        transactionBlocking {
+            onCompletion { committed -> afterCommit = committed }
+        }
+        afterCommit shouldBe true
+        var afterRollback: Boolean? = null
+        transactionBlocking {
+            onCompletion { committed -> afterRollback = committed }
+            setRollbackOnly()
+        }
+        afterRollback shouldBe false
     }
 }

--- a/storm-kotlin/src/test/kotlin/st/orm/template/model/FeatureFlag.kt
+++ b/storm-kotlin/src/test/kotlin/st/orm/template/model/FeatureFlag.kt
@@ -1,0 +1,10 @@
+package st.orm.template.model
+
+import st.orm.Entity
+import st.orm.PK
+
+internal data class FeatureFlag(
+    @PK val id: Int = 0,
+    val name: String,
+    val enabled: Boolean?,
+) : Entity<Int>

--- a/storm-kotlin/src/test/resources/data.sql
+++ b/storm-kotlin/src/test/resources/data.sql
@@ -198,3 +198,12 @@ INSERT INTO char_disc_animal (dtype, name, indoor) VALUES ('C', 'Whiskers', true
 INSERT INTO char_disc_animal (dtype, name, indoor) VALUES ('C', 'Luna', false);
 INSERT INTO char_disc_animal (dtype, name, weight) VALUES ('D', 'Rex', 30);
 INSERT INTO char_disc_animal (dtype, name, weight) VALUES ('D', 'Max', 15);
+
+-- A plain entity with a nullable boolean column, for the IS TRUE / IS FALSE predicates: neither matches the row
+-- that leaves the column null, which is what distinguishes them from an equality comparison.
+drop table if exists feature_flag CASCADE;
+create table feature_flag (id integer auto_increment, name varchar(255), enabled boolean, primary key (id));
+
+INSERT INTO feature_flag (name, enabled) VALUES ('rollout', true);
+INSERT INTO feature_flag (name, enabled) VALUES ('legacy', false);
+INSERT INTO feature_flag (name, enabled) VALUES ('undecided', null);

--- a/storm-spring-boot-test-autoconfigure/src/test/java/st/orm/spring/boot/test/DataStormTestIncludeFiltersTest.java
+++ b/storm-spring-boot-test-autoconfigure/src/test/java/st/orm/spring/boot/test/DataStormTestIncludeFiltersTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring.boot.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import st.orm.spring.boot.test.domain.UnrelatedService;
+import st.orm.spring.boot.test.domain.VisitRepository;
+
+/**
+ * Verifies that {@code includeFilters} pulls a regular component into the slice that the default filtering keeps
+ * out, while the slice's own beans are unaffected.
+ */
+@DataStormTest(includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UnrelatedService.class))
+class DataStormTestIncludeFiltersTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void anIncludedComponentJoinsTheSlice() {
+        assertThat(applicationContext.getBean(UnrelatedService.class)).isNotNull();
+        assertThat(applicationContext.getBean(VisitRepository.class)).isNotNull();
+    }
+}

--- a/storm-spring-boot-test-autoconfigure/src/test/java/st/orm/spring/boot/test/DataStormTypeExcludeFilterTest.java
+++ b/storm-spring-boot-test-autoconfigure/src/test/java/st/orm/spring/boot/test/DataStormTypeExcludeFilterTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring.boot.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+import org.springframework.core.type.filter.TypeFilter;
+import org.springframework.stereotype.Service;
+import st.orm.spring.boot.test.domain.UnrelatedService;
+import st.orm.spring.boot.test.domain.Visit;
+
+/**
+ * Verifies the slice's type exclusion: regular components stay out unless an include filter names them, an exclude
+ * filter wins over an include filter, {@code useDefaultFilters = false} lets everything in, every filter type the
+ * annotation offers is honored, and two filters built from equal annotations are equal, which is what lets test
+ * classes with the same slice configuration share a context.
+ */
+class DataStormTypeExcludeFilterTest {
+
+    private final MetadataReaderFactory metadataReaderFactory = new SimpleMetadataReaderFactory();
+
+    @DataStormTest
+    static class Defaults {
+    }
+
+    @DataStormTest
+    static class SameDefaults {
+    }
+
+    @DataStormTest(includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UnrelatedService.class))
+    static class IncludesByType {
+    }
+
+    @DataStormTest(
+            includeFilters = @Filter(type = FilterType.ANNOTATION, classes = Service.class),
+            excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UnrelatedService.class))
+    static class ExcludeWinsOverInclude {
+    }
+
+    @DataStormTest(includeFilters = @Filter(type = FilterType.REGEX, pattern = ".*\\.domain\\.Unrelated.*"))
+    static class IncludesByRegex {
+    }
+
+    @DataStormTest(includeFilters = @Filter(type = FilterType.ASPECTJ, pattern = "st.orm.spring.boot.test.domain.*"))
+    static class IncludesByAspectJ {
+    }
+
+    @DataStormTest(includeFilters = @Filter(type = FilterType.CUSTOM, classes = ServicesOnly.class))
+    static class IncludesByCustomFilter {
+    }
+
+    @DataStormTest(useDefaultFilters = false)
+    static class WithoutDefaultFilters {
+    }
+
+    @DataStormTest(includeFilters = @Filter(type = FilterType.REGEX, classes = UnrelatedService.class))
+    static class RegexWithClasses {
+    }
+
+    @DataStormTest(includeFilters = @Filter(type = FilterType.ANNOTATION, pattern = ".*"))
+    static class AnnotationWithPattern {
+    }
+
+    /** A custom filter, instantiated by the slice from the annotation, that admits {@code @Service} classes. */
+    public static class ServicesOnly implements TypeFilter {
+        @Override
+        public boolean match(MetadataReader metadataReader, MetadataReaderFactory metadataReaderFactory) {
+            return metadataReader.getAnnotationMetadata().hasAnnotation(Service.class.getName());
+        }
+    }
+
+    private static DataStormTypeExcludeFilter filterOf(Class<?> annotated) {
+        return new DataStormTypeExcludeFilter(annotated.getAnnotation(DataStormTest.class));
+    }
+
+    private boolean excludes(DataStormTypeExcludeFilter filter, Class<?> candidate) throws IOException {
+        return filter.match(metadataReaderFactory.getMetadataReader(candidate.getName()), metadataReaderFactory);
+    }
+
+    @Test
+    void defaultFilteringKeepsEveryScannedComponentOut() throws IOException {
+        var filter = filterOf(Defaults.class);
+        assertThat(excludes(filter, UnrelatedService.class)).isTrue();
+        assertThat(excludes(filter, Visit.class)).isTrue();
+    }
+
+    @Test
+    void anIncludeFilterAdmitsTheComponentItNames() throws IOException {
+        var filter = filterOf(IncludesByType.class);
+        assertThat(excludes(filter, UnrelatedService.class)).isFalse();
+        assertThat(excludes(filter, Visit.class)).as("components the include filter does not name stay out").isTrue();
+    }
+
+    @Test
+    void anExcludeFilterWinsOverAnIncludeFilter() throws IOException {
+        assertThat(excludes(filterOf(ExcludeWinsOverInclude.class), UnrelatedService.class)).isTrue();
+    }
+
+    @Test
+    void patternAndCustomFilterTypesAreHonored() throws IOException {
+        assertThat(excludes(filterOf(IncludesByRegex.class), UnrelatedService.class)).isFalse();
+        assertThat(excludes(filterOf(IncludesByAspectJ.class), UnrelatedService.class)).isFalse();
+        assertThat(excludes(filterOf(IncludesByCustomFilter.class), UnrelatedService.class)).isFalse();
+        assertThat(excludes(filterOf(IncludesByCustomFilter.class), Visit.class)).isTrue();
+    }
+
+    @Test
+    void withoutDefaultFiltersEverythingIsAdmitted() throws IOException {
+        var filter = filterOf(WithoutDefaultFilters.class);
+        assertThat(excludes(filter, UnrelatedService.class)).isFalse();
+        assertThat(excludes(filter, Visit.class)).isFalse();
+    }
+
+    @Test
+    void aFilterTypeUsedWithTheWrongAttributeFailsAtConstruction() {
+        assertThatThrownBy(() -> filterOf(RegexWithClasses.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("REGEX")
+                .hasMessageContaining("pattern");
+        assertThatThrownBy(() -> filterOf(AnnotationWithPattern.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ANNOTATION")
+                .hasMessageContaining("patterns");
+    }
+
+    @Test
+    void filtersBuiltFromEqualAnnotationsAreEqual() {
+        // Two test classes with the same slice configuration produce equal filters, so the context customizers
+        // that carry them compare equal and the classes share one Spring context.
+        assertThat(filterOf(Defaults.class)).isEqualTo(filterOf(SameDefaults.class));
+        assertThat(filterOf(Defaults.class).hashCode()).isEqualTo(filterOf(SameDefaults.class).hashCode());
+        assertThat(filterOf(Defaults.class)).isNotEqualTo(filterOf(IncludesByType.class));
+        assertThat(filterOf(Defaults.class)).isNotEqualTo(filterOf(WithoutDefaultFilters.class));
+        assertThat(filterOf(Defaults.class)).isNotEqualTo("not a filter");
+    }
+}

--- a/storm-spring/src/test/java/st/orm/spring/SpringExternalTransactionProviderTest.java
+++ b/storm-spring/src/test/java/st/orm/spring/SpringExternalTransactionProviderTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.transaction.interceptor.MatchAlwaysTransactionAttributeSource;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import st.orm.PersistenceException;
+import st.orm.Transaction;
+import st.orm.core.spi.TransactionRunner;
+
+/**
+ * Verifies the handle the external transaction provider hands out for a Spring-managed transaction: it is absent
+ * without one, its callbacks follow the physical transaction's outcome, and its rollback-only state reads and
+ * writes through whichever of Spring's two channels the transaction was driven by (the interceptor's bound status,
+ * or the resource holders a {@code TransactionTemplate} binds).
+ */
+class SpringExternalTransactionProviderTest {
+
+    /** The work a transactional proxy wraps, so the interceptor binds a transaction status for it. */
+    interface Work {
+        void run(Runnable body);
+    }
+
+    private final SpringExternalTransactionProvider provider = new SpringExternalTransactionProvider();
+    private DataSourceTransactionManager transactionManager;
+    private TransactionTemplate transactionTemplate;
+    private Work interceptedWork;
+
+    @BeforeEach
+    void setUp() {
+        DataSource dataSource = DataSourceBuilder.create()
+                .url("jdbc:h2:mem:externaltx;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false")
+                .username("sa")
+                .password("")
+                .driverClassName("org.h2.Driver")
+                .build();
+        transactionManager = new DataSourceTransactionManager(dataSource);
+        transactionTemplate = new TransactionTemplate(transactionManager);
+        // The interceptor is what @Transactional installs; a proxy over a plain object gives the same bound status
+        // without a Spring context.
+        var proxyFactory = new ProxyFactory((Work) Runnable::run);
+        proxyFactory.addAdvice(new TransactionInterceptor(transactionManager, new MatchAlwaysTransactionAttributeSource()));
+        interceptedWork = (Work) proxyFactory.getProxy();
+    }
+
+    private Transaction currentTransaction() {
+        return provider.currentTransaction().orElseThrow();
+    }
+
+    @Test
+    void noHandleWithoutASpringTransaction() {
+        assertTrue(provider.currentTransaction().isEmpty());
+        // The runner asks the same providers, so it sees none either.
+        assertNull(TransactionRunner.externalTransaction());
+    }
+
+    @Test
+    void commitCallbacksFireAfterTheSpringCommitOnly() {
+        List<String> events = new ArrayList<>();
+        transactionTemplate.executeWithoutResult(status -> {
+            Transaction transaction = currentTransaction();
+            transaction.onCommit(() -> events.add("commit"));
+            transaction.onRollback(() -> events.add("rollback"));
+            transaction.onCompletion(committed -> events.add("completed " + committed));
+            assertEquals(List.of(), events, "callbacks must wait for the physical transaction to complete");
+        });
+        assertEquals(List.of("commit", "completed true"), events);
+    }
+
+    @Test
+    void rollbackCallbacksFireAfterTheSpringRollbackOnly() {
+        List<String> events = new ArrayList<>();
+        transactionTemplate.executeWithoutResult(status -> {
+            Transaction transaction = currentTransaction();
+            transaction.onCommit(() -> events.add("commit"));
+            transaction.onRollback(() -> events.add("rollback"));
+            transaction.onCompletion(committed -> events.add("completed " + committed));
+            status.setRollbackOnly();
+        });
+        assertEquals(List.of("rollback", "completed false"), events);
+    }
+
+    @Test
+    void rollbackOnlyReadsAndWritesTheResourcesATransactionTemplateBinds() {
+        transactionTemplate.executeWithoutResult(status -> assertFalse(currentTransaction().isRollbackOnly()));
+        // Without an interceptor status, the handle marks the resource holders the transaction manager reads when
+        // it decides the outcome, so Spring's status sees the mark and the transaction rolls back. Spring reports
+        // that rollback as unexpected because it did not make the mark itself.
+        assertThrows(UnexpectedRollbackException.class, () ->
+                transactionTemplate.executeWithoutResult(status -> {
+                    Transaction transaction = currentTransaction();
+                    transaction.setRollbackOnly();
+                    assertTrue(transaction.isRollbackOnly(), "the handle reads the mark it made");
+                    assertTrue(status.isRollbackOnly(), "the mark must land where Spring reads it");
+                }));
+    }
+
+    @Test
+    void rollbackOnlyReadsAndWritesTheStatusTheInterceptorBinds() {
+        interceptedWork.run(() -> {
+            Transaction transaction = currentTransaction();
+            assertFalse(transaction.isRollbackOnly());
+            transaction.setRollbackOnly();
+            assertTrue(transaction.isRollbackOnly());
+        });
+        // Rolling back through the interceptor completes normally: the mark went onto the interceptor's status,
+        // which is Spring's own channel, so no unexpected rollback is reported.
+        List<String> events = new ArrayList<>();
+        interceptedWork.run(() -> {
+            currentTransaction().onRollback(() -> events.add("rollback"));
+            currentTransaction().setRollbackOnly();
+        });
+        assertEquals(List.of("rollback"), events);
+    }
+
+    @Test
+    void aSynchronizationOnlyTransactionCannotBeMarkedRollbackOnly() {
+        // Synchronization is active but no resource transaction was driven: there is nothing to mark, and the
+        // provider says so rather than pretending the mark took.
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            Transaction transaction = currentTransaction();
+            assertFalse(transaction.isRollbackOnly());
+            PersistenceException exception = assertThrows(PersistenceException.class, transaction::setRollbackOnly);
+            assertTrue(exception.getMessage().contains("holds no resource to mark rollback-only"), exception.getMessage());
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+            TransactionSynchronizationManager.setActualTransactionActive(false);
+        }
+    }
+}

--- a/storm-spring/src/test/java/st/orm/spring/boot/StormSqlLogAutoConfigurationTest.java
+++ b/storm-spring/src/test/java/st/orm/spring/boot/StormSqlLogAutoConfigurationTest.java
@@ -34,8 +34,11 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.scheduling.annotation.Scheduled;
 import st.orm.core.template.ORMTemplate;
 
@@ -199,6 +202,26 @@ public class StormSqlLogAutoConfigurationTest {
                     assertFalse(context.containsBean("stormSqlLogEntryPointPostProcessor"));
                     assertFalse(AopUtils.isAopProxy(context.getBean(ReportJob.class)));
                 });
+    }
+
+    @Test
+    public void testAServletWebApplicationRegistersTheFilterFromTheProperties() {
+        new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(StormSqlLogAutoConfiguration.class))
+                .withUserConfiguration(JobConfiguration.class)
+                .withPropertyValues("storm.sql-log.enabled=true", "storm.sql-log.threshold.statements=5")
+                .run(context -> withScopeLogger(events -> {
+                    var filter = context.getBean("stormSqlLogFilter", StormSqlLogFilter.class);
+                    // The threshold from the properties reached the filter: a request below it says nothing,
+                    // although the logger would report it without a threshold.
+                    try {
+                        filter.doFilter(new MockHttpServletRequest("GET", "/reports"), new MockHttpServletResponse(),
+                                (request, response) -> context.getBean(ReportJob.class).plain());
+                    } catch (Exception e) {
+                        throw new AssertionError(e);
+                    }
+                    assertTrue(events.isEmpty());
+                }));
     }
 
     @Test

--- a/storm-spring/src/test/java/st/orm/spring/boot/StormSqlLogFilterTest.java
+++ b/storm-spring/src/test/java/st/orm/spring/boot/StormSqlLogFilterTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package st.orm.spring.boot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import st.orm.core.template.ORMTemplate;
+
+/**
+ * Verifies the request filter that reports what each request cost the database: the scope is named after the
+ * request, opens only while something consumes the summary, reports every request at INFO without thresholds and
+ * only the requests exceeding a threshold at WARN with one, and lets the request's own failure through untouched.
+ */
+class StormSqlLogFilterTest {
+
+    private ORMTemplate orm;
+
+    @BeforeEach
+    void setUp() {
+        DataSource dataSource = DataSourceBuilder.create()
+                .url("jdbc:h2:mem:sql-log-filter;DB_CLOSE_DELAY=-1")
+                .build();
+        orm = ORMTemplate.of(dataSource);
+    }
+
+    /** A test body that runs the filter, which declares the servlet chain's checked exceptions. */
+    interface ScopeTest {
+        void run(List<ILoggingEvent> events) throws Exception;
+    }
+
+    private static void withScopeLogger(Level level, ScopeTest test) throws Exception {
+        var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger("st.orm.sql.perf");
+        var appender = new ListAppender<ILoggingEvent>();
+        appender.start();
+        logger.addAppender(appender);
+        var previous = logger.getLevel();
+        logger.setLevel(level);
+        try {
+            test.run(appender.list);
+        } finally {
+            logger.setLevel(previous);
+            logger.detachAppender(appender);
+        }
+    }
+
+    /** A request handler standing in for the rest of the filter chain, issuing the given number of statements. */
+    private FilterChain handler(int statements, AtomicInteger invocations) {
+        return (request, response) -> {
+            invocations.incrementAndGet();
+            for (int i = 0; i < statements; i++) {
+                orm.query("SELECT 1").getSingleResult();
+            }
+        };
+    }
+
+    private static void run(StormSqlLogFilter filter, FilterChain chain) throws ServletException, IOException {
+        filter.doFilter(new MockHttpServletRequest("GET", "/owners/42"), new MockHttpServletResponse(), chain);
+    }
+
+    @Test
+    void aRequestThatTouchesTheDatabaseIsReportedUnderItsMethodAndPath() throws Exception {
+        withScopeLogger(Level.INFO, events -> {
+            var invocations = new AtomicInteger();
+            run(new StormSqlLogFilter(10), handler(2, invocations));
+            assertEquals(1, invocations.get());
+            assertEquals(1, events.size());
+            assertEquals(Level.INFO, events.getFirst().getLevel());
+            String message = events.getFirst().getFormattedMessage();
+            assertTrue(message.startsWith("SQL (GET /owners/42): 2 statements"), message);
+        });
+    }
+
+    @Test
+    void aRequestThatTouchesNoDatabaseSaysNothing() throws Exception {
+        withScopeLogger(Level.INFO, events -> {
+            run(new StormSqlLogFilter(10), handler(0, new AtomicInteger()));
+            assertTrue(events.isEmpty());
+        });
+    }
+
+    @Test
+    void aThresholdReportsOnlyTheRequestsExceedingItAtWarn() throws Exception {
+        withScopeLogger(Level.WARN, events -> {
+            var filter = new StormSqlLogFilter(10, 3, null);
+            run(filter, handler(2, new AtomicInteger()));
+            assertTrue(events.isEmpty(), "a request below the threshold stays quiet");
+            run(filter, handler(3, new AtomicInteger()));
+            assertEquals(1, events.size());
+            assertEquals(Level.WARN, events.getFirst().getLevel());
+            assertTrue(events.getFirst().getFormattedMessage().startsWith("SQL (GET /owners/42): 3 statements"),
+                    events.getFirst().getFormattedMessage());
+        });
+    }
+
+    @Test
+    void aDurationThresholdOfZeroReportsEveryRequestThatTouchesTheDatabase() throws Exception {
+        withScopeLogger(Level.WARN, events -> {
+            // Any request lasts longer than zero, so the duration threshold alone selects it; the call-site
+            // variant of the constructor is exercised alongside.
+            run(new StormSqlLogFilter(10, true, null, Duration.ZERO), handler(1, new AtomicInteger()));
+            assertEquals(1, events.size());
+            assertEquals(Level.WARN, events.getFirst().getLevel());
+        });
+    }
+
+    @Test
+    void theRequestRunsWithoutAScopeWhenNothingConsumesTheSummary() throws Exception {
+        // INFO is off, so an unthresholded filter has no consumer; the request itself is unaffected.
+        withScopeLogger(Level.WARN, events -> {
+            var invocations = new AtomicInteger();
+            run(new StormSqlLogFilter(10), handler(2, invocations));
+            assertEquals(1, invocations.get());
+            assertTrue(events.isEmpty());
+        });
+        // WARN is off, so a thresholded filter has no consumer either.
+        withScopeLogger(Level.ERROR, events -> {
+            var invocations = new AtomicInteger();
+            run(new StormSqlLogFilter(10, 1, null), handler(2, invocations));
+            assertEquals(1, invocations.get());
+            assertTrue(events.isEmpty());
+        });
+    }
+
+    @Test
+    void aFailingRequestPropagatesItsExceptionUnchanged() throws Exception {
+        withScopeLogger(Level.INFO, events -> {
+            var failure = new IllegalStateException("handler failed");
+            var thrown = assertThrows(IllegalStateException.class, () -> run(new StormSqlLogFilter(10),
+                    (request, response) -> {
+                        orm.query("SELECT 1").getSingleResult();
+                        throw failure;
+                    }));
+            assertSame(failure, thrown);
+            var servletFailure = new ServletException("handler failed");
+            var thrownServletFailure = assertThrows(ServletException.class, () -> run(new StormSqlLogFilter(10),
+                    (request, response) -> {
+                        throw servletFailure;
+                    }));
+            assertSame(servletFailure, thrownServletFailure);
+        });
+    }
+}


### PR DESCRIPTION
Builds on #513, which is what made these gaps visible: with coverage attributed across modules, the remaining zeroes are real rather than misattributed.

## What was uncovered

Methods no test called at all, from the aggregate report:

- **Java `Query` defaults** — `getSingleResult`, `getOptionalResult`, `getResultCount`, `getResultList`, `getRefList`, `withoutFetchSize`, and the `singleResult`/`optionalResult` helpers with their `NoResultException` / `NonUniqueResultException` paths. The production implementation overrides them, so a stub supplying only the abstract streams is what exercises the defaults; the test also holds them to closing the streams they open.
- **Kotlin `Query` defaults** — the same contract through `Query$DefaultImpls`.
- **`EntityRepository` / `ProjectionRepository` Ref-based defaults** — `findBy`, `getBy`, `existsBy`, `findRefBy`, `getRefBy`, `findAllRefBy`, `findAllRefByRef`, `removeAllBy`, `removeAllByRef`, `countBy`, `scroll(Scrollable)`.
- **`WriteSet`** single-entity `insert`, `upsert`, `upsertAndFetch`.
- **`SqlLog`** Java facade: all three `open` overloads, `Scope.close`, `recorder`, `recordThrowing`.
- **`RefImpl` / `AbstractRef`** — attached refs for a non-scalar primary key (`ScalarRefImpl` was covered, this half was not).
- **Kotlin `select { }` block vocabulary** — the ~40 `SqlScope` clause methods (`where` variants, `having`, `whereExists`/`havingExists`, the join forms, `distinct`, `forUpdate`/`forShare`, `unsafe`, `groupBy`/`orderBy` lambdas), plus the top-level `eq`/`neq` on `Ref`, `inRefs`/`notInRefs`, `isTrue`/`isFalse`.
- **`Transactions.kt` scope callbacks** — `onCommit`, `onRollback`, `onCompletion`, `isRollbackOnly`.
- **`StormSqlLogFilter`** (0%) — the per-request scope, threshold behavior, and that a request's own failure passes through.
- **`SpringExternalTransactionProvider`** commit/rollback callbacks and `isRollbackOnly`.
- **`AbstractNavigableMetamodel`** equality, hashing, `table()`, `isInline`.
- **`DataStormTypeExcludeFilter`** equality and `createFilter` with include filters.

## Result

Aggregate line coverage **87.91% → 89.17%** (+251 lines), branches **78.14% → 78.97%**. Per module: storm-kotlin 82.3% → 90.2%, storm-java21 82.5% → 89.1%, storm-spring 84.0% → 89.5%, storm-foundation 85.6% → 88.5%.

Tests were added to the class that already covers the area (`RepositoryTest`, `SqlLogIntegrationTest`, `QueryBuilderTest`, `SqlDslTest`, `TransactionCallbackTest`, `RefsAndKeysTest`, `StormSqlLogAutoConfigurationTest`) rather than beside it, so no parallel suite appears. Full reactor `mvn verify` is green.

## Two notes

- `storm-java21`'s surefire gains `--add-reads storm.java=org.slf4j,ch.qos.logback.classic,ch.qos.logback.core`. Its tests are patched into `storm.java`, which requires nothing of the logging backend, so asserting on what a scope reported needs the read edge — the same kind of accommodation as the `--add-opens` lines already there.
- `storm-kotlin` gains a `feature_flag` table and entity with a nullable boolean, because `IS TRUE` / `IS FALSE` need a plain boolean column and every existing one belongs to a polymorphic subtype that cannot be queried standalone. The null row is what distinguishes the predicates from an equality comparison.

No main code changed; nothing here is a workaround for a defect.
